### PR TITLE
Fix for retrive session in sync and async both

### DIFF
--- a/src/llama_stack_client/resources/agents/sessions.py
+++ b/src/llama_stack_client/resources/agents/sessions.py
@@ -120,19 +120,15 @@ class SessionsResource(SyncAPIResource):
         }
         return self._post(
             "/agents/session/get",
-            body=maybe_transform({"turn_ids": turn_ids}, session_retrieve_params.SessionRetrieveParams),
+            body=maybe_transform({"agent_id": agent_id,
+                                  "session_id": session_id,
+                                  "turn_ids": turn_ids},
+                                 session_retrieve_params.SessionRetrieveParams),
             options=make_request_options(
                 extra_headers=extra_headers,
                 extra_query=extra_query,
                 extra_body=extra_body,
                 timeout=timeout,
-                query=maybe_transform(
-                    {
-                        "agent_id": agent_id,
-                        "session_id": session_id,
-                    },
-                    session_retrieve_params.SessionRetrieveParams,
-                ),
             ),
             cast_to=Session,
         )
@@ -273,19 +269,14 @@ class AsyncSessionsResource(AsyncAPIResource):
         }
         return await self._post(
             "/agents/session/get",
-            body=await async_maybe_transform({"turn_ids": turn_ids}, session_retrieve_params.SessionRetrieveParams),
+            body=await async_maybe_transform({"agent_id": agent_id,
+                                              "session_id": session_id,
+                                              "turn_ids": turn_ids}, session_retrieve_params.SessionRetrieveParams),
             options=make_request_options(
                 extra_headers=extra_headers,
                 extra_query=extra_query,
                 extra_body=extra_body,
                 timeout=timeout,
-                query=await async_maybe_transform(
-                    {
-                        "agent_id": agent_id,
-                        "session_id": session_id,
-                    },
-                    session_retrieve_params.SessionRetrieveParams,
-                ),
             ),
             cast_to=Session,
         )


### PR DESCRIPTION
This error is occuring because, in the main implementation of this API endpoint, its a post request (Even though it should be a GET request) and agent_id and session_id are being passed in the body where as this method is sending it in query_params which is causing a 400 Error and a pydantic error of FASTAPI. This is a fix for now but might suggest converting fetching methods in implementation to be converted into GET methods in llama stack repo.