### PR TITLE
[CLI] visualize categorical scores eval results with bars

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ dependencies = [
     "distro>=1.7.0, <2",
     "sniffio",
     "cached-property; python_version < '3.8'",
-    "tabulate>=0.9.0",
 ]
 requires-python = ">= 3.7"
 classifiers = [

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -90,10 +90,6 @@ sniffio==1.3.0
     # via anyio
     # via httpx
     # via llama-stack-client
-tabulate==0.9.0
-    # via llama-stack-client
-termcolor==2.4.0
-    # via llama-stack-client
 time-machine==2.9.0
 tomli==2.0.1
     # via mypy

--- a/requirements.lock
+++ b/requirements.lock
@@ -39,10 +39,6 @@ sniffio==1.3.0
     # via anyio
     # via httpx
     # via llama-stack-client
-tabulate==0.9.0
-    # via llama-stack-client
-termcolor==2.4.0
-    # via llama-stack-client
 typing-extensions==4.8.0
     # via anyio
     # via llama-stack-client

--- a/src/llama_stack_client/lib/cli/__init__.py
+++ b/src/llama_stack_client/lib/cli/__init__.py
@@ -3,3 +3,10 @@
 #
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
+
+# Ignore tqdm experimental warning
+import warnings
+
+from tqdm import TqdmExperimentalWarning
+
+warnings.filterwarnings("ignore", category=TqdmExperimentalWarning)

--- a/src/llama_stack_client/lib/cli/common/utils.py
+++ b/src/llama_stack_client/lib/cli/common/utils.py
@@ -3,15 +3,28 @@
 #
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
-from tabulate import tabulate
+from rich.console import Console
+from rich.table import Table
 
 
-def print_table_from_response(response, headers=()):
-    if not headers:
-        headers = sorted(response[0].__dict__.keys())
+def create_bar_chart(data, labels, title=""):
+    """Create a bar chart using Rich Table."""
 
-    rows = []
-    for spec in response:
-        rows.append([spec.__dict__[headers[i]] for i in range(len(headers))])
+    console = Console()
+    table = Table(title=title)
+    table.add_column("Score")
+    table.add_column("Count")
 
-    print(tabulate(rows, headers=headers, tablefmt="grid"))
+    max_value = max(data)
+    total_count = sum(data)
+
+    # Define a list of colors to cycle through
+    colors = ["green", "blue", "red", "yellow", "magenta", "cyan"]
+
+    for i, (label, value) in enumerate(zip(labels, data)):
+        bar_length = int((value / max_value) * 20)  # Adjust bar length as needed
+        bar = "█" * bar_length + " " * (20 - bar_length)
+        color = colors[i % len(colors)]
+        table.add_row(label, f"[{color}]{bar}[/] {value}/{total_count}")
+
+    console.print(table)

--- a/src/llama_stack_client/lib/cli/eval/run_benchmark.py
+++ b/src/llama_stack_client/lib/cli/eval/run_benchmark.py
@@ -96,10 +96,10 @@ def run_benchmark(
         rprint(f"[green]✓[/green] Results saved to: [blue]{output_file}[/blue]!\n")
 
         if visualize:
-            for scoring_fn in ["llm-as-judge::llm_as_judge_base"]:
+            for scoring_fn in scoring_functions:
                 res = output_res[scoring_fn]
                 assert len(res) > 0 and "score" in res[0]
-                scores = [r["score"] for r in res]
-                unique_scores = sorted(list(set([r["score"] for r in res])))
+                scores = [str(r["score"]) for r in res]
+                unique_scores = sorted(list(set(scores)))
                 counts = [scores.count(s) for s in unique_scores]
                 create_bar_chart(counts, unique_scores, title=f"ScoringFunction = {scoring_fn}")

--- a/src/llama_stack_client/lib/cli/eval/run_benchmark.py
+++ b/src/llama_stack_client/lib/cli/eval/run_benchmark.py
@@ -102,4 +102,4 @@ def run_benchmark(
                 scores = [str(r["score"]) for r in res]
                 unique_scores = sorted(list(set(scores)))
                 counts = [scores.count(s) for s in unique_scores]
-                create_bar_chart(counts, unique_scores, title=f"ScoringFunction = {scoring_fn}")
+                create_bar_chart(counts, unique_scores, title=f"{scoring_fn}")

--- a/src/llama_stack_client/lib/cli/eval/run_benchmark.py
+++ b/src/llama_stack_client/lib/cli/eval/run_benchmark.py
@@ -9,7 +9,10 @@ import os
 from typing import Optional
 
 import click
+from rich import print as rprint
 from tqdm.rich import tqdm
+
+from ..common.utils import create_bar_chart
 
 
 @click.command("run_benchmark")
@@ -28,9 +31,20 @@ from tqdm.rich import tqdm
 @click.option(
     "--num-examples", required=False, help="Number of examples to evaluate on, useful for debugging", default=None
 )
+@click.option(
+    "--visualize",
+    is_flag=True,
+    default=False,
+    help="Visualize evaluation results after completion",
+)
 @click.pass_context
 def run_benchmark(
-    ctx, eval_task_ids: tuple[str, ...], eval_task_config: str, output_dir: str, num_examples: Optional[int]
+    ctx,
+    eval_task_ids: tuple[str, ...],
+    eval_task_config: str,
+    output_dir: str,
+    num_examples: Optional[int],
+    visualize: bool,
 ):
     """Run a evaluation benchmark"""
 
@@ -79,4 +93,13 @@ def run_benchmark(
         with open(output_file, "w") as f:
             json.dump(output_res, f, indent=2)
 
-        print(f"Results saved to: {output_file}")
+        rprint(f"[green]✓[/green] Results saved to: [blue]{output_file}[/blue]!\n")
+
+        if visualize:
+            for scoring_fn in ["llm-as-judge::llm_as_judge_base"]:
+                res = output_res[scoring_fn]
+                assert len(res) > 0 and "score" in res[0]
+                scores = [r["score"] for r in res]
+                unique_scores = sorted(list(set([r["score"] for r in res])))
+                counts = [scores.count(s) for s in unique_scores]
+                create_bar_chart(counts, unique_scores, title=f"ScoringFunction = {scoring_fn}")

--- a/src/llama_stack_client/lib/cli/llama_stack_client.py
+++ b/src/llama_stack_client/lib/cli/llama_stack_client.py
@@ -57,7 +57,7 @@ def cli(ctx, endpoint: str, config: str | None):
         base_url=endpoint,
         provider_data={
             "fireworks_api_key": os.environ.get("FIREWORKS_API_KEY", ""),
-            "togethers_api_key": os.environ.get("TOGETHERS_API_KEY", ""),
+            "together_api_key": os.environ.get("TOGETHER_API_KEY", ""),
         },
     )
     ctx.obj = {"client": client}


### PR DESCRIPTION
# TL;DR
- fixes typo w/ together api key for client
- visualize eval results for categorical scores 
- Note: SimpleQA has "app" as type b/c we do not pre-register any SimpleQA specific scoring functions, and uses LLMAsJudge w/ prompt template as scoring function. 

<img width="664" alt="image" src="https://github.com/user-attachments/assets/125b2856-56e3-4fba-83aa-c965968b2ca6">


# Test
#### SimpleQA
```
llama-stack-client eval run_benchmark meta-reference-simpleqa --num-examples 5 --output-dir ./ --eval-task-config ~/eval_task_config_simpleqa.json --visualize
```

```yaml
{
    "type": "app",
    "eval_candidate": {
        "type": "model",
        "model": "Llama3.1-405B-Instruct",
        "sampling_params": {
            "strategy": "greedy",
            "temperature": 0,
            "top_p": 0.95,
            "top_k": 0,
            "max_tokens": 0,
            "repetition_penalty": 1.0
        }
    },
    "scoring_params": {
        "llm-as-judge::llm_as_judge_base": {
            "type": "llm_as_judge",
            "judge_model": "Llama3.1-405B-Instruct",
            "prompt_template": "Your job is to look at a question, a gold target ........",
            "judge_score_regexes": [
                "(A|B|C)"
            ]
        }
    }
}
```

#### MMLU
```
llama-stack-client eval run_benchmark meta-reference-mmlu --num-examples 5 --output-dir ./ --eval-task-config ~/eval_task_config.json --visualize
```

```yaml
{
    "type": "benchmark",
    "eval_candidate": {
        "type": "model",
        "model": "Llama3.2-3B-Instruct",
        "sampling_params": {
            "strategy": "greedy",
            "temperature": 0,
            "top_p": 0.95,
            "top_k": 0,
            "max_tokens": 0,
            "repetition_penalty": 1.0
        }
    }
}
```



