### PR TITLE
add ability to instantiate direct client with template

### DIFF
--- a/src/llama_stack_client/lib/direct/direct.py
+++ b/src/llama_stack_client/lib/direct/direct.py
@@ -1,6 +1,8 @@
 import inspect
+import yaml
 from typing import Any, cast, get_args, get_origin, Type
 
+from rich.console import Console
 from llama_stack.distribution.datatypes import StackRunConfig
 from llama_stack.distribution.distribution import get_provider_registry
 from llama_stack.distribution.resolver import resolve_impls
@@ -31,6 +33,9 @@ class LlamaStackDirectClient(LlamaStackClient):
     @classmethod
     async def from_template(cls, template_name: str, **kwargs):
         config = get_stack_run_config_from_template(template_name)
+        console = Console()
+        console.print(f"[green]Using template[/green] [blue]{template_name}[/blue] with config:")
+        console.print(yaml.dump(config.model_dump(), indent=2, default_flow_style=False))
         instance = object.__new__(cls)
         await instance._initialize(config, **kwargs)
         return instance

--- a/src/llama_stack_client/lib/direct/direct.py
+++ b/src/llama_stack_client/lib/direct/direct.py
@@ -22,7 +22,7 @@ from ..._types import Body, NOT_GIVEN, RequestFiles, RequestOptions
 
 class LlamaStackDirectClient(LlamaStackClient):
     def __init__(self, config: StackRunConfig, **kwargs):
-        raise TypeError("Use from_yaml() or from_template() instead of direct initialization")
+        raise TypeError("Use from_config() or from_template() instead of direct initialization")
 
     @classmethod
     async def from_config(cls, config: StackRunConfig, **kwargs):

--- a/src/llama_stack_client/lib/direct/test.py
+++ b/src/llama_stack_client/lib/direct/test.py
@@ -12,7 +12,7 @@ async def main(config_path: str):
 
     run_config = parse_and_maybe_upgrade_config(config_dict)
 
-    client = LlamaStackDirectClient(config=run_config)
+    client = await LlamaStackDirectClient.from_config(run_config)
     await client.initialize()
 
     response = await client.models.list()


### PR DESCRIPTION
needs to go in after https://github.com/meta-llama/llama-stack/pull/477

test plan:
1) pip install -e . on llama stack main
2) pip install -e . in llama stack client python
3) run a app with direct client:
```
import asyncio
from llama_stack_client.lib.direct.direct import LlamaStackDirectClient


async def main():
    client = await LlamaStackDirectClient.from_template("ollama")

    response = await client.models.list()
    print(response)


if __name__ == "__main__":
    asyncio.run(main())

```

```
INFERENCE_MODEL=llama3.2:1b-instruct-fp16 python app.py
Resolved 12 providers
 inner-inference => ollama
 inner-memory => faiss
 models => __routing_table__
 inference => __autorouted__
 inner-safety => llama-guard
 shields => __routing_table__
 safety => __autorouted__
 memory_banks => __routing_table__
 memory => __autorouted__
 agents => meta-reference
 telemetry => meta-reference
 inspect => __builtin__

checking connectivity to Ollama at `http://localhost:11434`...
`llama3.2:1b-instruct-fp16` already registered with `ollama`
Models: llama3.2:1b-instruct-fp16 served by ollama

[Model(identifier='llama3.2:1b-instruct-fp16', provider_resource_id='llama3.2:1b-instruct-fp16', provider_id='ollama', type='model', metadata={})]
```