### PR TITLE
Add direct install helper print

### DIFF
--- a/src/llama_stack_client/lib/cli/inference/inference.py
+++ b/src/llama_stack_client/lib/cli/inference/inference.py
@@ -7,9 +7,7 @@
 from typing import Optional
 
 import click
-import yaml
 from rich.console import Console
-from rich.table import Table
 
 from ..common.utils import handle_client_errors
 

--- a/src/llama_stack_client/lib/direct/direct.py
+++ b/src/llama_stack_client/lib/direct/direct.py
@@ -1,24 +1,20 @@
 import inspect
-from typing import Any, cast, get_args, get_origin, Type
+from typing import Any, Type, cast, get_args, get_origin
 
 import yaml
 from llama_stack.distribution.build import print_pip_install_help
 from llama_stack.distribution.datatypes import StackRunConfig
-from llama_stack.distribution.distribution import get_provider_registry
-from llama_stack.distribution.resolver import resolve_impls
 from llama_stack.distribution.server.endpoints import get_all_api_endpoints
 from llama_stack.distribution.server.server import is_streaming_request
-from llama_stack.distribution.stack import (
-    construct_stack,
-    get_stack_run_config_from_template,
-)
+from llama_stack.distribution.stack import (construct_stack,
+                                            get_stack_run_config_from_template)
 from pydantic import BaseModel
 from rich.console import Console
 
 from ..._base_client import ResponseT
 from ..._client import LlamaStackClient
 from ..._streaming import Stream
-from ..._types import Body, NOT_GIVEN, RequestFiles, RequestOptions
+from ..._types import NOT_GIVEN, Body, RequestFiles, RequestOptions
 
 
 class LlamaStackDirectClient(LlamaStackClient):


### PR DESCRIPTION
Adds https://github.com/meta-llama/llama-stack/pull/404 to DirectClient:

```
$ python src/llama_stack_client/lib/direct/test.py <run.yaml>

Please install needed dependencies using the following commands:

        pip install blobfile scikit-learn transformers matplotlib lm-format-enforcer scipy tqdm accelerate nltk redis chardet torch torchvision zmq numpy sentencepiece faiss-cpu fairscale pillow pypdf psycopg2-binary pandas aiosqlite

[...]
ModuleNotFoundError: No module named 'aiosqlite'
```

