### PR TITLE
add openai api_key to provider_data

### DIFF
--- a/src/llama_stack_client/lib/cli/llama_stack_client.py
+++ b/src/llama_stack_client/lib/cli/llama_stack_client.py
@@ -58,6 +58,7 @@ def cli(ctx, endpoint: str, config: str | None):
         provider_data={
             "fireworks_api_key": os.environ.get("FIREWORKS_API_KEY", ""),
             "together_api_key": os.environ.get("TOGETHER_API_KEY", ""),
+            "openai_api_key": os.environ.get("OPENAI_API_KEY", ""),
         },
     )
     ctx.obj = {"client": client}


### PR DESCRIPTION
# TL;DR
- move api keys to request headers in https://github.com/meta-llama/llama-stack/pull/535

# Test
<img width="852" alt="image" src="https://github.com/user-attachments/assets/671cf1ce-d8d9-4539-a758-6840fda4ef74">


```
llama-stack-client eval run-scoring braintrust::factuality --dataset-path <path/to/dataset> --output-dir ./ --visualize --num-examples 5
```