### PR TITLE
[bugfix] add termcolor dep

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,8 @@ dependencies = [
     "click",
     "pyaml",
     "prompt_toolkit",
-    "pandas"
+    "pandas",
+    "termcolor",
 ]
 requires-python = ">= 3.7"
 classifiers = [

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -22,6 +22,8 @@ attrs==23.1.0
 certifi==2023.7.22
     # via httpcore
     # via httpx
+click==8.1.7
+    # via llama-stack-client
 colorlog==6.7.0
     # via nox
 dirty-equals==0.6.0
@@ -56,15 +58,23 @@ mypy-extensions==1.0.0
 nodeenv==1.8.0
     # via pyright
 nox==2023.4.22
+numpy==2.0.2
+    # via pandas
 packaging==23.2
     # via nox
     # via pytest
+pandas==2.2.3
+    # via llama-stack-client
 platformdirs==3.11.0
     # via virtualenv
 pluggy==1.3.0
     # via pytest
+prompt-toolkit==3.0.48
+    # via llama-stack-client
 py==1.11.0
     # via pytest
+pyaml==24.12.1
+    # via llama-stack-client
 pydantic==2.7.1
     # via llama-stack-client
 pydantic-core==2.18.2
@@ -76,11 +86,16 @@ pytest==7.1.1
     # via pytest-asyncio
 pytest-asyncio==0.21.1
 python-dateutil==2.8.2
+    # via pandas
     # via time-machine
 pytz==2023.3.post1
     # via dirty-equals
+    # via pandas
+pyyaml==6.0.2
+    # via pyaml
 respx==0.20.2
 rich==13.7.1
+    # via llama-stack-client
 ruff==0.6.5
 setuptools==68.2.2
     # via nodeenv
@@ -90,17 +105,25 @@ sniffio==1.3.0
     # via anyio
     # via httpx
     # via llama-stack-client
+termcolor==2.5.0
+    # via llama-stack-client
 time-machine==2.9.0
 tomli==2.0.1
     # via mypy
     # via pytest
+tqdm==4.67.1
+    # via llama-stack-client
 typing-extensions==4.8.0
     # via anyio
     # via llama-stack-client
     # via mypy
     # via pydantic
     # via pydantic-core
+tzdata==2024.2
+    # via pandas
 virtualenv==20.24.5
     # via nox
+wcwidth==0.2.13
+    # via prompt-toolkit
 zipp==3.17.0
     # via importlib-metadata

--- a/requirements.lock
+++ b/requirements.lock
@@ -18,6 +18,8 @@ anyio==4.4.0
 certifi==2023.7.22
     # via httpcore
     # via httpx
+click==8.1.7
+    # via llama-stack-client
 distro==1.8.0
     # via llama-stack-client
 exceptiongroup==1.1.3
@@ -31,16 +33,49 @@ httpx==0.25.2
 idna==3.4
     # via anyio
     # via httpx
+markdown-it-py==3.0.0
+    # via rich
+mdurl==0.1.2
+    # via markdown-it-py
+numpy==2.0.2
+    # via pandas
+pandas==2.2.3
+    # via llama-stack-client
+prompt-toolkit==3.0.48
+    # via llama-stack-client
+pyaml==24.12.1
+    # via llama-stack-client
 pydantic==2.7.1
     # via llama-stack-client
 pydantic-core==2.18.2
     # via pydantic
+pygments==2.18.0
+    # via rich
+python-dateutil==2.9.0.post0
+    # via pandas
+pytz==2024.2
+    # via pandas
+pyyaml==6.0.2
+    # via pyaml
+rich==13.9.4
+    # via llama-stack-client
+six==1.17.0
+    # via python-dateutil
 sniffio==1.3.0
     # via anyio
     # via httpx
+    # via llama-stack-client
+termcolor==2.5.0
+    # via llama-stack-client
+tqdm==4.67.1
     # via llama-stack-client
 typing-extensions==4.8.0
     # via anyio
     # via llama-stack-client
     # via pydantic
     # via pydantic-core
+    # via rich
+tzdata==2024.2
+    # via pandas
+wcwidth==0.2.13
+    # via prompt-toolkit


### PR DESCRIPTION
Fix issue w/ just installing llama-stack-client only w/o llama-stack. 

```
$ llama-stack-client configure
Traceback (most recent call last):
  File "/Users/rsm/miniforge3/bin/llama-stack-client", line 5, in <module>
    from llama_stack_client.lib.cli.llama_stack_client import main
  File "/Users/rsm/miniforge3/lib/python3.12/site-packages/llama_stack_client/lib/cli/llama_stack_client.py", line 19, in <module>
    from .inference import inference
  File "/Users/rsm/miniforge3/lib/python3.12/site-packages/llama_stack_client/lib/cli/inference/__init__.py", line 7, in <module>
    from .inference import inference
  File "/Users/rsm/miniforge3/lib/python3.12/site-packages/llama_stack_client/lib/cli/inference/inference.py", line 13, in <module>
    from ...inference.event_logger import EventLogger
  File "/Users/rsm/miniforge3/lib/python3.12/site-packages/llama_stack_client/lib/inference/event_logger.py", line 6, in <module>
    from termcolor import cprint
ModuleNotFoundError: No module named 'termcolor'
```

- Sync requirements files via: 
```
rye sync
```

## After Fix
```
conda create -n fresh python=3.11
cd llama-stack-client-python
pip install -e .
llama-stack-client configure --endpoint http://localhost:5000
```
<img width="694" alt="image" src="https://github.com/user-attachments/assets/1e75bc2d-756f-44c5-9d18-701beaf03057" />

