### PR TITLE
update github links to official meta-llama org/account

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,9 +243,9 @@ session = response.parse()  # get the object that `agents.sessions.create()` wou
 print(session.session_id)
 ```
 
-These methods return an [`APIResponse`](https://github.com/stainless-sdks/llama-stack-python/tree/main/src/llama_stack_client/_response.py) object.
+These methods return an [`APIResponse`](https://github.com/meta-llama/llama-stack-python/tree/main/src/llama_stack_client/_response.py) object.
 
-The async client returns an [`AsyncAPIResponse`](https://github.com/stainless-sdks/llama-stack-python/tree/main/src/llama_stack_client/_response.py) with the same structure, the only difference being `await`able methods for reading the response content.
+The async client returns an [`AsyncAPIResponse`](https://github.com/meta-llama/llama-stack-python/tree/main/src/llama_stack_client/_response.py) with the same structure, the only difference being `await`able methods for reading the response content.
 
 #### `.with_streaming_response`
 
@@ -342,7 +342,7 @@ This package generally follows [SemVer](https://semver.org/spec/v2.0.0.html) con
 
 We take backwards-compatibility seriously and work hard to ensure you can rely on a smooth upgrade experience.
 
-We are keen for your feedback; please open an [issue](https://www.github.com/stainless-sdks/llama-stack-python/issues) with questions, bugs, or suggestions.
+We are keen for your feedback; please open an [issue](https://www.github.com/meta-llama/llama-stack-python/issues) with questions, bugs, or suggestions.
 
 ### Determining the installed version
 


### PR DESCRIPTION
some links in the readme are to the stale repository url under an old org/account

this pr updates them to the new https://github.com/meta-llama/llama-stack-client-python base url