### PR TITLE
fix typing for model list endpoints

### DIFF
--- a/src/llama_stack_client/resources/models.py
+++ b/src/llama_stack_client/resources/models.py
@@ -96,7 +96,7 @@ class ModelsResource(SyncAPIResource):
         extra_query: Query | None = None,
         extra_body: Body | None = None,
         timeout: float | httpx.Timeout | None | NotGiven = NOT_GIVEN,
-    ) -> Model:
+    ) -> list[Model]:
         """
         Args:
           extra_headers: Send extra headers
@@ -275,7 +275,7 @@ class AsyncModelsResource(AsyncAPIResource):
         extra_query: Query | None = None,
         extra_body: Body | None = None,
         timeout: float | httpx.Timeout | None | NotGiven = NOT_GIVEN,
-    ) -> Model:
+    ) -> list[Model]:
         """
         Args:
           extra_headers: Send extra headers


### PR DESCRIPTION
the type hint for the `models.list` endpoint is `Model`, but in actuality the method returns a `list[Model]`