### PR TITLE
Support for new tools and agents API

### DIFF
--- a/src/llama_stack_client/_base_client.py
+++ b/src/llama_stack_client/_base_client.py
@@ -767,6 +767,9 @@ else:
 
 class SyncHttpxClientWrapper(DefaultHttpxClient):
     def __del__(self) -> None:
+        if self.is_closed:
+            return
+
         try:
             self.close()
         except Exception:
@@ -1334,6 +1337,9 @@ else:
 
 class AsyncHttpxClientWrapper(DefaultAsyncHttpxClient):
     def __del__(self) -> None:
+        if self.is_closed:
+            return
+
         try:
             # TODO(someday): support non asyncio runtimes here
             asyncio.get_running_loop().create_task(self.aclose())

--- a/src/llama_stack_client/_client.py
+++ b/src/llama_stack_client/_client.py
@@ -1,61 +1,62 @@
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
-import json
 from __future__ import annotations
 
+import json
 import os
-from typing import Any, Union, Mapping
-from typing_extensions import Self, override
+from typing import Any, Mapping, Union
 
 import httpx
+from typing_extensions import Self, override
 
 from . import _exceptions
+from ._base_client import (
+    DEFAULT_MAX_RETRIES,
+    AsyncAPIClient,
+    SyncAPIClient,
+)
+from ._exceptions import APIStatusError
 from ._qs import Querystring
+from ._streaming import AsyncStream as AsyncStream
+from ._streaming import Stream as Stream
 from ._types import (
     NOT_GIVEN,
-    Omit,
-    Timeout,
     NotGiven,
-    Transport,
+    Omit,
     ProxiesTypes,
     RequestOptions,
+    Timeout,
+    Transport,
 )
 from ._utils import (
-    is_given,
     get_async_library,
+    is_given,
 )
 from ._version import __version__
 from .resources import (
-    tools,
+    batch_inference,
+    datasetio,
+    datasets,
+    eval_tasks,
+    inference,
+    inspect,
     memory,
+    memory_banks,
     models,
+    providers,
     routes,
     safety,
-    inspect,
     scoring,
-    shields,
-    datasets,
-    datasetio,
-    inference,
-    providers,
-    telemetry,
-    eval_tasks,
-    toolgroups,
-    memory_banks,
-    tool_runtime,
-    batch_inference,
     scoring_functions,
+    shields,
     synthetic_data_generation,
+    telemetry,
+    tool_runtime,
+    toolgroups,
+    tools,
 )
-from ._streaming import Stream as Stream, AsyncStream as AsyncStream
-from ._exceptions import APIStatusError
-from ._base_client import (
-    DEFAULT_MAX_RETRIES,
-    SyncAPIClient,
-    AsyncAPIClient,
-)
-from .resources.eval import eval
 from .resources.agents import agents
+from .resources.eval import eval
 from .resources.post_training import post_training
 
 __all__ = [
@@ -126,7 +127,7 @@ class LlamaStackClient(SyncAPIClient):
         if base_url is None:
             base_url = os.environ.get("LLAMA_STACK_CLIENT_BASE_URL")
         if base_url is None:
-            base_url = f"http://any-hosted-llama-stack.com"
+            base_url = "http://any-hosted-llama-stack.com"
 
         if provider_data is not None:
             if default_headers is None:
@@ -161,7 +162,9 @@ class LlamaStackClient(SyncAPIClient):
         self.routes = routes.RoutesResource(self)
         self.safety = safety.SafetyResource(self)
         self.shields = shields.ShieldsResource(self)
-        self.synthetic_data_generation = synthetic_data_generation.SyntheticDataGenerationResource(self)
+        self.synthetic_data_generation = (
+            synthetic_data_generation.SyntheticDataGenerationResource(self)
+        )
         self.telemetry = telemetry.TelemetryResource(self)
         self.datasetio = datasetio.DatasetioResource(self)
         self.scoring = scoring.ScoringResource(self)
@@ -201,10 +204,14 @@ class LlamaStackClient(SyncAPIClient):
         Create a new client instance re-using the same options given to the current client with optional overriding.
         """
         if default_headers is not None and set_default_headers is not None:
-            raise ValueError("The `default_headers` and `set_default_headers` arguments are mutually exclusive")
+            raise ValueError(
+                "The `default_headers` and `set_default_headers` arguments are mutually exclusive"
+            )
 
         if default_query is not None and set_default_query is not None:
-            raise ValueError("The `default_query` and `set_default_query` arguments are mutually exclusive")
+            raise ValueError(
+                "The `default_query` and `set_default_query` arguments are mutually exclusive"
+            )
 
         headers = self._custom_headers
         if default_headers is not None:
@@ -245,10 +252,14 @@ class LlamaStackClient(SyncAPIClient):
             return _exceptions.BadRequestError(err_msg, response=response, body=body)
 
         if response.status_code == 401:
-            return _exceptions.AuthenticationError(err_msg, response=response, body=body)
+            return _exceptions.AuthenticationError(
+                err_msg, response=response, body=body
+            )
 
         if response.status_code == 403:
-            return _exceptions.PermissionDeniedError(err_msg, response=response, body=body)
+            return _exceptions.PermissionDeniedError(
+                err_msg, response=response, body=body
+            )
 
         if response.status_code == 404:
             return _exceptions.NotFoundError(err_msg, response=response, body=body)
@@ -257,13 +268,17 @@ class LlamaStackClient(SyncAPIClient):
             return _exceptions.ConflictError(err_msg, response=response, body=body)
 
         if response.status_code == 422:
-            return _exceptions.UnprocessableEntityError(err_msg, response=response, body=body)
+            return _exceptions.UnprocessableEntityError(
+                err_msg, response=response, body=body
+            )
 
         if response.status_code == 429:
             return _exceptions.RateLimitError(err_msg, response=response, body=body)
 
         if response.status_code >= 500:
-            return _exceptions.InternalServerError(err_msg, response=response, body=body)
+            return _exceptions.InternalServerError(
+                err_msg, response=response, body=body
+            )
         return APIStatusError(err_msg, response=response, body=body)
 
 
@@ -285,7 +300,9 @@ class AsyncLlamaStackClient(AsyncAPIClient):
     routes: routes.AsyncRoutesResource
     safety: safety.AsyncSafetyResource
     shields: shields.AsyncShieldsResource
-    synthetic_data_generation: synthetic_data_generation.AsyncSyntheticDataGenerationResource
+    synthetic_data_generation: (
+        synthetic_data_generation.AsyncSyntheticDataGenerationResource
+    )
     telemetry: telemetry.AsyncTelemetryResource
     datasetio: datasetio.AsyncDatasetioResource
     scoring: scoring.AsyncScoringResource
@@ -323,7 +340,7 @@ class AsyncLlamaStackClient(AsyncAPIClient):
         if base_url is None:
             base_url = os.environ.get("LLAMA_STACK_CLIENT_BASE_URL")
         if base_url is None:
-            base_url = f"http://any-hosted-llama-stack.com"
+            base_url = "http://any-hosted-llama-stack.com"
 
         if provider_data is not None:
             if default_headers is None:
@@ -358,7 +375,9 @@ class AsyncLlamaStackClient(AsyncAPIClient):
         self.routes = routes.AsyncRoutesResource(self)
         self.safety = safety.AsyncSafetyResource(self)
         self.shields = shields.AsyncShieldsResource(self)
-        self.synthetic_data_generation = synthetic_data_generation.AsyncSyntheticDataGenerationResource(self)
+        self.synthetic_data_generation = (
+            synthetic_data_generation.AsyncSyntheticDataGenerationResource(self)
+        )
         self.telemetry = telemetry.AsyncTelemetryResource(self)
         self.datasetio = datasetio.AsyncDatasetioResource(self)
         self.scoring = scoring.AsyncScoringResource(self)
@@ -398,10 +417,14 @@ class AsyncLlamaStackClient(AsyncAPIClient):
         Create a new client instance re-using the same options given to the current client with optional overriding.
         """
         if default_headers is not None and set_default_headers is not None:
-            raise ValueError("The `default_headers` and `set_default_headers` arguments are mutually exclusive")
+            raise ValueError(
+                "The `default_headers` and `set_default_headers` arguments are mutually exclusive"
+            )
 
         if default_query is not None and set_default_query is not None:
-            raise ValueError("The `default_query` and `set_default_query` arguments are mutually exclusive")
+            raise ValueError(
+                "The `default_query` and `set_default_query` arguments are mutually exclusive"
+            )
 
         headers = self._custom_headers
         if default_headers is not None:
@@ -442,10 +465,14 @@ class AsyncLlamaStackClient(AsyncAPIClient):
             return _exceptions.BadRequestError(err_msg, response=response, body=body)
 
         if response.status_code == 401:
-            return _exceptions.AuthenticationError(err_msg, response=response, body=body)
+            return _exceptions.AuthenticationError(
+                err_msg, response=response, body=body
+            )
 
         if response.status_code == 403:
-            return _exceptions.PermissionDeniedError(err_msg, response=response, body=body)
+            return _exceptions.PermissionDeniedError(
+                err_msg, response=response, body=body
+            )
 
         if response.status_code == 404:
             return _exceptions.NotFoundError(err_msg, response=response, body=body)
@@ -454,138 +481,232 @@ class AsyncLlamaStackClient(AsyncAPIClient):
             return _exceptions.ConflictError(err_msg, response=response, body=body)
 
         if response.status_code == 422:
-            return _exceptions.UnprocessableEntityError(err_msg, response=response, body=body)
+            return _exceptions.UnprocessableEntityError(
+                err_msg, response=response, body=body
+            )
 
         if response.status_code == 429:
             return _exceptions.RateLimitError(err_msg, response=response, body=body)
 
         if response.status_code >= 500:
-            return _exceptions.InternalServerError(err_msg, response=response, body=body)
+            return _exceptions.InternalServerError(
+                err_msg, response=response, body=body
+            )
         return APIStatusError(err_msg, response=response, body=body)
 
 
 class LlamaStackClientWithRawResponse:
     def __init__(self, client: LlamaStackClient) -> None:
-        self.toolgroups = toolgroups.ToolgroupsResourceWithRawResponse(client.toolgroups)
+        self.toolgroups = toolgroups.ToolgroupsResourceWithRawResponse(
+            client.toolgroups
+        )
         self.tools = tools.ToolsResourceWithRawResponse(client.tools)
-        self.tool_runtime = tool_runtime.ToolRuntimeResourceWithRawResponse(client.tool_runtime)
+        self.tool_runtime = tool_runtime.ToolRuntimeResourceWithRawResponse(
+            client.tool_runtime
+        )
         self.agents = agents.AgentsResourceWithRawResponse(client.agents)
-        self.batch_inference = batch_inference.BatchInferenceResourceWithRawResponse(client.batch_inference)
+        self.batch_inference = batch_inference.BatchInferenceResourceWithRawResponse(
+            client.batch_inference
+        )
         self.datasets = datasets.DatasetsResourceWithRawResponse(client.datasets)
         self.eval = eval.EvalResourceWithRawResponse(client.eval)
         self.inspect = inspect.InspectResourceWithRawResponse(client.inspect)
         self.inference = inference.InferenceResourceWithRawResponse(client.inference)
         self.memory = memory.MemoryResourceWithRawResponse(client.memory)
-        self.memory_banks = memory_banks.MemoryBanksResourceWithRawResponse(client.memory_banks)
+        self.memory_banks = memory_banks.MemoryBanksResourceWithRawResponse(
+            client.memory_banks
+        )
         self.models = models.ModelsResourceWithRawResponse(client.models)
-        self.post_training = post_training.PostTrainingResourceWithRawResponse(client.post_training)
+        self.post_training = post_training.PostTrainingResourceWithRawResponse(
+            client.post_training
+        )
         self.providers = providers.ProvidersResourceWithRawResponse(client.providers)
         self.routes = routes.RoutesResourceWithRawResponse(client.routes)
         self.safety = safety.SafetyResourceWithRawResponse(client.safety)
         self.shields = shields.ShieldsResourceWithRawResponse(client.shields)
-        self.synthetic_data_generation = synthetic_data_generation.SyntheticDataGenerationResourceWithRawResponse(
-            client.synthetic_data_generation
+        self.synthetic_data_generation = (
+            synthetic_data_generation.SyntheticDataGenerationResourceWithRawResponse(
+                client.synthetic_data_generation
+            )
         )
         self.telemetry = telemetry.TelemetryResourceWithRawResponse(client.telemetry)
         self.datasetio = datasetio.DatasetioResourceWithRawResponse(client.datasetio)
         self.scoring = scoring.ScoringResourceWithRawResponse(client.scoring)
-        self.scoring_functions = scoring_functions.ScoringFunctionsResourceWithRawResponse(client.scoring_functions)
+        self.scoring_functions = (
+            scoring_functions.ScoringFunctionsResourceWithRawResponse(
+                client.scoring_functions
+            )
+        )
         self.eval_tasks = eval_tasks.EvalTasksResourceWithRawResponse(client.eval_tasks)
 
 
 class AsyncLlamaStackClientWithRawResponse:
     def __init__(self, client: AsyncLlamaStackClient) -> None:
-        self.toolgroups = toolgroups.AsyncToolgroupsResourceWithRawResponse(client.toolgroups)
+        self.toolgroups = toolgroups.AsyncToolgroupsResourceWithRawResponse(
+            client.toolgroups
+        )
         self.tools = tools.AsyncToolsResourceWithRawResponse(client.tools)
-        self.tool_runtime = tool_runtime.AsyncToolRuntimeResourceWithRawResponse(client.tool_runtime)
+        self.tool_runtime = tool_runtime.AsyncToolRuntimeResourceWithRawResponse(
+            client.tool_runtime
+        )
         self.agents = agents.AsyncAgentsResourceWithRawResponse(client.agents)
-        self.batch_inference = batch_inference.AsyncBatchInferenceResourceWithRawResponse(client.batch_inference)
+        self.batch_inference = (
+            batch_inference.AsyncBatchInferenceResourceWithRawResponse(
+                client.batch_inference
+            )
+        )
         self.datasets = datasets.AsyncDatasetsResourceWithRawResponse(client.datasets)
         self.eval = eval.AsyncEvalResourceWithRawResponse(client.eval)
         self.inspect = inspect.AsyncInspectResourceWithRawResponse(client.inspect)
-        self.inference = inference.AsyncInferenceResourceWithRawResponse(client.inference)
+        self.inference = inference.AsyncInferenceResourceWithRawResponse(
+            client.inference
+        )
         self.memory = memory.AsyncMemoryResourceWithRawResponse(client.memory)
-        self.memory_banks = memory_banks.AsyncMemoryBanksResourceWithRawResponse(client.memory_banks)
+        self.memory_banks = memory_banks.AsyncMemoryBanksResourceWithRawResponse(
+            client.memory_banks
+        )
         self.models = models.AsyncModelsResourceWithRawResponse(client.models)
-        self.post_training = post_training.AsyncPostTrainingResourceWithRawResponse(client.post_training)
-        self.providers = providers.AsyncProvidersResourceWithRawResponse(client.providers)
+        self.post_training = post_training.AsyncPostTrainingResourceWithRawResponse(
+            client.post_training
+        )
+        self.providers = providers.AsyncProvidersResourceWithRawResponse(
+            client.providers
+        )
         self.routes = routes.AsyncRoutesResourceWithRawResponse(client.routes)
         self.safety = safety.AsyncSafetyResourceWithRawResponse(client.safety)
         self.shields = shields.AsyncShieldsResourceWithRawResponse(client.shields)
         self.synthetic_data_generation = synthetic_data_generation.AsyncSyntheticDataGenerationResourceWithRawResponse(
             client.synthetic_data_generation
         )
-        self.telemetry = telemetry.AsyncTelemetryResourceWithRawResponse(client.telemetry)
-        self.datasetio = datasetio.AsyncDatasetioResourceWithRawResponse(client.datasetio)
-        self.scoring = scoring.AsyncScoringResourceWithRawResponse(client.scoring)
-        self.scoring_functions = scoring_functions.AsyncScoringFunctionsResourceWithRawResponse(
-            client.scoring_functions
+        self.telemetry = telemetry.AsyncTelemetryResourceWithRawResponse(
+            client.telemetry
         )
-        self.eval_tasks = eval_tasks.AsyncEvalTasksResourceWithRawResponse(client.eval_tasks)
+        self.datasetio = datasetio.AsyncDatasetioResourceWithRawResponse(
+            client.datasetio
+        )
+        self.scoring = scoring.AsyncScoringResourceWithRawResponse(client.scoring)
+        self.scoring_functions = (
+            scoring_functions.AsyncScoringFunctionsResourceWithRawResponse(
+                client.scoring_functions
+            )
+        )
+        self.eval_tasks = eval_tasks.AsyncEvalTasksResourceWithRawResponse(
+            client.eval_tasks
+        )
 
 
 class LlamaStackClientWithStreamedResponse:
     def __init__(self, client: LlamaStackClient) -> None:
-        self.toolgroups = toolgroups.ToolgroupsResourceWithStreamingResponse(client.toolgroups)
+        self.toolgroups = toolgroups.ToolgroupsResourceWithStreamingResponse(
+            client.toolgroups
+        )
         self.tools = tools.ToolsResourceWithStreamingResponse(client.tools)
-        self.tool_runtime = tool_runtime.ToolRuntimeResourceWithStreamingResponse(client.tool_runtime)
+        self.tool_runtime = tool_runtime.ToolRuntimeResourceWithStreamingResponse(
+            client.tool_runtime
+        )
         self.agents = agents.AgentsResourceWithStreamingResponse(client.agents)
-        self.batch_inference = batch_inference.BatchInferenceResourceWithStreamingResponse(client.batch_inference)
+        self.batch_inference = (
+            batch_inference.BatchInferenceResourceWithStreamingResponse(
+                client.batch_inference
+            )
+        )
         self.datasets = datasets.DatasetsResourceWithStreamingResponse(client.datasets)
         self.eval = eval.EvalResourceWithStreamingResponse(client.eval)
         self.inspect = inspect.InspectResourceWithStreamingResponse(client.inspect)
-        self.inference = inference.InferenceResourceWithStreamingResponse(client.inference)
+        self.inference = inference.InferenceResourceWithStreamingResponse(
+            client.inference
+        )
         self.memory = memory.MemoryResourceWithStreamingResponse(client.memory)
-        self.memory_banks = memory_banks.MemoryBanksResourceWithStreamingResponse(client.memory_banks)
+        self.memory_banks = memory_banks.MemoryBanksResourceWithStreamingResponse(
+            client.memory_banks
+        )
         self.models = models.ModelsResourceWithStreamingResponse(client.models)
-        self.post_training = post_training.PostTrainingResourceWithStreamingResponse(client.post_training)
-        self.providers = providers.ProvidersResourceWithStreamingResponse(client.providers)
+        self.post_training = post_training.PostTrainingResourceWithStreamingResponse(
+            client.post_training
+        )
+        self.providers = providers.ProvidersResourceWithStreamingResponse(
+            client.providers
+        )
         self.routes = routes.RoutesResourceWithStreamingResponse(client.routes)
         self.safety = safety.SafetyResourceWithStreamingResponse(client.safety)
         self.shields = shields.ShieldsResourceWithStreamingResponse(client.shields)
         self.synthetic_data_generation = synthetic_data_generation.SyntheticDataGenerationResourceWithStreamingResponse(
             client.synthetic_data_generation
         )
-        self.telemetry = telemetry.TelemetryResourceWithStreamingResponse(client.telemetry)
-        self.datasetio = datasetio.DatasetioResourceWithStreamingResponse(client.datasetio)
-        self.scoring = scoring.ScoringResourceWithStreamingResponse(client.scoring)
-        self.scoring_functions = scoring_functions.ScoringFunctionsResourceWithStreamingResponse(
-            client.scoring_functions
+        self.telemetry = telemetry.TelemetryResourceWithStreamingResponse(
+            client.telemetry
         )
-        self.eval_tasks = eval_tasks.EvalTasksResourceWithStreamingResponse(client.eval_tasks)
+        self.datasetio = datasetio.DatasetioResourceWithStreamingResponse(
+            client.datasetio
+        )
+        self.scoring = scoring.ScoringResourceWithStreamingResponse(client.scoring)
+        self.scoring_functions = (
+            scoring_functions.ScoringFunctionsResourceWithStreamingResponse(
+                client.scoring_functions
+            )
+        )
+        self.eval_tasks = eval_tasks.EvalTasksResourceWithStreamingResponse(
+            client.eval_tasks
+        )
 
 
 class AsyncLlamaStackClientWithStreamedResponse:
     def __init__(self, client: AsyncLlamaStackClient) -> None:
-        self.toolgroups = toolgroups.AsyncToolgroupsResourceWithStreamingResponse(client.toolgroups)
+        self.toolgroups = toolgroups.AsyncToolgroupsResourceWithStreamingResponse(
+            client.toolgroups
+        )
         self.tools = tools.AsyncToolsResourceWithStreamingResponse(client.tools)
-        self.tool_runtime = tool_runtime.AsyncToolRuntimeResourceWithStreamingResponse(client.tool_runtime)
+        self.tool_runtime = tool_runtime.AsyncToolRuntimeResourceWithStreamingResponse(
+            client.tool_runtime
+        )
         self.agents = agents.AsyncAgentsResourceWithStreamingResponse(client.agents)
-        self.batch_inference = batch_inference.AsyncBatchInferenceResourceWithStreamingResponse(client.batch_inference)
-        self.datasets = datasets.AsyncDatasetsResourceWithStreamingResponse(client.datasets)
+        self.batch_inference = (
+            batch_inference.AsyncBatchInferenceResourceWithStreamingResponse(
+                client.batch_inference
+            )
+        )
+        self.datasets = datasets.AsyncDatasetsResourceWithStreamingResponse(
+            client.datasets
+        )
         self.eval = eval.AsyncEvalResourceWithStreamingResponse(client.eval)
         self.inspect = inspect.AsyncInspectResourceWithStreamingResponse(client.inspect)
-        self.inference = inference.AsyncInferenceResourceWithStreamingResponse(client.inference)
+        self.inference = inference.AsyncInferenceResourceWithStreamingResponse(
+            client.inference
+        )
         self.memory = memory.AsyncMemoryResourceWithStreamingResponse(client.memory)
-        self.memory_banks = memory_banks.AsyncMemoryBanksResourceWithStreamingResponse(client.memory_banks)
+        self.memory_banks = memory_banks.AsyncMemoryBanksResourceWithStreamingResponse(
+            client.memory_banks
+        )
         self.models = models.AsyncModelsResourceWithStreamingResponse(client.models)
-        self.post_training = post_training.AsyncPostTrainingResourceWithStreamingResponse(client.post_training)
-        self.providers = providers.AsyncProvidersResourceWithStreamingResponse(client.providers)
+        self.post_training = (
+            post_training.AsyncPostTrainingResourceWithStreamingResponse(
+                client.post_training
+            )
+        )
+        self.providers = providers.AsyncProvidersResourceWithStreamingResponse(
+            client.providers
+        )
         self.routes = routes.AsyncRoutesResourceWithStreamingResponse(client.routes)
         self.safety = safety.AsyncSafetyResourceWithStreamingResponse(client.safety)
         self.shields = shields.AsyncShieldsResourceWithStreamingResponse(client.shields)
-        self.synthetic_data_generation = (
-            synthetic_data_generation.AsyncSyntheticDataGenerationResourceWithStreamingResponse(
-                client.synthetic_data_generation
+        self.synthetic_data_generation = synthetic_data_generation.AsyncSyntheticDataGenerationResourceWithStreamingResponse(
+            client.synthetic_data_generation
+        )
+        self.telemetry = telemetry.AsyncTelemetryResourceWithStreamingResponse(
+            client.telemetry
+        )
+        self.datasetio = datasetio.AsyncDatasetioResourceWithStreamingResponse(
+            client.datasetio
+        )
+        self.scoring = scoring.AsyncScoringResourceWithStreamingResponse(client.scoring)
+        self.scoring_functions = (
+            scoring_functions.AsyncScoringFunctionsResourceWithStreamingResponse(
+                client.scoring_functions
             )
         )
-        self.telemetry = telemetry.AsyncTelemetryResourceWithStreamingResponse(client.telemetry)
-        self.datasetio = datasetio.AsyncDatasetioResourceWithStreamingResponse(client.datasetio)
-        self.scoring = scoring.AsyncScoringResourceWithStreamingResponse(client.scoring)
-        self.scoring_functions = scoring_functions.AsyncScoringFunctionsResourceWithStreamingResponse(
-            client.scoring_functions
+        self.eval_tasks = eval_tasks.AsyncEvalTasksResourceWithStreamingResponse(
+            client.eval_tasks
         )
-        self.eval_tasks = eval_tasks.AsyncEvalTasksResourceWithStreamingResponse(client.eval_tasks)
 
 
 Client = LlamaStackClient

--- a/src/llama_stack_client/_client.py
+++ b/src/llama_stack_client/_client.py
@@ -1,7 +1,7 @@
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
-from __future__ import annotations
 import json
+from __future__ import annotations
 
 import os
 from typing import Any, Union, Mapping
@@ -26,6 +26,7 @@ from ._utils import (
 )
 from ._version import __version__
 from .resources import (
+    tools,
     memory,
     models,
     routes,
@@ -39,7 +40,9 @@ from .resources import (
     providers,
     telemetry,
     eval_tasks,
+    toolgroups,
     memory_banks,
+    tool_runtime,
     batch_inference,
     scoring_functions,
     synthetic_data_generation,
@@ -68,6 +71,9 @@ __all__ = [
 
 
 class LlamaStackClient(SyncAPIClient):
+    toolgroups: toolgroups.ToolgroupsResource
+    tools: tools.ToolsResource
+    tool_runtime: tool_runtime.ToolRuntimeResource
     agents: agents.AgentsResource
     batch_inference: batch_inference.BatchInferenceResource
     datasets: datasets.DatasetsResource
@@ -126,6 +132,7 @@ class LlamaStackClient(SyncAPIClient):
             if default_headers is None:
                 default_headers = {}
             default_headers["X-LlamaStack-ProviderData"] = json.dumps(provider_data)
+
         super().__init__(
             version=__version__,
             base_url=base_url,
@@ -137,6 +144,9 @@ class LlamaStackClient(SyncAPIClient):
             _strict_response_validation=_strict_response_validation,
         )
 
+        self.toolgroups = toolgroups.ToolgroupsResource(self)
+        self.tools = tools.ToolsResource(self)
+        self.tool_runtime = tool_runtime.ToolRuntimeResource(self)
         self.agents = agents.AgentsResource(self)
         self.batch_inference = batch_inference.BatchInferenceResource(self)
         self.datasets = datasets.DatasetsResource(self)
@@ -258,6 +268,9 @@ class LlamaStackClient(SyncAPIClient):
 
 
 class AsyncLlamaStackClient(AsyncAPIClient):
+    toolgroups: toolgroups.AsyncToolgroupsResource
+    tools: tools.AsyncToolsResource
+    tool_runtime: tool_runtime.AsyncToolRuntimeResource
     agents: agents.AsyncAgentsResource
     batch_inference: batch_inference.AsyncBatchInferenceResource
     datasets: datasets.AsyncDatasetsResource
@@ -316,6 +329,7 @@ class AsyncLlamaStackClient(AsyncAPIClient):
             if default_headers is None:
                 default_headers = {}
             default_headers["X-LlamaStack-ProviderData"] = json.dumps(provider_data)
+
         super().__init__(
             version=__version__,
             base_url=base_url,
@@ -327,6 +341,9 @@ class AsyncLlamaStackClient(AsyncAPIClient):
             _strict_response_validation=_strict_response_validation,
         )
 
+        self.toolgroups = toolgroups.AsyncToolgroupsResource(self)
+        self.tools = tools.AsyncToolsResource(self)
+        self.tool_runtime = tool_runtime.AsyncToolRuntimeResource(self)
         self.agents = agents.AsyncAgentsResource(self)
         self.batch_inference = batch_inference.AsyncBatchInferenceResource(self)
         self.datasets = datasets.AsyncDatasetsResource(self)
@@ -449,6 +466,9 @@ class AsyncLlamaStackClient(AsyncAPIClient):
 
 class LlamaStackClientWithRawResponse:
     def __init__(self, client: LlamaStackClient) -> None:
+        self.toolgroups = toolgroups.ToolgroupsResourceWithRawResponse(client.toolgroups)
+        self.tools = tools.ToolsResourceWithRawResponse(client.tools)
+        self.tool_runtime = tool_runtime.ToolRuntimeResourceWithRawResponse(client.tool_runtime)
         self.agents = agents.AgentsResourceWithRawResponse(client.agents)
         self.batch_inference = batch_inference.BatchInferenceResourceWithRawResponse(client.batch_inference)
         self.datasets = datasets.DatasetsResourceWithRawResponse(client.datasets)
@@ -475,6 +495,9 @@ class LlamaStackClientWithRawResponse:
 
 class AsyncLlamaStackClientWithRawResponse:
     def __init__(self, client: AsyncLlamaStackClient) -> None:
+        self.toolgroups = toolgroups.AsyncToolgroupsResourceWithRawResponse(client.toolgroups)
+        self.tools = tools.AsyncToolsResourceWithRawResponse(client.tools)
+        self.tool_runtime = tool_runtime.AsyncToolRuntimeResourceWithRawResponse(client.tool_runtime)
         self.agents = agents.AsyncAgentsResourceWithRawResponse(client.agents)
         self.batch_inference = batch_inference.AsyncBatchInferenceResourceWithRawResponse(client.batch_inference)
         self.datasets = datasets.AsyncDatasetsResourceWithRawResponse(client.datasets)
@@ -503,6 +526,9 @@ class AsyncLlamaStackClientWithRawResponse:
 
 class LlamaStackClientWithStreamedResponse:
     def __init__(self, client: LlamaStackClient) -> None:
+        self.toolgroups = toolgroups.ToolgroupsResourceWithStreamingResponse(client.toolgroups)
+        self.tools = tools.ToolsResourceWithStreamingResponse(client.tools)
+        self.tool_runtime = tool_runtime.ToolRuntimeResourceWithStreamingResponse(client.tool_runtime)
         self.agents = agents.AgentsResourceWithStreamingResponse(client.agents)
         self.batch_inference = batch_inference.BatchInferenceResourceWithStreamingResponse(client.batch_inference)
         self.datasets = datasets.DatasetsResourceWithStreamingResponse(client.datasets)
@@ -531,6 +557,9 @@ class LlamaStackClientWithStreamedResponse:
 
 class AsyncLlamaStackClientWithStreamedResponse:
     def __init__(self, client: AsyncLlamaStackClient) -> None:
+        self.toolgroups = toolgroups.AsyncToolgroupsResourceWithStreamingResponse(client.toolgroups)
+        self.tools = tools.AsyncToolsResourceWithStreamingResponse(client.tools)
+        self.tool_runtime = tool_runtime.AsyncToolRuntimeResourceWithStreamingResponse(client.tool_runtime)
         self.agents = agents.AsyncAgentsResourceWithStreamingResponse(client.agents)
         self.batch_inference = batch_inference.AsyncBatchInferenceResourceWithStreamingResponse(client.batch_inference)
         self.datasets = datasets.AsyncDatasetsResourceWithStreamingResponse(client.datasets)

--- a/src/llama_stack_client/_models.py
+++ b/src/llama_stack_client/_models.py
@@ -488,7 +488,11 @@ def construct_type(*, value: object, type_: object) -> object:
         _, items_type = get_args(type_)  # Dict[_, items_type]
         return {key: construct_type(value=item, type_=items_type) for key, item in value.items()}
 
-    if not is_literal_type(type_) and (issubclass(origin, BaseModel) or issubclass(origin, GenericModel)):
+    if (
+        not is_literal_type(type_)
+        and inspect.isclass(origin)
+        and (issubclass(origin, BaseModel) or issubclass(origin, GenericModel))
+    ):
         if is_list(value):
             return [cast(Any, type_).construct(**entry) if is_mapping(entry) else entry for entry in value]
 

--- a/src/llama_stack_client/lib/agents/agent.py
+++ b/src/llama_stack_client/lib/agents/agent.py
@@ -6,11 +6,11 @@
 from typing import List, Optional, Tuple, Union
 
 from llama_stack_client import LlamaStackClient
-from llama_stack_client.types import (Attachment, ToolResponseMessage,
-                                      UserMessage)
+from llama_stack_client.types import ToolResponseMessage, UserMessage
 from llama_stack_client.types.agent_create_params import AgentConfig
+from llama_stack_client.types.agents.turn_create_params import Document, Toolgroup
 
-from .custom_tool import CustomTool
+from .client_tool import ClientTool
 
 
 class Agent:
@@ -18,13 +18,15 @@ class Agent:
         self,
         client: LlamaStackClient,
         agent_config: AgentConfig,
-        custom_tools: Tuple[CustomTool] = (),
+        client_tools: Tuple[ClientTool] = (),
+        memory_bank_id: Optional[str] = None,
     ):
         self.client = client
         self.agent_config = agent_config
         self.agent_id = self._create_agent(agent_config)
-        self.custom_tools = {t.get_name(): t for t in custom_tools}
+        self.client_tools = {t.get_name(): t for t in client_tools}
         self.sessions = []
+        self.memory_bank_id = memory_bank_id
 
     def _create_agent(self, agent_config: AgentConfig) -> int:
         agentic_system_create_response = self.client.agents.create(
@@ -53,14 +55,14 @@ class Agent:
     def _run_tool(self, chunk):
         message = chunk.event.payload.turn.output_message
         tool_call = message.tool_calls[0]
-        if tool_call.tool_name not in self.custom_tools:
+        if tool_call.tool_name not in self.client_tools:
             return ToolResponseMessage(
                 call_id=tool_call.call_id,
                 tool_name=tool_call.tool_name,
                 content=f"Unknown tool `{tool_call.tool_name}` was called.",
                 role="ipython",
             )
-        tool = self.custom_tools[tool_call.tool_name]
+        tool = self.client_tools[tool_call.tool_name]
         result_messages = tool.run([message])
         next_message = result_messages[0]
         return next_message
@@ -68,16 +70,18 @@ class Agent:
     def create_turn(
         self,
         messages: List[Union[UserMessage, ToolResponseMessage]],
-        attachments: Optional[List[Attachment]] = None,
         session_id: Optional[str] = None,
+        toolgroups: Optional[List[Toolgroup]] = None,
+        documents: Optional[List[Document]] = None,
     ):
         response = self.client.agents.turn.create(
             agent_id=self.agent_id,
             # use specified session_id or last session created
             session_id=session_id or self.session_id[-1],
             messages=messages,
-            attachments=attachments,
             stream=True,
+            documents=documents,
+            toolgroups=toolgroups,
         )
         for chunk in response:
             if hasattr(chunk, "error"):

--- a/src/llama_stack_client/lib/agents/client_tool.py
+++ b/src/llama_stack_client/lib/agents/client_tool.py
@@ -8,13 +8,14 @@ import json
 from abc import abstractmethod
 from typing import Dict, List, Union
 
-from llama_stack_client.types import (FunctionCallToolDefinition,
-                                      ToolResponseMessage, UserMessage)
-from llama_stack_client.types.tool_param_definition_param import \
-    ToolParamDefinitionParam
+from llama_stack_client.types import ToolResponseMessage, UserMessage
+from llama_stack_client.types.tool_def_param import (
+    Parameter,
+    ToolDefParam,
+)
 
 
-class CustomTool:
+class ClientTool:
     """
     Developers can define their custom tools that models can use
     by extending this class.
@@ -37,7 +38,7 @@ class CustomTool:
         raise NotImplementedError
 
     @abstractmethod
-    def get_params_definition(self) -> Dict[str, ToolParamDefinitionParam]:
+    def get_params_definition(self) -> Dict[str, Parameter]:
         raise NotImplementedError
 
     def get_instruction_string(self) -> str:
@@ -48,16 +49,20 @@ class CustomTool:
             {
                 "name": self.get_name(),
                 "description": self.get_description(),
-                "parameters": {name: definition.__dict__ for name, definition in self.get_params_definition().items()},
+                "parameters": {
+                    name: definition.__dict__
+                    for name, definition in self.get_params_definition().items()
+                },
             }
         )
 
-    def get_tool_definition(self) -> FunctionCallToolDefinition:
-        return FunctionCallToolDefinition(
-            type="function_call",
-            function_name=self.get_name(),
+    def get_tool_definition(self) -> ToolDefParam:
+        return ToolDefParam(
+            name=self.get_name(),
             description=self.get_description(),
-            parameters=self.get_params_definition(),
+            parameters=list(self.get_params_definition().values()),
+            metadata={},
+            tool_prompt_format="python_list",
         )
 
     @abstractmethod

--- a/src/llama_stack_client/lib/agents/event_logger.py
+++ b/src/llama_stack_client/lib/agents/event_logger.py
@@ -125,25 +125,21 @@ class EventLogger:
                 )
 
             for r in details.tool_responses:
-                yield LogEvent(
-                    role=step_type,
-                    content=f"Tool:{r.tool_name} Response:{r.content}",
-                    color="green",
-                )
+                if r.tool_name == "query_memory":
+                    inserted_context = interleaved_content_as_str(r.content)
+                    content = f"fetched {len(inserted_context)} bytes from memory"
 
-        # memory retrieval
-        if step_type == "memory_retrieval" and event_type == "step_complete":
-            details = event.payload.step_details
-            inserted_context = interleaved_content_as_str(details.inserted_context)
-            content = (
-                f"fetched {len(inserted_context)} bytes from {details.memory_bank_ids}"
-            )
-
-            yield LogEvent(
-                role=step_type,
-                content=content,
-                color="cyan",
-            )
+                    yield LogEvent(
+                        role=step_type,
+                        content=content,
+                        color="cyan",
+                    )
+                else:
+                    yield LogEvent(
+                        role=step_type,
+                        content=f"Tool:{r.tool_name} Response:{r.content}",
+                        color="green",
+                    )
 
     def _get_event_type_step_type(self, chunk):
         if hasattr(chunk, "event"):

--- a/src/llama_stack_client/resources/__init__.py
+++ b/src/llama_stack_client/resources/__init__.py
@@ -8,6 +8,14 @@ from .eval import (
     EvalResourceWithStreamingResponse,
     AsyncEvalResourceWithStreamingResponse,
 )
+from .tools import (
+    ToolsResource,
+    AsyncToolsResource,
+    ToolsResourceWithRawResponse,
+    AsyncToolsResourceWithRawResponse,
+    ToolsResourceWithStreamingResponse,
+    AsyncToolsResourceWithStreamingResponse,
+)
 from .agents import (
     AgentsResource,
     AsyncAgentsResource,
@@ -120,6 +128,14 @@ from .eval_tasks import (
     EvalTasksResourceWithStreamingResponse,
     AsyncEvalTasksResourceWithStreamingResponse,
 )
+from .toolgroups import (
+    ToolgroupsResource,
+    AsyncToolgroupsResource,
+    ToolgroupsResourceWithRawResponse,
+    AsyncToolgroupsResourceWithRawResponse,
+    ToolgroupsResourceWithStreamingResponse,
+    AsyncToolgroupsResourceWithStreamingResponse,
+)
 from .memory_banks import (
     MemoryBanksResource,
     AsyncMemoryBanksResource,
@@ -127,6 +143,14 @@ from .memory_banks import (
     AsyncMemoryBanksResourceWithRawResponse,
     MemoryBanksResourceWithStreamingResponse,
     AsyncMemoryBanksResourceWithStreamingResponse,
+)
+from .tool_runtime import (
+    ToolRuntimeResource,
+    AsyncToolRuntimeResource,
+    ToolRuntimeResourceWithRawResponse,
+    AsyncToolRuntimeResourceWithRawResponse,
+    ToolRuntimeResourceWithStreamingResponse,
+    AsyncToolRuntimeResourceWithStreamingResponse,
 )
 from .post_training import (
     PostTrainingResource,
@@ -162,6 +186,24 @@ from .synthetic_data_generation import (
 )
 
 __all__ = [
+    "ToolgroupsResource",
+    "AsyncToolgroupsResource",
+    "ToolgroupsResourceWithRawResponse",
+    "AsyncToolgroupsResourceWithRawResponse",
+    "ToolgroupsResourceWithStreamingResponse",
+    "AsyncToolgroupsResourceWithStreamingResponse",
+    "ToolsResource",
+    "AsyncToolsResource",
+    "ToolsResourceWithRawResponse",
+    "AsyncToolsResourceWithRawResponse",
+    "ToolsResourceWithStreamingResponse",
+    "AsyncToolsResourceWithStreamingResponse",
+    "ToolRuntimeResource",
+    "AsyncToolRuntimeResource",
+    "ToolRuntimeResourceWithRawResponse",
+    "AsyncToolRuntimeResourceWithRawResponse",
+    "ToolRuntimeResourceWithStreamingResponse",
+    "AsyncToolRuntimeResourceWithStreamingResponse",
     "AgentsResource",
     "AsyncAgentsResource",
     "AgentsResourceWithRawResponse",

--- a/src/llama_stack_client/resources/agents/turn.py
+++ b/src/llama_stack_client/resources/agents/turn.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Iterable, cast
+from typing import Any, List, Iterable, cast
 from typing_extensions import Literal, overload
 
 import httpx
@@ -26,7 +26,6 @@ from ..._streaming import Stream, AsyncStream
 from ..._base_client import make_request_options
 from ...types.agents import turn_create_params, turn_retrieve_params
 from ...types.agents.turn import Turn
-from ...types.shared_params.attachment import Attachment
 from ...types.agents.turn_create_response import TurnCreateResponse
 
 __all__ = ["TurnResource", "AsyncTurnResource"]
@@ -59,8 +58,9 @@ class TurnResource(SyncAPIResource):
         agent_id: str,
         messages: Iterable[turn_create_params.Message],
         session_id: str,
-        attachments: Iterable[Attachment] | NotGiven = NOT_GIVEN,
+        documents: Iterable[turn_create_params.Document] | NotGiven = NOT_GIVEN,
         stream: Literal[False] | NotGiven = NOT_GIVEN,
+        toolgroups: List[turn_create_params.Toolgroup] | NotGiven = NOT_GIVEN,
         x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
@@ -89,7 +89,8 @@ class TurnResource(SyncAPIResource):
         messages: Iterable[turn_create_params.Message],
         session_id: str,
         stream: Literal[True],
-        attachments: Iterable[Attachment] | NotGiven = NOT_GIVEN,
+        documents: Iterable[turn_create_params.Document] | NotGiven = NOT_GIVEN,
+        toolgroups: List[turn_create_params.Toolgroup] | NotGiven = NOT_GIVEN,
         x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
@@ -118,7 +119,8 @@ class TurnResource(SyncAPIResource):
         messages: Iterable[turn_create_params.Message],
         session_id: str,
         stream: bool,
-        attachments: Iterable[Attachment] | NotGiven = NOT_GIVEN,
+        documents: Iterable[turn_create_params.Document] | NotGiven = NOT_GIVEN,
+        toolgroups: List[turn_create_params.Toolgroup] | NotGiven = NOT_GIVEN,
         x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
@@ -146,8 +148,9 @@ class TurnResource(SyncAPIResource):
         agent_id: str,
         messages: Iterable[turn_create_params.Message],
         session_id: str,
-        attachments: Iterable[Attachment] | NotGiven = NOT_GIVEN,
+        documents: Iterable[turn_create_params.Document] | NotGiven = NOT_GIVEN,
         stream: Literal[False] | Literal[True] | NotGiven = NOT_GIVEN,
+        toolgroups: List[turn_create_params.Toolgroup] | NotGiven = NOT_GIVEN,
         x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
@@ -170,8 +173,9 @@ class TurnResource(SyncAPIResource):
                         "agent_id": agent_id,
                         "messages": messages,
                         "session_id": session_id,
-                        "attachments": attachments,
+                        "documents": documents,
                         "stream": stream,
+                        "toolgroups": toolgroups,
                     },
                     turn_create_params.TurnCreateParams,
                 ),
@@ -261,8 +265,9 @@ class AsyncTurnResource(AsyncAPIResource):
         agent_id: str,
         messages: Iterable[turn_create_params.Message],
         session_id: str,
-        attachments: Iterable[Attachment] | NotGiven = NOT_GIVEN,
+        documents: Iterable[turn_create_params.Document] | NotGiven = NOT_GIVEN,
         stream: Literal[False] | NotGiven = NOT_GIVEN,
+        toolgroups: List[turn_create_params.Toolgroup] | NotGiven = NOT_GIVEN,
         x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
@@ -291,7 +296,8 @@ class AsyncTurnResource(AsyncAPIResource):
         messages: Iterable[turn_create_params.Message],
         session_id: str,
         stream: Literal[True],
-        attachments: Iterable[Attachment] | NotGiven = NOT_GIVEN,
+        documents: Iterable[turn_create_params.Document] | NotGiven = NOT_GIVEN,
+        toolgroups: List[turn_create_params.Toolgroup] | NotGiven = NOT_GIVEN,
         x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
@@ -320,7 +326,8 @@ class AsyncTurnResource(AsyncAPIResource):
         messages: Iterable[turn_create_params.Message],
         session_id: str,
         stream: bool,
-        attachments: Iterable[Attachment] | NotGiven = NOT_GIVEN,
+        documents: Iterable[turn_create_params.Document] | NotGiven = NOT_GIVEN,
+        toolgroups: List[turn_create_params.Toolgroup] | NotGiven = NOT_GIVEN,
         x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
@@ -348,8 +355,9 @@ class AsyncTurnResource(AsyncAPIResource):
         agent_id: str,
         messages: Iterable[turn_create_params.Message],
         session_id: str,
-        attachments: Iterable[Attachment] | NotGiven = NOT_GIVEN,
+        documents: Iterable[turn_create_params.Document] | NotGiven = NOT_GIVEN,
         stream: Literal[False] | Literal[True] | NotGiven = NOT_GIVEN,
+        toolgroups: List[turn_create_params.Toolgroup] | NotGiven = NOT_GIVEN,
         x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
@@ -372,8 +380,9 @@ class AsyncTurnResource(AsyncAPIResource):
                         "agent_id": agent_id,
                         "messages": messages,
                         "session_id": session_id,
-                        "attachments": attachments,
+                        "documents": documents,
                         "stream": stream,
+                        "toolgroups": toolgroups,
                     },
                     turn_create_params.TurnCreateParams,
                 ),

--- a/src/llama_stack_client/resources/tool_runtime.py
+++ b/src/llama_stack_client/resources/tool_runtime.py
@@ -1,0 +1,297 @@
+# File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
+
+from __future__ import annotations
+
+from typing import Dict, Union, Iterable
+
+import httpx
+
+from ..types import tool_runtime_list_tools_params, tool_runtime_invoke_tool_params
+from .._types import NOT_GIVEN, Body, Query, Headers, NotGiven
+from .._utils import (
+    maybe_transform,
+    strip_not_given,
+    async_maybe_transform,
+)
+from .._compat import cached_property
+from .._resource import SyncAPIResource, AsyncAPIResource
+from .._response import (
+    to_raw_response_wrapper,
+    to_streamed_response_wrapper,
+    async_to_raw_response_wrapper,
+    async_to_streamed_response_wrapper,
+)
+from .._base_client import make_request_options
+from ..types.tool_def import ToolDef
+from ..types.shared_params.url import URL
+from ..types.tool_invocation_result import ToolInvocationResult
+
+__all__ = ["ToolRuntimeResource", "AsyncToolRuntimeResource"]
+
+
+class ToolRuntimeResource(SyncAPIResource):
+    @cached_property
+    def with_raw_response(self) -> ToolRuntimeResourceWithRawResponse:
+        """
+        This property can be used as a prefix for any HTTP method call to return the
+        the raw response object instead of the parsed content.
+
+        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#accessing-raw-response-data-eg-headers
+        """
+        return ToolRuntimeResourceWithRawResponse(self)
+
+    @cached_property
+    def with_streaming_response(self) -> ToolRuntimeResourceWithStreamingResponse:
+        """
+        An alternative to `.with_raw_response` that doesn't eagerly read the response body.
+
+        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#with_streaming_response
+        """
+        return ToolRuntimeResourceWithStreamingResponse(self)
+
+    def invoke_tool(
+        self,
+        *,
+        args: Dict[str, Union[bool, float, str, Iterable[object], object, None]],
+        tool_name: str,
+        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
+        # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
+        # The extra values given here take precedence over values defined on the client or passed to this method.
+        extra_headers: Headers | None = None,
+        extra_query: Query | None = None,
+        extra_body: Body | None = None,
+        timeout: float | httpx.Timeout | None | NotGiven = NOT_GIVEN,
+    ) -> ToolInvocationResult:
+        """
+        Run a tool with the given arguments
+
+        Args:
+          extra_headers: Send extra headers
+
+          extra_query: Add additional query parameters to the request
+
+          extra_body: Add additional JSON properties to the request
+
+          timeout: Override the client-level default timeout for this request, in seconds
+        """
+        extra_headers = {
+            **strip_not_given({"X-LlamaStack-ProviderData": x_llama_stack_provider_data}),
+            **(extra_headers or {}),
+        }
+        return self._post(
+            "/alpha/tool-runtime/invoke",
+            body=maybe_transform(
+                {
+                    "args": args,
+                    "tool_name": tool_name,
+                },
+                tool_runtime_invoke_tool_params.ToolRuntimeInvokeToolParams,
+            ),
+            options=make_request_options(
+                extra_headers=extra_headers, extra_query=extra_query, extra_body=extra_body, timeout=timeout
+            ),
+            cast_to=ToolInvocationResult,
+        )
+
+    def list_tools(
+        self,
+        *,
+        tool_group_id: str | NotGiven = NOT_GIVEN,
+        mcp_endpoint: URL | NotGiven = NOT_GIVEN,
+        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
+        # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
+        # The extra values given here take precedence over values defined on the client or passed to this method.
+        extra_headers: Headers | None = None,
+        extra_query: Query | None = None,
+        extra_body: Body | None = None,
+        timeout: float | httpx.Timeout | None | NotGiven = NOT_GIVEN,
+    ) -> ToolDef:
+        """
+        Args:
+          extra_headers: Send extra headers
+
+          extra_query: Add additional query parameters to the request
+
+          extra_body: Add additional JSON properties to the request
+
+          timeout: Override the client-level default timeout for this request, in seconds
+        """
+        extra_headers = {"Accept": "application/jsonl", **(extra_headers or {})}
+        extra_headers = {
+            **strip_not_given({"X-LlamaStack-ProviderData": x_llama_stack_provider_data}),
+            **(extra_headers or {}),
+        }
+        return self._post(
+            "/alpha/tool-runtime/list-tools",
+            body=maybe_transform(
+                {"mcp_endpoint": mcp_endpoint}, tool_runtime_list_tools_params.ToolRuntimeListToolsParams
+            ),
+            options=make_request_options(
+                extra_headers=extra_headers,
+                extra_query=extra_query,
+                extra_body=extra_body,
+                timeout=timeout,
+                query=maybe_transform(
+                    {"tool_group_id": tool_group_id}, tool_runtime_list_tools_params.ToolRuntimeListToolsParams
+                ),
+            ),
+            cast_to=ToolDef,
+        )
+
+
+class AsyncToolRuntimeResource(AsyncAPIResource):
+    @cached_property
+    def with_raw_response(self) -> AsyncToolRuntimeResourceWithRawResponse:
+        """
+        This property can be used as a prefix for any HTTP method call to return the
+        the raw response object instead of the parsed content.
+
+        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#accessing-raw-response-data-eg-headers
+        """
+        return AsyncToolRuntimeResourceWithRawResponse(self)
+
+    @cached_property
+    def with_streaming_response(self) -> AsyncToolRuntimeResourceWithStreamingResponse:
+        """
+        An alternative to `.with_raw_response` that doesn't eagerly read the response body.
+
+        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#with_streaming_response
+        """
+        return AsyncToolRuntimeResourceWithStreamingResponse(self)
+
+    async def invoke_tool(
+        self,
+        *,
+        args: Dict[str, Union[bool, float, str, Iterable[object], object, None]],
+        tool_name: str,
+        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
+        # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
+        # The extra values given here take precedence over values defined on the client or passed to this method.
+        extra_headers: Headers | None = None,
+        extra_query: Query | None = None,
+        extra_body: Body | None = None,
+        timeout: float | httpx.Timeout | None | NotGiven = NOT_GIVEN,
+    ) -> ToolInvocationResult:
+        """
+        Run a tool with the given arguments
+
+        Args:
+          extra_headers: Send extra headers
+
+          extra_query: Add additional query parameters to the request
+
+          extra_body: Add additional JSON properties to the request
+
+          timeout: Override the client-level default timeout for this request, in seconds
+        """
+        extra_headers = {
+            **strip_not_given({"X-LlamaStack-ProviderData": x_llama_stack_provider_data}),
+            **(extra_headers or {}),
+        }
+        return await self._post(
+            "/alpha/tool-runtime/invoke",
+            body=await async_maybe_transform(
+                {
+                    "args": args,
+                    "tool_name": tool_name,
+                },
+                tool_runtime_invoke_tool_params.ToolRuntimeInvokeToolParams,
+            ),
+            options=make_request_options(
+                extra_headers=extra_headers, extra_query=extra_query, extra_body=extra_body, timeout=timeout
+            ),
+            cast_to=ToolInvocationResult,
+        )
+
+    async def list_tools(
+        self,
+        *,
+        tool_group_id: str | NotGiven = NOT_GIVEN,
+        mcp_endpoint: URL | NotGiven = NOT_GIVEN,
+        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
+        # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
+        # The extra values given here take precedence over values defined on the client or passed to this method.
+        extra_headers: Headers | None = None,
+        extra_query: Query | None = None,
+        extra_body: Body | None = None,
+        timeout: float | httpx.Timeout | None | NotGiven = NOT_GIVEN,
+    ) -> ToolDef:
+        """
+        Args:
+          extra_headers: Send extra headers
+
+          extra_query: Add additional query parameters to the request
+
+          extra_body: Add additional JSON properties to the request
+
+          timeout: Override the client-level default timeout for this request, in seconds
+        """
+        extra_headers = {"Accept": "application/jsonl", **(extra_headers or {})}
+        extra_headers = {
+            **strip_not_given({"X-LlamaStack-ProviderData": x_llama_stack_provider_data}),
+            **(extra_headers or {}),
+        }
+        return await self._post(
+            "/alpha/tool-runtime/list-tools",
+            body=await async_maybe_transform(
+                {"mcp_endpoint": mcp_endpoint}, tool_runtime_list_tools_params.ToolRuntimeListToolsParams
+            ),
+            options=make_request_options(
+                extra_headers=extra_headers,
+                extra_query=extra_query,
+                extra_body=extra_body,
+                timeout=timeout,
+                query=await async_maybe_transform(
+                    {"tool_group_id": tool_group_id}, tool_runtime_list_tools_params.ToolRuntimeListToolsParams
+                ),
+            ),
+            cast_to=ToolDef,
+        )
+
+
+class ToolRuntimeResourceWithRawResponse:
+    def __init__(self, tool_runtime: ToolRuntimeResource) -> None:
+        self._tool_runtime = tool_runtime
+
+        self.invoke_tool = to_raw_response_wrapper(
+            tool_runtime.invoke_tool,
+        )
+        self.list_tools = to_raw_response_wrapper(
+            tool_runtime.list_tools,
+        )
+
+
+class AsyncToolRuntimeResourceWithRawResponse:
+    def __init__(self, tool_runtime: AsyncToolRuntimeResource) -> None:
+        self._tool_runtime = tool_runtime
+
+        self.invoke_tool = async_to_raw_response_wrapper(
+            tool_runtime.invoke_tool,
+        )
+        self.list_tools = async_to_raw_response_wrapper(
+            tool_runtime.list_tools,
+        )
+
+
+class ToolRuntimeResourceWithStreamingResponse:
+    def __init__(self, tool_runtime: ToolRuntimeResource) -> None:
+        self._tool_runtime = tool_runtime
+
+        self.invoke_tool = to_streamed_response_wrapper(
+            tool_runtime.invoke_tool,
+        )
+        self.list_tools = to_streamed_response_wrapper(
+            tool_runtime.list_tools,
+        )
+
+
+class AsyncToolRuntimeResourceWithStreamingResponse:
+    def __init__(self, tool_runtime: AsyncToolRuntimeResource) -> None:
+        self._tool_runtime = tool_runtime
+
+        self.invoke_tool = async_to_streamed_response_wrapper(
+            tool_runtime.invoke_tool,
+        )
+        self.list_tools = async_to_streamed_response_wrapper(
+            tool_runtime.list_tools,
+        )

--- a/src/llama_stack_client/resources/toolgroups.py
+++ b/src/llama_stack_client/resources/toolgroups.py
@@ -1,0 +1,470 @@
+# File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
+
+from __future__ import annotations
+
+from typing import Dict, Union, Iterable
+
+import httpx
+
+from ..types import toolgroup_get_params, toolgroup_register_params, toolgroup_unregister_params
+from .._types import NOT_GIVEN, Body, Query, Headers, NoneType, NotGiven
+from .._utils import (
+    maybe_transform,
+    strip_not_given,
+    async_maybe_transform,
+)
+from .._compat import cached_property
+from .._resource import SyncAPIResource, AsyncAPIResource
+from .._response import (
+    to_raw_response_wrapper,
+    to_streamed_response_wrapper,
+    async_to_raw_response_wrapper,
+    async_to_streamed_response_wrapper,
+)
+from .._base_client import make_request_options
+from ..types.tool_group import ToolGroup
+from ..types.shared_params.url import URL
+
+__all__ = ["ToolgroupsResource", "AsyncToolgroupsResource"]
+
+
+class ToolgroupsResource(SyncAPIResource):
+    @cached_property
+    def with_raw_response(self) -> ToolgroupsResourceWithRawResponse:
+        """
+        This property can be used as a prefix for any HTTP method call to return the
+        the raw response object instead of the parsed content.
+
+        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#accessing-raw-response-data-eg-headers
+        """
+        return ToolgroupsResourceWithRawResponse(self)
+
+    @cached_property
+    def with_streaming_response(self) -> ToolgroupsResourceWithStreamingResponse:
+        """
+        An alternative to `.with_raw_response` that doesn't eagerly read the response body.
+
+        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#with_streaming_response
+        """
+        return ToolgroupsResourceWithStreamingResponse(self)
+
+    def list(
+        self,
+        *,
+        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
+        # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
+        # The extra values given here take precedence over values defined on the client or passed to this method.
+        extra_headers: Headers | None = None,
+        extra_query: Query | None = None,
+        extra_body: Body | None = None,
+        timeout: float | httpx.Timeout | None | NotGiven = NOT_GIVEN,
+    ) -> ToolGroup:
+        """
+        List tool groups with optional provider
+
+        Args:
+          extra_headers: Send extra headers
+
+          extra_query: Add additional query parameters to the request
+
+          extra_body: Add additional JSON properties to the request
+
+          timeout: Override the client-level default timeout for this request, in seconds
+        """
+        extra_headers = {"Accept": "application/jsonl", **(extra_headers or {})}
+        extra_headers = {
+            **strip_not_given({"X-LlamaStack-ProviderData": x_llama_stack_provider_data}),
+            **(extra_headers or {}),
+        }
+        return self._get(
+            "/alpha/toolgroups/list",
+            options=make_request_options(
+                extra_headers=extra_headers, extra_query=extra_query, extra_body=extra_body, timeout=timeout
+            ),
+            cast_to=ToolGroup,
+        )
+
+    def get(
+        self,
+        *,
+        toolgroup_id: str,
+        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
+        # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
+        # The extra values given here take precedence over values defined on the client or passed to this method.
+        extra_headers: Headers | None = None,
+        extra_query: Query | None = None,
+        extra_body: Body | None = None,
+        timeout: float | httpx.Timeout | None | NotGiven = NOT_GIVEN,
+    ) -> ToolGroup:
+        """
+        Args:
+          extra_headers: Send extra headers
+
+          extra_query: Add additional query parameters to the request
+
+          extra_body: Add additional JSON properties to the request
+
+          timeout: Override the client-level default timeout for this request, in seconds
+        """
+        extra_headers = {
+            **strip_not_given({"X-LlamaStack-ProviderData": x_llama_stack_provider_data}),
+            **(extra_headers or {}),
+        }
+        return self._get(
+            "/alpha/toolgroups/get",
+            options=make_request_options(
+                extra_headers=extra_headers,
+                extra_query=extra_query,
+                extra_body=extra_body,
+                timeout=timeout,
+                query=maybe_transform({"toolgroup_id": toolgroup_id}, toolgroup_get_params.ToolgroupGetParams),
+            ),
+            cast_to=ToolGroup,
+        )
+
+    def register(
+        self,
+        *,
+        provider_id: str,
+        toolgroup_id: str,
+        args: Dict[str, Union[bool, float, str, Iterable[object], object, None]] | NotGiven = NOT_GIVEN,
+        mcp_endpoint: URL | NotGiven = NOT_GIVEN,
+        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
+        # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
+        # The extra values given here take precedence over values defined on the client or passed to this method.
+        extra_headers: Headers | None = None,
+        extra_query: Query | None = None,
+        extra_body: Body | None = None,
+        timeout: float | httpx.Timeout | None | NotGiven = NOT_GIVEN,
+    ) -> None:
+        """
+        Register a tool group
+
+        Args:
+          extra_headers: Send extra headers
+
+          extra_query: Add additional query parameters to the request
+
+          extra_body: Add additional JSON properties to the request
+
+          timeout: Override the client-level default timeout for this request, in seconds
+        """
+        extra_headers = {"Accept": "*/*", **(extra_headers or {})}
+        extra_headers = {
+            **strip_not_given({"X-LlamaStack-ProviderData": x_llama_stack_provider_data}),
+            **(extra_headers or {}),
+        }
+        return self._post(
+            "/alpha/toolgroups/register",
+            body=maybe_transform(
+                {
+                    "provider_id": provider_id,
+                    "toolgroup_id": toolgroup_id,
+                    "args": args,
+                    "mcp_endpoint": mcp_endpoint,
+                },
+                toolgroup_register_params.ToolgroupRegisterParams,
+            ),
+            options=make_request_options(
+                extra_headers=extra_headers, extra_query=extra_query, extra_body=extra_body, timeout=timeout
+            ),
+            cast_to=NoneType,
+        )
+
+    def unregister(
+        self,
+        *,
+        tool_group_id: str,
+        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
+        # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
+        # The extra values given here take precedence over values defined on the client or passed to this method.
+        extra_headers: Headers | None = None,
+        extra_query: Query | None = None,
+        extra_body: Body | None = None,
+        timeout: float | httpx.Timeout | None | NotGiven = NOT_GIVEN,
+    ) -> None:
+        """
+        Unregister a tool group
+
+        Args:
+          extra_headers: Send extra headers
+
+          extra_query: Add additional query parameters to the request
+
+          extra_body: Add additional JSON properties to the request
+
+          timeout: Override the client-level default timeout for this request, in seconds
+        """
+        extra_headers = {"Accept": "*/*", **(extra_headers or {})}
+        extra_headers = {
+            **strip_not_given({"X-LlamaStack-ProviderData": x_llama_stack_provider_data}),
+            **(extra_headers or {}),
+        }
+        return self._post(
+            "/alpha/toolgroups/unregister",
+            body=maybe_transform(
+                {"tool_group_id": tool_group_id}, toolgroup_unregister_params.ToolgroupUnregisterParams
+            ),
+            options=make_request_options(
+                extra_headers=extra_headers, extra_query=extra_query, extra_body=extra_body, timeout=timeout
+            ),
+            cast_to=NoneType,
+        )
+
+
+class AsyncToolgroupsResource(AsyncAPIResource):
+    @cached_property
+    def with_raw_response(self) -> AsyncToolgroupsResourceWithRawResponse:
+        """
+        This property can be used as a prefix for any HTTP method call to return the
+        the raw response object instead of the parsed content.
+
+        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#accessing-raw-response-data-eg-headers
+        """
+        return AsyncToolgroupsResourceWithRawResponse(self)
+
+    @cached_property
+    def with_streaming_response(self) -> AsyncToolgroupsResourceWithStreamingResponse:
+        """
+        An alternative to `.with_raw_response` that doesn't eagerly read the response body.
+
+        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#with_streaming_response
+        """
+        return AsyncToolgroupsResourceWithStreamingResponse(self)
+
+    async def list(
+        self,
+        *,
+        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
+        # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
+        # The extra values given here take precedence over values defined on the client or passed to this method.
+        extra_headers: Headers | None = None,
+        extra_query: Query | None = None,
+        extra_body: Body | None = None,
+        timeout: float | httpx.Timeout | None | NotGiven = NOT_GIVEN,
+    ) -> ToolGroup:
+        """
+        List tool groups with optional provider
+
+        Args:
+          extra_headers: Send extra headers
+
+          extra_query: Add additional query parameters to the request
+
+          extra_body: Add additional JSON properties to the request
+
+          timeout: Override the client-level default timeout for this request, in seconds
+        """
+        extra_headers = {"Accept": "application/jsonl", **(extra_headers or {})}
+        extra_headers = {
+            **strip_not_given({"X-LlamaStack-ProviderData": x_llama_stack_provider_data}),
+            **(extra_headers or {}),
+        }
+        return await self._get(
+            "/alpha/toolgroups/list",
+            options=make_request_options(
+                extra_headers=extra_headers, extra_query=extra_query, extra_body=extra_body, timeout=timeout
+            ),
+            cast_to=ToolGroup,
+        )
+
+    async def get(
+        self,
+        *,
+        toolgroup_id: str,
+        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
+        # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
+        # The extra values given here take precedence over values defined on the client or passed to this method.
+        extra_headers: Headers | None = None,
+        extra_query: Query | None = None,
+        extra_body: Body | None = None,
+        timeout: float | httpx.Timeout | None | NotGiven = NOT_GIVEN,
+    ) -> ToolGroup:
+        """
+        Args:
+          extra_headers: Send extra headers
+
+          extra_query: Add additional query parameters to the request
+
+          extra_body: Add additional JSON properties to the request
+
+          timeout: Override the client-level default timeout for this request, in seconds
+        """
+        extra_headers = {
+            **strip_not_given({"X-LlamaStack-ProviderData": x_llama_stack_provider_data}),
+            **(extra_headers or {}),
+        }
+        return await self._get(
+            "/alpha/toolgroups/get",
+            options=make_request_options(
+                extra_headers=extra_headers,
+                extra_query=extra_query,
+                extra_body=extra_body,
+                timeout=timeout,
+                query=await async_maybe_transform(
+                    {"toolgroup_id": toolgroup_id}, toolgroup_get_params.ToolgroupGetParams
+                ),
+            ),
+            cast_to=ToolGroup,
+        )
+
+    async def register(
+        self,
+        *,
+        provider_id: str,
+        toolgroup_id: str,
+        args: Dict[str, Union[bool, float, str, Iterable[object], object, None]] | NotGiven = NOT_GIVEN,
+        mcp_endpoint: URL | NotGiven = NOT_GIVEN,
+        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
+        # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
+        # The extra values given here take precedence over values defined on the client or passed to this method.
+        extra_headers: Headers | None = None,
+        extra_query: Query | None = None,
+        extra_body: Body | None = None,
+        timeout: float | httpx.Timeout | None | NotGiven = NOT_GIVEN,
+    ) -> None:
+        """
+        Register a tool group
+
+        Args:
+          extra_headers: Send extra headers
+
+          extra_query: Add additional query parameters to the request
+
+          extra_body: Add additional JSON properties to the request
+
+          timeout: Override the client-level default timeout for this request, in seconds
+        """
+        extra_headers = {"Accept": "*/*", **(extra_headers or {})}
+        extra_headers = {
+            **strip_not_given({"X-LlamaStack-ProviderData": x_llama_stack_provider_data}),
+            **(extra_headers or {}),
+        }
+        return await self._post(
+            "/alpha/toolgroups/register",
+            body=await async_maybe_transform(
+                {
+                    "provider_id": provider_id,
+                    "toolgroup_id": toolgroup_id,
+                    "args": args,
+                    "mcp_endpoint": mcp_endpoint,
+                },
+                toolgroup_register_params.ToolgroupRegisterParams,
+            ),
+            options=make_request_options(
+                extra_headers=extra_headers, extra_query=extra_query, extra_body=extra_body, timeout=timeout
+            ),
+            cast_to=NoneType,
+        )
+
+    async def unregister(
+        self,
+        *,
+        tool_group_id: str,
+        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
+        # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
+        # The extra values given here take precedence over values defined on the client or passed to this method.
+        extra_headers: Headers | None = None,
+        extra_query: Query | None = None,
+        extra_body: Body | None = None,
+        timeout: float | httpx.Timeout | None | NotGiven = NOT_GIVEN,
+    ) -> None:
+        """
+        Unregister a tool group
+
+        Args:
+          extra_headers: Send extra headers
+
+          extra_query: Add additional query parameters to the request
+
+          extra_body: Add additional JSON properties to the request
+
+          timeout: Override the client-level default timeout for this request, in seconds
+        """
+        extra_headers = {"Accept": "*/*", **(extra_headers or {})}
+        extra_headers = {
+            **strip_not_given({"X-LlamaStack-ProviderData": x_llama_stack_provider_data}),
+            **(extra_headers or {}),
+        }
+        return await self._post(
+            "/alpha/toolgroups/unregister",
+            body=await async_maybe_transform(
+                {"tool_group_id": tool_group_id}, toolgroup_unregister_params.ToolgroupUnregisterParams
+            ),
+            options=make_request_options(
+                extra_headers=extra_headers, extra_query=extra_query, extra_body=extra_body, timeout=timeout
+            ),
+            cast_to=NoneType,
+        )
+
+
+class ToolgroupsResourceWithRawResponse:
+    def __init__(self, toolgroups: ToolgroupsResource) -> None:
+        self._toolgroups = toolgroups
+
+        self.list = to_raw_response_wrapper(
+            toolgroups.list,
+        )
+        self.get = to_raw_response_wrapper(
+            toolgroups.get,
+        )
+        self.register = to_raw_response_wrapper(
+            toolgroups.register,
+        )
+        self.unregister = to_raw_response_wrapper(
+            toolgroups.unregister,
+        )
+
+
+class AsyncToolgroupsResourceWithRawResponse:
+    def __init__(self, toolgroups: AsyncToolgroupsResource) -> None:
+        self._toolgroups = toolgroups
+
+        self.list = async_to_raw_response_wrapper(
+            toolgroups.list,
+        )
+        self.get = async_to_raw_response_wrapper(
+            toolgroups.get,
+        )
+        self.register = async_to_raw_response_wrapper(
+            toolgroups.register,
+        )
+        self.unregister = async_to_raw_response_wrapper(
+            toolgroups.unregister,
+        )
+
+
+class ToolgroupsResourceWithStreamingResponse:
+    def __init__(self, toolgroups: ToolgroupsResource) -> None:
+        self._toolgroups = toolgroups
+
+        self.list = to_streamed_response_wrapper(
+            toolgroups.list,
+        )
+        self.get = to_streamed_response_wrapper(
+            toolgroups.get,
+        )
+        self.register = to_streamed_response_wrapper(
+            toolgroups.register,
+        )
+        self.unregister = to_streamed_response_wrapper(
+            toolgroups.unregister,
+        )
+
+
+class AsyncToolgroupsResourceWithStreamingResponse:
+    def __init__(self, toolgroups: AsyncToolgroupsResource) -> None:
+        self._toolgroups = toolgroups
+
+        self.list = async_to_streamed_response_wrapper(
+            toolgroups.list,
+        )
+        self.get = async_to_streamed_response_wrapper(
+            toolgroups.get,
+        )
+        self.register = async_to_streamed_response_wrapper(
+            toolgroups.register,
+        )
+        self.unregister = async_to_streamed_response_wrapper(
+            toolgroups.unregister,
+        )

--- a/src/llama_stack_client/resources/tools.py
+++ b/src/llama_stack_client/resources/tools.py
@@ -1,0 +1,273 @@
+# File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
+
+from __future__ import annotations
+
+import httpx
+
+from ..types import tool_get_params, tool_list_params
+from .._types import NOT_GIVEN, Body, Query, Headers, NotGiven
+from .._utils import (
+    maybe_transform,
+    strip_not_given,
+    async_maybe_transform,
+)
+from .._compat import cached_property
+from .._resource import SyncAPIResource, AsyncAPIResource
+from .._response import (
+    to_raw_response_wrapper,
+    to_streamed_response_wrapper,
+    async_to_raw_response_wrapper,
+    async_to_streamed_response_wrapper,
+)
+from ..types.tool import Tool
+from .._base_client import make_request_options
+
+__all__ = ["ToolsResource", "AsyncToolsResource"]
+
+
+class ToolsResource(SyncAPIResource):
+    @cached_property
+    def with_raw_response(self) -> ToolsResourceWithRawResponse:
+        """
+        This property can be used as a prefix for any HTTP method call to return the
+        the raw response object instead of the parsed content.
+
+        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#accessing-raw-response-data-eg-headers
+        """
+        return ToolsResourceWithRawResponse(self)
+
+    @cached_property
+    def with_streaming_response(self) -> ToolsResourceWithStreamingResponse:
+        """
+        An alternative to `.with_raw_response` that doesn't eagerly read the response body.
+
+        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#with_streaming_response
+        """
+        return ToolsResourceWithStreamingResponse(self)
+
+    def list(
+        self,
+        *,
+        tool_group_id: str | NotGiven = NOT_GIVEN,
+        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
+        # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
+        # The extra values given here take precedence over values defined on the client or passed to this method.
+        extra_headers: Headers | None = None,
+        extra_query: Query | None = None,
+        extra_body: Body | None = None,
+        timeout: float | httpx.Timeout | None | NotGiven = NOT_GIVEN,
+    ) -> Tool:
+        """
+        List tools with optional tool group
+
+        Args:
+          extra_headers: Send extra headers
+
+          extra_query: Add additional query parameters to the request
+
+          extra_body: Add additional JSON properties to the request
+
+          timeout: Override the client-level default timeout for this request, in seconds
+        """
+        extra_headers = {"Accept": "application/jsonl", **(extra_headers or {})}
+        extra_headers = {
+            **strip_not_given({"X-LlamaStack-ProviderData": x_llama_stack_provider_data}),
+            **(extra_headers or {}),
+        }
+        return self._get(
+            "/alpha/tools/list",
+            options=make_request_options(
+                extra_headers=extra_headers,
+                extra_query=extra_query,
+                extra_body=extra_body,
+                timeout=timeout,
+                query=maybe_transform({"tool_group_id": tool_group_id}, tool_list_params.ToolListParams),
+            ),
+            cast_to=Tool,
+        )
+
+    def get(
+        self,
+        *,
+        tool_name: str,
+        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
+        # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
+        # The extra values given here take precedence over values defined on the client or passed to this method.
+        extra_headers: Headers | None = None,
+        extra_query: Query | None = None,
+        extra_body: Body | None = None,
+        timeout: float | httpx.Timeout | None | NotGiven = NOT_GIVEN,
+    ) -> Tool:
+        """
+        Args:
+          extra_headers: Send extra headers
+
+          extra_query: Add additional query parameters to the request
+
+          extra_body: Add additional JSON properties to the request
+
+          timeout: Override the client-level default timeout for this request, in seconds
+        """
+        extra_headers = {
+            **strip_not_given({"X-LlamaStack-ProviderData": x_llama_stack_provider_data}),
+            **(extra_headers or {}),
+        }
+        return self._get(
+            "/alpha/tools/get",
+            options=make_request_options(
+                extra_headers=extra_headers,
+                extra_query=extra_query,
+                extra_body=extra_body,
+                timeout=timeout,
+                query=maybe_transform({"tool_name": tool_name}, tool_get_params.ToolGetParams),
+            ),
+            cast_to=Tool,
+        )
+
+
+class AsyncToolsResource(AsyncAPIResource):
+    @cached_property
+    def with_raw_response(self) -> AsyncToolsResourceWithRawResponse:
+        """
+        This property can be used as a prefix for any HTTP method call to return the
+        the raw response object instead of the parsed content.
+
+        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#accessing-raw-response-data-eg-headers
+        """
+        return AsyncToolsResourceWithRawResponse(self)
+
+    @cached_property
+    def with_streaming_response(self) -> AsyncToolsResourceWithStreamingResponse:
+        """
+        An alternative to `.with_raw_response` that doesn't eagerly read the response body.
+
+        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#with_streaming_response
+        """
+        return AsyncToolsResourceWithStreamingResponse(self)
+
+    async def list(
+        self,
+        *,
+        tool_group_id: str | NotGiven = NOT_GIVEN,
+        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
+        # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
+        # The extra values given here take precedence over values defined on the client or passed to this method.
+        extra_headers: Headers | None = None,
+        extra_query: Query | None = None,
+        extra_body: Body | None = None,
+        timeout: float | httpx.Timeout | None | NotGiven = NOT_GIVEN,
+    ) -> Tool:
+        """
+        List tools with optional tool group
+
+        Args:
+          extra_headers: Send extra headers
+
+          extra_query: Add additional query parameters to the request
+
+          extra_body: Add additional JSON properties to the request
+
+          timeout: Override the client-level default timeout for this request, in seconds
+        """
+        extra_headers = {"Accept": "application/jsonl", **(extra_headers or {})}
+        extra_headers = {
+            **strip_not_given({"X-LlamaStack-ProviderData": x_llama_stack_provider_data}),
+            **(extra_headers or {}),
+        }
+        return await self._get(
+            "/alpha/tools/list",
+            options=make_request_options(
+                extra_headers=extra_headers,
+                extra_query=extra_query,
+                extra_body=extra_body,
+                timeout=timeout,
+                query=await async_maybe_transform({"tool_group_id": tool_group_id}, tool_list_params.ToolListParams),
+            ),
+            cast_to=Tool,
+        )
+
+    async def get(
+        self,
+        *,
+        tool_name: str,
+        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
+        # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
+        # The extra values given here take precedence over values defined on the client or passed to this method.
+        extra_headers: Headers | None = None,
+        extra_query: Query | None = None,
+        extra_body: Body | None = None,
+        timeout: float | httpx.Timeout | None | NotGiven = NOT_GIVEN,
+    ) -> Tool:
+        """
+        Args:
+          extra_headers: Send extra headers
+
+          extra_query: Add additional query parameters to the request
+
+          extra_body: Add additional JSON properties to the request
+
+          timeout: Override the client-level default timeout for this request, in seconds
+        """
+        extra_headers = {
+            **strip_not_given({"X-LlamaStack-ProviderData": x_llama_stack_provider_data}),
+            **(extra_headers or {}),
+        }
+        return await self._get(
+            "/alpha/tools/get",
+            options=make_request_options(
+                extra_headers=extra_headers,
+                extra_query=extra_query,
+                extra_body=extra_body,
+                timeout=timeout,
+                query=await async_maybe_transform({"tool_name": tool_name}, tool_get_params.ToolGetParams),
+            ),
+            cast_to=Tool,
+        )
+
+
+class ToolsResourceWithRawResponse:
+    def __init__(self, tools: ToolsResource) -> None:
+        self._tools = tools
+
+        self.list = to_raw_response_wrapper(
+            tools.list,
+        )
+        self.get = to_raw_response_wrapper(
+            tools.get,
+        )
+
+
+class AsyncToolsResourceWithRawResponse:
+    def __init__(self, tools: AsyncToolsResource) -> None:
+        self._tools = tools
+
+        self.list = async_to_raw_response_wrapper(
+            tools.list,
+        )
+        self.get = async_to_raw_response_wrapper(
+            tools.get,
+        )
+
+
+class ToolsResourceWithStreamingResponse:
+    def __init__(self, tools: ToolsResource) -> None:
+        self._tools = tools
+
+        self.list = to_streamed_response_wrapper(
+            tools.list,
+        )
+        self.get = to_streamed_response_wrapper(
+            tools.get,
+        )
+
+
+class AsyncToolsResourceWithStreamingResponse:
+    def __init__(self, tools: AsyncToolsResource) -> None:
+        self._tools = tools
+
+        self.list = async_to_streamed_response_wrapper(
+            tools.list,
+        )
+        self.get = async_to_streamed_response_wrapper(
+            tools.get,
+        )

--- a/src/llama_stack_client/types/__init__.py
+++ b/src/llama_stack_client/types/__init__.py
@@ -3,13 +3,13 @@
 from __future__ import annotations
 
 from .job import Job as Job
+from .tool import Tool as Tool
 from .model import Model as Model
 from .trace import Trace as Trace
 from .shared import (
     URL as URL,
     ToolCall as ToolCall,
     ParamType as ParamType,
-    Attachment as Attachment,
     ReturnType as ReturnType,
     AgentConfig as AgentConfig,
     UserMessage as UserMessage,
@@ -18,30 +18,27 @@ from .shared import (
     SamplingParams as SamplingParams,
     BatchCompletion as BatchCompletion,
     SafetyViolation as SafetyViolation,
-    CompletionMessage as CompletionMessage,
     InterleavedContent as InterleavedContent,
     ToolParamDefinition as ToolParamDefinition,
     ToolResponseMessage as ToolResponseMessage,
-    MemoryToolDefinition as MemoryToolDefinition,
-    SearchToolDefinition as SearchToolDefinition,
     InterleavedContentItem as InterleavedContentItem,
-    PhotogenToolDefinition as PhotogenToolDefinition,
-    RestAPIExecutionConfig as RestAPIExecutionConfig,
-    FunctionCallToolDefinition as FunctionCallToolDefinition,
-    WolframAlphaToolDefinition as WolframAlphaToolDefinition,
-    CodeInterpreterToolDefinition as CodeInterpreterToolDefinition,
 )
 from .shield import Shield as Shield
+from .tool_def import ToolDef as ToolDef
 from .eval_task import EvalTask as EvalTask
 from .route_info import RouteInfo as RouteInfo
 from .scoring_fn import ScoringFn as ScoringFn
+from .tool_group import ToolGroup as ToolGroup
 from .health_info import HealthInfo as HealthInfo
 from .provider_info import ProviderInfo as ProviderInfo
 from .tool_response import ToolResponse as ToolResponse
 from .inference_step import InferenceStep as InferenceStep
+from .tool_def_param import ToolDefParam as ToolDefParam
 from .token_log_probs import TokenLogProbs as TokenLogProbs
+from .tool_get_params import ToolGetParams as ToolGetParams
 from .shield_call_step import ShieldCallStep as ShieldCallStep
 from .span_with_status import SpanWithStatus as SpanWithStatus
+from .tool_list_params import ToolListParams as ToolListParams
 from .evaluate_response import EvaluateResponse as EvaluateResponse
 from .post_training_job import PostTrainingJob as PostTrainingJob
 from .agent_create_params import AgentCreateParams as AgentCreateParams
@@ -55,6 +52,7 @@ from .tool_execution_step import ToolExecutionStep as ToolExecutionStep
 from .eval_run_eval_params import EvalRunEvalParams as EvalRunEvalParams
 from .memory_insert_params import MemoryInsertParams as MemoryInsertParams
 from .scoring_score_params import ScoringScoreParams as ScoringScoreParams
+from .toolgroup_get_params import ToolgroupGetParams as ToolgroupGetParams
 from .agent_create_response import AgentCreateResponse as AgentCreateResponse
 from .dataset_list_response import DatasetListResponse as DatasetListResponse
 from .memory_retrieval_step import MemoryRetrievalStep as MemoryRetrievalStep
@@ -65,6 +63,7 @@ from .provider_list_response import ProviderListResponse as ProviderListResponse
 from .scoring_score_response import ScoringScoreResponse as ScoringScoreResponse
 from .shield_register_params import ShieldRegisterParams as ShieldRegisterParams
 from .shield_retrieve_params import ShieldRetrieveParams as ShieldRetrieveParams
+from .tool_invocation_result import ToolInvocationResult as ToolInvocationResult
 from .dataset_register_params import DatasetRegisterParams as DatasetRegisterParams
 from .dataset_retrieve_params import DatasetRetrieveParams as DatasetRetrieveParams
 from .model_unregister_params import ModelUnregisterParams as ModelUnregisterParams
@@ -76,12 +75,14 @@ from .eval_evaluate_rows_params import EvalEvaluateRowsParams as EvalEvaluateRow
 from .eval_task_register_params import EvalTaskRegisterParams as EvalTaskRegisterParams
 from .eval_task_retrieve_params import EvalTaskRetrieveParams as EvalTaskRetrieveParams
 from .memory_bank_list_response import MemoryBankListResponse as MemoryBankListResponse
+from .toolgroup_register_params import ToolgroupRegisterParams as ToolgroupRegisterParams
 from .scoring_score_batch_params import ScoringScoreBatchParams as ScoringScoreBatchParams
 from .telemetry_log_event_params import TelemetryLogEventParams as TelemetryLogEventParams
 from .inference_completion_params import InferenceCompletionParams as InferenceCompletionParams
 from .inference_embeddings_params import InferenceEmbeddingsParams as InferenceEmbeddingsParams
 from .memory_bank_register_params import MemoryBankRegisterParams as MemoryBankRegisterParams
 from .memory_bank_retrieve_params import MemoryBankRetrieveParams as MemoryBankRetrieveParams
+from .toolgroup_unregister_params import ToolgroupUnregisterParams as ToolgroupUnregisterParams
 from .datasetio_append_rows_params import DatasetioAppendRowsParams as DatasetioAppendRowsParams
 from .scoring_score_batch_response import ScoringScoreBatchResponse as ScoringScoreBatchResponse
 from .telemetry_query_spans_params import TelemetryQuerySpansParams as TelemetryQuerySpansParams
@@ -91,6 +92,8 @@ from .memory_bank_unregister_params import MemoryBankUnregisterParams as MemoryB
 from .telemetry_query_traces_params import TelemetryQueryTracesParams as TelemetryQueryTracesParams
 from .telemetry_get_span_tree_params import TelemetryGetSpanTreeParams as TelemetryGetSpanTreeParams
 from .telemetry_query_spans_response import TelemetryQuerySpansResponse as TelemetryQuerySpansResponse
+from .tool_runtime_list_tools_params import ToolRuntimeListToolsParams as ToolRuntimeListToolsParams
+from .tool_runtime_invoke_tool_params import ToolRuntimeInvokeToolParams as ToolRuntimeInvokeToolParams
 from .inference_chat_completion_params import InferenceChatCompletionParams as InferenceChatCompletionParams
 from .scoring_function_register_params import ScoringFunctionRegisterParams as ScoringFunctionRegisterParams
 from .scoring_function_retrieve_params import ScoringFunctionRetrieveParams as ScoringFunctionRetrieveParams

--- a/src/llama_stack_client/types/agents/turn_create_params.py
+++ b/src/llama_stack_client/types/agents/turn_create_params.py
@@ -2,15 +2,27 @@
 
 from __future__ import annotations
 
-from typing import Union, Iterable
+from typing import Dict, List, Union, Iterable
 from typing_extensions import Literal, Required, Annotated, TypeAlias, TypedDict
 
 from ..._utils import PropertyInfo
-from ..shared_params.attachment import Attachment
+from ..shared_params.url import URL
 from ..shared_params.user_message import UserMessage
 from ..shared_params.tool_response_message import ToolResponseMessage
+from ..shared_params.interleaved_content_item import InterleavedContentItem
 
-__all__ = ["TurnCreateParamsBase", "Message", "TurnCreateParamsNonStreaming", "TurnCreateParamsStreaming"]
+__all__ = [
+    "TurnCreateParamsBase",
+    "Message",
+    "Document",
+    "DocumentContent",
+    "DocumentContentImageContentItem",
+    "DocumentContentTextContentItem",
+    "Toolgroup",
+    "ToolgroupUnionMember1",
+    "TurnCreateParamsNonStreaming",
+    "TurnCreateParamsStreaming",
+]
 
 
 class TurnCreateParamsBase(TypedDict, total=False):
@@ -20,12 +32,48 @@ class TurnCreateParamsBase(TypedDict, total=False):
 
     session_id: Required[str]
 
-    attachments: Iterable[Attachment]
+    documents: Iterable[Document]
+
+    toolgroups: List[Toolgroup]
 
     x_llama_stack_provider_data: Annotated[str, PropertyInfo(alias="X-LlamaStack-ProviderData")]
 
 
 Message: TypeAlias = Union[UserMessage, ToolResponseMessage]
+
+
+class DocumentContentImageContentItem(TypedDict, total=False):
+    type: Required[Literal["image"]]
+
+    data: str
+
+    url: URL
+
+
+class DocumentContentTextContentItem(TypedDict, total=False):
+    text: Required[str]
+
+    type: Required[Literal["text"]]
+
+
+DocumentContent: TypeAlias = Union[
+    str, DocumentContentImageContentItem, DocumentContentTextContentItem, Iterable[InterleavedContentItem], URL
+]
+
+
+class Document(TypedDict, total=False):
+    content: Required[DocumentContent]
+
+    mime_type: Required[str]
+
+
+class ToolgroupUnionMember1(TypedDict, total=False):
+    args: Required[Dict[str, Union[bool, float, str, Iterable[object], object, None]]]
+
+    name: Required[str]
+
+
+Toolgroup: TypeAlias = Union[str, ToolgroupUnionMember1]
 
 
 class TurnCreateParamsNonStreaming(TurnCreateParamsBase, total=False):

--- a/src/llama_stack_client/types/agents/turn_create_response.py
+++ b/src/llama_stack_client/types/agents/turn_create_response.py
@@ -72,6 +72,8 @@ class AgentTurnResponseStreamChunkEventPayloadAgentTurnResponseStepCompletePaylo
 
     step_details: AgentTurnResponseStreamChunkEventPayloadAgentTurnResponseStepCompletePayloadStepDetails
 
+    step_id: str
+
     step_type: Literal["inference", "tool_execution", "shield_call", "memory_retrieval"]
 
 

--- a/src/llama_stack_client/types/batch_inference_chat_completion_params.py
+++ b/src/llama_stack_client/types/batch_inference_chat_completion_params.py
@@ -6,14 +6,15 @@ from typing import Dict, Union, Iterable
 from typing_extensions import Literal, Required, Annotated, TypeAlias, TypedDict
 
 from .._utils import PropertyInfo
+from .shared_params.tool_call import ToolCall
 from .shared_params.user_message import UserMessage
 from .shared_params.system_message import SystemMessage
 from .shared_params.sampling_params import SamplingParams
-from .shared_params.completion_message import CompletionMessage
+from .shared_params.interleaved_content import InterleavedContent
 from .shared_params.tool_param_definition import ToolParamDefinition
 from .shared_params.tool_response_message import ToolResponseMessage
 
-__all__ = ["BatchInferenceChatCompletionParams", "MessagesBatch", "Logprobs", "Tool"]
+__all__ = ["BatchInferenceChatCompletionParams", "MessagesBatch", "MessagesBatchCompletionMessage", "Logprobs", "Tool"]
 
 
 class BatchInferenceChatCompletionParams(TypedDict, total=False):
@@ -45,7 +46,17 @@ class BatchInferenceChatCompletionParams(TypedDict, total=False):
     x_llama_stack_provider_data: Annotated[str, PropertyInfo(alias="X-LlamaStack-ProviderData")]
 
 
-MessagesBatch: TypeAlias = Union[UserMessage, SystemMessage, ToolResponseMessage, CompletionMessage]
+class MessagesBatchCompletionMessage(TypedDict, total=False):
+    content: Required[InterleavedContent]
+
+    role: Required[Literal["assistant"]]
+
+    stop_reason: Required[Literal["end_of_turn", "end_of_message", "out_of_tokens"]]
+
+    tool_calls: Required[Iterable[ToolCall]]
+
+
+MessagesBatch: TypeAlias = Union[UserMessage, SystemMessage, ToolResponseMessage, MessagesBatchCompletionMessage]
 
 
 class Logprobs(TypedDict, total=False):

--- a/src/llama_stack_client/types/batch_inference_chat_completion_response.py
+++ b/src/llama_stack_client/types/batch_inference_chat_completion_response.py
@@ -1,12 +1,24 @@
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from typing import List
+from typing_extensions import Literal
 
 from .._models import BaseModel
-from .shared.completion_message import CompletionMessage
+from .shared.tool_call import ToolCall
+from .shared.interleaved_content import InterleavedContent
 
-__all__ = ["BatchInferenceChatCompletionResponse"]
+__all__ = ["BatchInferenceChatCompletionResponse", "CompletionMessageBatch"]
+
+
+class CompletionMessageBatch(BaseModel):
+    content: InterleavedContent
+
+    role: Literal["assistant"]
+
+    stop_reason: Literal["end_of_turn", "end_of_message", "out_of_tokens"]
+
+    tool_calls: List[ToolCall]
 
 
 class BatchInferenceChatCompletionResponse(BaseModel):
-    completion_message_batch: List[CompletionMessage]
+    completion_message_batch: List[CompletionMessageBatch]

--- a/src/llama_stack_client/types/inference_chat_completion_params.py
+++ b/src/llama_stack_client/types/inference_chat_completion_params.py
@@ -6,20 +6,22 @@ from typing import Dict, Union, Iterable
 from typing_extensions import Literal, Required, Annotated, TypeAlias, TypedDict
 
 from .._utils import PropertyInfo
+from .shared_params.tool_call import ToolCall
 from .shared_params.user_message import UserMessage
 from .shared_params.system_message import SystemMessage
 from .shared_params.sampling_params import SamplingParams
-from .shared_params.completion_message import CompletionMessage
+from .shared_params.interleaved_content import InterleavedContent
 from .shared_params.tool_param_definition import ToolParamDefinition
 from .shared_params.tool_response_message import ToolResponseMessage
 
 __all__ = [
     "InferenceChatCompletionParamsBase",
     "Message",
+    "MessageCompletionMessage",
     "Logprobs",
     "ResponseFormat",
-    "ResponseFormatJsonSchemaFormat",
-    "ResponseFormatGrammarFormat",
+    "ResponseFormatUnionMember0",
+    "ResponseFormatUnionMember1",
     "Tool",
     "InferenceChatCompletionParamsNonStreaming",
     "InferenceChatCompletionParamsStreaming",
@@ -57,26 +59,36 @@ class InferenceChatCompletionParamsBase(TypedDict, total=False):
     x_llama_stack_provider_data: Annotated[str, PropertyInfo(alias="X-LlamaStack-ProviderData")]
 
 
-Message: TypeAlias = Union[UserMessage, SystemMessage, ToolResponseMessage, CompletionMessage]
+class MessageCompletionMessage(TypedDict, total=False):
+    content: Required[InterleavedContent]
+
+    role: Required[Literal["assistant"]]
+
+    stop_reason: Required[Literal["end_of_turn", "end_of_message", "out_of_tokens"]]
+
+    tool_calls: Required[Iterable[ToolCall]]
+
+
+Message: TypeAlias = Union[UserMessage, SystemMessage, ToolResponseMessage, MessageCompletionMessage]
 
 
 class Logprobs(TypedDict, total=False):
     top_k: int
 
 
-class ResponseFormatJsonSchemaFormat(TypedDict, total=False):
+class ResponseFormatUnionMember0(TypedDict, total=False):
     json_schema: Required[Dict[str, Union[bool, float, str, Iterable[object], object, None]]]
 
     type: Required[Literal["json_schema"]]
 
 
-class ResponseFormatGrammarFormat(TypedDict, total=False):
+class ResponseFormatUnionMember1(TypedDict, total=False):
     bnf: Required[Dict[str, Union[bool, float, str, Iterable[object], object, None]]]
 
     type: Required[Literal["grammar"]]
 
 
-ResponseFormat: TypeAlias = Union[ResponseFormatJsonSchemaFormat, ResponseFormatGrammarFormat]
+ResponseFormat: TypeAlias = Union[ResponseFormatUnionMember0, ResponseFormatUnionMember1]
 
 
 class Tool(TypedDict, total=False):

--- a/src/llama_stack_client/types/inference_chat_completion_response.py
+++ b/src/llama_stack_client/types/inference_chat_completion_response.py
@@ -6,11 +6,12 @@ from typing_extensions import Literal, TypeAlias
 from .._models import BaseModel
 from .token_log_probs import TokenLogProbs
 from .shared.tool_call import ToolCall
-from .shared.completion_message import CompletionMessage
+from .shared.interleaved_content import InterleavedContent
 
 __all__ = [
     "InferenceChatCompletionResponse",
     "ChatCompletionResponse",
+    "ChatCompletionResponseCompletionMessage",
     "ChatCompletionResponseStreamChunk",
     "ChatCompletionResponseStreamChunkEvent",
     "ChatCompletionResponseStreamChunkEventDelta",
@@ -19,8 +20,18 @@ __all__ = [
 ]
 
 
+class ChatCompletionResponseCompletionMessage(BaseModel):
+    content: InterleavedContent
+
+    role: Literal["assistant"]
+
+    stop_reason: Literal["end_of_turn", "end_of_message", "out_of_tokens"]
+
+    tool_calls: List[ToolCall]
+
+
 class ChatCompletionResponse(BaseModel):
-    completion_message: CompletionMessage
+    completion_message: ChatCompletionResponseCompletionMessage
 
     logprobs: Optional[List[TokenLogProbs]] = None
 

--- a/src/llama_stack_client/types/inference_completion_params.py
+++ b/src/llama_stack_client/types/inference_completion_params.py
@@ -13,8 +13,8 @@ __all__ = [
     "InferenceCompletionParamsBase",
     "Logprobs",
     "ResponseFormat",
-    "ResponseFormatJsonSchemaFormat",
-    "ResponseFormatGrammarFormat",
+    "ResponseFormatUnionMember0",
+    "ResponseFormatUnionMember1",
     "InferenceCompletionParamsNonStreaming",
     "InferenceCompletionParamsStreaming",
 ]
@@ -38,19 +38,19 @@ class Logprobs(TypedDict, total=False):
     top_k: int
 
 
-class ResponseFormatJsonSchemaFormat(TypedDict, total=False):
+class ResponseFormatUnionMember0(TypedDict, total=False):
     json_schema: Required[Dict[str, Union[bool, float, str, Iterable[object], object, None]]]
 
     type: Required[Literal["json_schema"]]
 
 
-class ResponseFormatGrammarFormat(TypedDict, total=False):
+class ResponseFormatUnionMember1(TypedDict, total=False):
     bnf: Required[Dict[str, Union[bool, float, str, Iterable[object], object, None]]]
 
     type: Required[Literal["grammar"]]
 
 
-ResponseFormat: TypeAlias = Union[ResponseFormatJsonSchemaFormat, ResponseFormatGrammarFormat]
+ResponseFormat: TypeAlias = Union[ResponseFormatUnionMember0, ResponseFormatUnionMember1]
 
 
 class InferenceCompletionParamsNonStreaming(InferenceCompletionParamsBase, total=False):

--- a/src/llama_stack_client/types/inference_step.py
+++ b/src/llama_stack_client/types/inference_step.py
@@ -1,19 +1,30 @@
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
-from typing import Optional
+from typing import List, Optional
 from datetime import datetime
 from typing_extensions import Literal
 
 from pydantic import Field as FieldInfo
 
 from .._models import BaseModel
-from .shared.completion_message import CompletionMessage
+from .shared.tool_call import ToolCall
+from .shared.interleaved_content import InterleavedContent
 
-__all__ = ["InferenceStep"]
+__all__ = ["InferenceStep", "ModelResponse"]
+
+
+class ModelResponse(BaseModel):
+    content: InterleavedContent
+
+    role: Literal["assistant"]
+
+    stop_reason: Literal["end_of_turn", "end_of_message", "out_of_tokens"]
+
+    tool_calls: List[ToolCall]
 
 
 class InferenceStep(BaseModel):
-    inference_model_response: CompletionMessage = FieldInfo(alias="model_response")
+    inference_model_response: ModelResponse = FieldInfo(alias="model_response")
 
     step_id: str
 

--- a/src/llama_stack_client/types/post_training_preference_optimize_params.py
+++ b/src/llama_stack_client/types/post_training_preference_optimize_params.py
@@ -84,6 +84,8 @@ class TrainingConfig(TypedDict, total=False):
 
     max_steps_per_epoch: Required[int]
 
+    max_validation_steps: Required[int]
+
     n_epochs: Required[int]
 
     optimizer_config: Required[TrainingConfigOptimizerConfig]

--- a/src/llama_stack_client/types/post_training_supervised_fine_tune_params.py
+++ b/src/llama_stack_client/types/post_training_supervised_fine_tune_params.py
@@ -78,6 +78,8 @@ class TrainingConfig(TypedDict, total=False):
 
     max_steps_per_epoch: Required[int]
 
+    max_validation_steps: Required[int]
+
     n_epochs: Required[int]
 
     optimizer_config: Required[TrainingConfigOptimizerConfig]

--- a/src/llama_stack_client/types/safety_run_shield_params.py
+++ b/src/llama_stack_client/types/safety_run_shield_params.py
@@ -3,15 +3,16 @@
 from __future__ import annotations
 
 from typing import Dict, Union, Iterable
-from typing_extensions import Required, Annotated, TypeAlias, TypedDict
+from typing_extensions import Literal, Required, Annotated, TypeAlias, TypedDict
 
 from .._utils import PropertyInfo
+from .shared_params.tool_call import ToolCall
 from .shared_params.user_message import UserMessage
 from .shared_params.system_message import SystemMessage
-from .shared_params.completion_message import CompletionMessage
+from .shared_params.interleaved_content import InterleavedContent
 from .shared_params.tool_response_message import ToolResponseMessage
 
-__all__ = ["SafetyRunShieldParams", "Message"]
+__all__ = ["SafetyRunShieldParams", "Message", "MessageCompletionMessage"]
 
 
 class SafetyRunShieldParams(TypedDict, total=False):
@@ -24,4 +25,14 @@ class SafetyRunShieldParams(TypedDict, total=False):
     x_llama_stack_provider_data: Annotated[str, PropertyInfo(alias="X-LlamaStack-ProviderData")]
 
 
-Message: TypeAlias = Union[UserMessage, SystemMessage, ToolResponseMessage, CompletionMessage]
+class MessageCompletionMessage(TypedDict, total=False):
+    content: Required[InterleavedContent]
+
+    role: Required[Literal["assistant"]]
+
+    stop_reason: Required[Literal["end_of_turn", "end_of_message", "out_of_tokens"]]
+
+    tool_calls: Required[Iterable[ToolCall]]
+
+
+Message: TypeAlias = Union[UserMessage, SystemMessage, ToolResponseMessage, MessageCompletionMessage]

--- a/src/llama_stack_client/types/shared/__init__.py
+++ b/src/llama_stack_client/types/shared/__init__.py
@@ -2,7 +2,6 @@
 
 from .url import URL as URL
 from .tool_call import ToolCall as ToolCall
-from .attachment import Attachment as Attachment
 from .param_type import ParamType as ParamType
 from .return_type import ReturnType as ReturnType
 from .agent_config import AgentConfig as AgentConfig
@@ -12,15 +11,7 @@ from .system_message import SystemMessage as SystemMessage
 from .sampling_params import SamplingParams as SamplingParams
 from .batch_completion import BatchCompletion as BatchCompletion
 from .safety_violation import SafetyViolation as SafetyViolation
-from .completion_message import CompletionMessage as CompletionMessage
 from .interleaved_content import InterleavedContent as InterleavedContent
 from .tool_param_definition import ToolParamDefinition as ToolParamDefinition
 from .tool_response_message import ToolResponseMessage as ToolResponseMessage
-from .memory_tool_definition import MemoryToolDefinition as MemoryToolDefinition
-from .search_tool_definition import SearchToolDefinition as SearchToolDefinition
 from .interleaved_content_item import InterleavedContentItem as InterleavedContentItem
-from .photogen_tool_definition import PhotogenToolDefinition as PhotogenToolDefinition
-from .rest_api_execution_config import RestAPIExecutionConfig as RestAPIExecutionConfig
-from .function_call_tool_definition import FunctionCallToolDefinition as FunctionCallToolDefinition
-from .wolfram_alpha_tool_definition import WolframAlphaToolDefinition as WolframAlphaToolDefinition
-from .code_interpreter_tool_definition import CodeInterpreterToolDefinition as CodeInterpreterToolDefinition

--- a/src/llama_stack_client/types/shared/agent_config.py
+++ b/src/llama_stack_client/types/shared/agent_config.py
@@ -1,27 +1,22 @@
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
-from typing import List, Union, Optional
+from typing import Dict, List, Union, Optional
 from typing_extensions import Literal, TypeAlias
 
 from ..._models import BaseModel
+from ..tool_def import ToolDef
 from .sampling_params import SamplingParams
-from .memory_tool_definition import MemoryToolDefinition
-from .search_tool_definition import SearchToolDefinition
-from .photogen_tool_definition import PhotogenToolDefinition
-from .function_call_tool_definition import FunctionCallToolDefinition
-from .wolfram_alpha_tool_definition import WolframAlphaToolDefinition
-from .code_interpreter_tool_definition import CodeInterpreterToolDefinition
 
-__all__ = ["AgentConfig", "Tool"]
+__all__ = ["AgentConfig", "Toolgroup", "ToolgroupUnionMember1"]
 
-Tool: TypeAlias = Union[
-    SearchToolDefinition,
-    WolframAlphaToolDefinition,
-    PhotogenToolDefinition,
-    CodeInterpreterToolDefinition,
-    FunctionCallToolDefinition,
-    MemoryToolDefinition,
-]
+
+class ToolgroupUnionMember1(BaseModel):
+    args: Dict[str, Union[bool, float, str, List[object], object, None]]
+
+    name: str
+
+
+Toolgroup: TypeAlias = Union[str, ToolgroupUnionMember1]
 
 
 class AgentConfig(BaseModel):
@@ -32,6 +27,8 @@ class AgentConfig(BaseModel):
     max_infer_iters: int
 
     model: str
+
+    client_tools: Optional[List[ToolDef]] = None
 
     input_shields: Optional[List[str]] = None
 
@@ -54,4 +51,4 @@ class AgentConfig(BaseModel):
     The detailed prompts for each of these formats are added to llama cli
     """
 
-    tools: Optional[List[Tool]] = None
+    toolgroups: Optional[List[Toolgroup]] = None

--- a/src/llama_stack_client/types/shared/batch_completion.py
+++ b/src/llama_stack_client/types/shared/batch_completion.py
@@ -1,12 +1,24 @@
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
 from typing import List
+from typing_extensions import Literal
 
 from ..._models import BaseModel
-from .completion_message import CompletionMessage
+from .tool_call import ToolCall
+from .interleaved_content import InterleavedContent
 
-__all__ = ["BatchCompletion"]
+__all__ = ["BatchCompletion", "CompletionMessageBatch"]
+
+
+class CompletionMessageBatch(BaseModel):
+    content: InterleavedContent
+
+    role: Literal["assistant"]
+
+    stop_reason: Literal["end_of_turn", "end_of_message", "out_of_tokens"]
+
+    tool_calls: List[ToolCall]
 
 
 class BatchCompletion(BaseModel):
-    completion_message_batch: List[CompletionMessage]
+    completion_message_batch: List[CompletionMessageBatch]

--- a/src/llama_stack_client/types/shared_params/__init__.py
+++ b/src/llama_stack_client/types/shared_params/__init__.py
@@ -2,22 +2,13 @@
 
 from .url import URL as URL
 from .tool_call import ToolCall as ToolCall
-from .attachment import Attachment as Attachment
 from .param_type import ParamType as ParamType
 from .return_type import ReturnType as ReturnType
 from .agent_config import AgentConfig as AgentConfig
 from .user_message import UserMessage as UserMessage
 from .system_message import SystemMessage as SystemMessage
 from .sampling_params import SamplingParams as SamplingParams
-from .completion_message import CompletionMessage as CompletionMessage
 from .interleaved_content import InterleavedContent as InterleavedContent
 from .tool_param_definition import ToolParamDefinition as ToolParamDefinition
 from .tool_response_message import ToolResponseMessage as ToolResponseMessage
-from .memory_tool_definition import MemoryToolDefinition as MemoryToolDefinition
-from .search_tool_definition import SearchToolDefinition as SearchToolDefinition
 from .interleaved_content_item import InterleavedContentItem as InterleavedContentItem
-from .photogen_tool_definition import PhotogenToolDefinition as PhotogenToolDefinition
-from .rest_api_execution_config import RestAPIExecutionConfig as RestAPIExecutionConfig
-from .function_call_tool_definition import FunctionCallToolDefinition as FunctionCallToolDefinition
-from .wolfram_alpha_tool_definition import WolframAlphaToolDefinition as WolframAlphaToolDefinition
-from .code_interpreter_tool_definition import CodeInterpreterToolDefinition as CodeInterpreterToolDefinition

--- a/src/llama_stack_client/types/shared_params/agent_config.py
+++ b/src/llama_stack_client/types/shared_params/agent_config.py
@@ -2,27 +2,22 @@
 
 from __future__ import annotations
 
-from typing import List, Union, Iterable
+from typing import Dict, List, Union, Iterable
 from typing_extensions import Literal, Required, TypeAlias, TypedDict
 
+from ..tool_def_param import ToolDefParam
 from .sampling_params import SamplingParams
-from .memory_tool_definition import MemoryToolDefinition
-from .search_tool_definition import SearchToolDefinition
-from .photogen_tool_definition import PhotogenToolDefinition
-from .function_call_tool_definition import FunctionCallToolDefinition
-from .wolfram_alpha_tool_definition import WolframAlphaToolDefinition
-from .code_interpreter_tool_definition import CodeInterpreterToolDefinition
 
-__all__ = ["AgentConfig", "Tool"]
+__all__ = ["AgentConfig", "Toolgroup", "ToolgroupUnionMember1"]
 
-Tool: TypeAlias = Union[
-    SearchToolDefinition,
-    WolframAlphaToolDefinition,
-    PhotogenToolDefinition,
-    CodeInterpreterToolDefinition,
-    FunctionCallToolDefinition,
-    MemoryToolDefinition,
-]
+
+class ToolgroupUnionMember1(TypedDict, total=False):
+    args: Required[Dict[str, Union[bool, float, str, Iterable[object], object, None]]]
+
+    name: Required[str]
+
+
+Toolgroup: TypeAlias = Union[str, ToolgroupUnionMember1]
 
 
 class AgentConfig(TypedDict, total=False):
@@ -33,6 +28,8 @@ class AgentConfig(TypedDict, total=False):
     max_infer_iters: Required[int]
 
     model: Required[str]
+
+    client_tools: Iterable[ToolDefParam]
 
     input_shields: List[str]
 
@@ -55,4 +52,4 @@ class AgentConfig(TypedDict, total=False):
     The detailed prompts for each of these formats are added to llama cli
     """
 
-    tools: Iterable[Tool]
+    toolgroups: List[Toolgroup]

--- a/src/llama_stack_client/types/synthetic_data_generation_generate_params.py
+++ b/src/llama_stack_client/types/synthetic_data_generation_generate_params.py
@@ -6,12 +6,13 @@ from typing import Union, Iterable
 from typing_extensions import Literal, Required, Annotated, TypeAlias, TypedDict
 
 from .._utils import PropertyInfo
+from .shared_params.tool_call import ToolCall
 from .shared_params.user_message import UserMessage
 from .shared_params.system_message import SystemMessage
-from .shared_params.completion_message import CompletionMessage
+from .shared_params.interleaved_content import InterleavedContent
 from .shared_params.tool_response_message import ToolResponseMessage
 
-__all__ = ["SyntheticDataGenerationGenerateParams", "Dialog"]
+__all__ = ["SyntheticDataGenerationGenerateParams", "Dialog", "DialogCompletionMessage"]
 
 
 class SyntheticDataGenerationGenerateParams(TypedDict, total=False):
@@ -24,4 +25,14 @@ class SyntheticDataGenerationGenerateParams(TypedDict, total=False):
     x_llama_stack_provider_data: Annotated[str, PropertyInfo(alias="X-LlamaStack-ProviderData")]
 
 
-Dialog: TypeAlias = Union[UserMessage, SystemMessage, ToolResponseMessage, CompletionMessage]
+class DialogCompletionMessage(TypedDict, total=False):
+    content: Required[InterleavedContent]
+
+    role: Required[Literal["assistant"]]
+
+    stop_reason: Required[Literal["end_of_turn", "end_of_message", "out_of_tokens"]]
+
+    tool_calls: Required[Iterable[ToolCall]]
+
+
+Dialog: TypeAlias = Union[UserMessage, SystemMessage, ToolResponseMessage, DialogCompletionMessage]

--- a/src/llama_stack_client/types/tool.py
+++ b/src/llama_stack_client/types/tool.py
@@ -1,0 +1,53 @@
+# File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
+
+from typing import Dict, List, Union, Optional
+from typing_extensions import Literal
+
+from .._models import BaseModel
+
+__all__ = ["Tool", "Parameter"]
+
+
+class Parameter(BaseModel):
+    description: str
+
+    name: str
+
+    parameter_type: str
+
+    required: bool
+
+    default: Union[bool, float, str, List[object], object, None] = None
+
+
+class Tool(BaseModel):
+    description: str
+
+    identifier: str
+
+    parameters: List[Parameter]
+
+    provider_id: str
+
+    provider_resource_id: str
+
+    tool_host: Literal["distribution", "client", "model_context_protocol"]
+
+    toolgroup_id: str
+
+    type: Literal["tool"]
+
+    metadata: Optional[Dict[str, Union[bool, float, str, List[object], object, None]]] = None
+
+    tool_prompt_format: Optional[Literal["json", "function_tag", "python_list"]] = None
+    """
+    `json` -- Refers to the json format for calling tools. The json format takes the
+    form like { "type": "function", "function" : { "name": "function_name",
+    "description": "function_description", "parameters": {...} } }
+
+    `function_tag` -- This is an example of how you could define your own user
+    defined format for making tool calls. The function_tag format looks like this,
+    <function=function_name>(parameters)</function>
+
+    The detailed prompts for each of these formats are added to llama cli
+    """

--- a/src/llama_stack_client/types/tool_def.py
+++ b/src/llama_stack_client/types/tool_def.py
@@ -1,0 +1,43 @@
+# File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
+
+from typing import Dict, List, Union, Optional
+from typing_extensions import Literal
+
+from .._models import BaseModel
+
+__all__ = ["ToolDef", "Parameter"]
+
+
+class Parameter(BaseModel):
+    description: str
+
+    name: str
+
+    parameter_type: str
+
+    required: bool
+
+    default: Union[bool, float, str, List[object], object, None] = None
+
+
+class ToolDef(BaseModel):
+    name: str
+
+    description: Optional[str] = None
+
+    metadata: Optional[Dict[str, Union[bool, float, str, List[object], object, None]]] = None
+
+    parameters: Optional[List[Parameter]] = None
+
+    tool_prompt_format: Optional[Literal["json", "function_tag", "python_list"]] = None
+    """
+    `json` -- Refers to the json format for calling tools. The json format takes the
+    form like { "type": "function", "function" : { "name": "function_name",
+    "description": "function_description", "parameters": {...} } }
+
+    `function_tag` -- This is an example of how you could define your own user
+    defined format for making tool calls. The function_tag format looks like this,
+    <function=function_name>(parameters)</function>
+
+    The detailed prompts for each of these formats are added to llama cli
+    """

--- a/src/llama_stack_client/types/tool_def_param.py
+++ b/src/llama_stack_client/types/tool_def_param.py
@@ -1,0 +1,43 @@
+# File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
+
+from __future__ import annotations
+
+from typing import Dict, Union, Iterable
+from typing_extensions import Literal, Required, TypedDict
+
+__all__ = ["ToolDefParam", "Parameter"]
+
+
+class Parameter(TypedDict, total=False):
+    description: Required[str]
+
+    name: Required[str]
+
+    parameter_type: Required[str]
+
+    required: Required[bool]
+
+    default: Union[bool, float, str, Iterable[object], object, None]
+
+
+class ToolDefParam(TypedDict, total=False):
+    name: Required[str]
+
+    description: str
+
+    metadata: Dict[str, Union[bool, float, str, Iterable[object], object, None]]
+
+    parameters: Iterable[Parameter]
+
+    tool_prompt_format: Literal["json", "function_tag", "python_list"]
+    """
+    `json` -- Refers to the json format for calling tools. The json format takes the
+    form like { "type": "function", "function" : { "name": "function_name",
+    "description": "function_description", "parameters": {...} } }
+
+    `function_tag` -- This is an example of how you could define your own user
+    defined format for making tool calls. The function_tag format looks like this,
+    <function=function_name>(parameters)</function>
+
+    The detailed prompts for each of these formats are added to llama cli
+    """

--- a/src/llama_stack_client/types/tool_get_params.py
+++ b/src/llama_stack_client/types/tool_get_params.py
@@ -1,0 +1,15 @@
+# File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
+
+from __future__ import annotations
+
+from typing_extensions import Required, Annotated, TypedDict
+
+from .._utils import PropertyInfo
+
+__all__ = ["ToolGetParams"]
+
+
+class ToolGetParams(TypedDict, total=False):
+    tool_name: Required[str]
+
+    x_llama_stack_provider_data: Annotated[str, PropertyInfo(alias="X-LlamaStack-ProviderData")]

--- a/src/llama_stack_client/types/tool_group.py
+++ b/src/llama_stack_client/types/tool_group.py
@@ -1,0 +1,23 @@
+# File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
+
+from typing import Dict, List, Union, Optional
+from typing_extensions import Literal
+
+from .._models import BaseModel
+from .shared.url import URL
+
+__all__ = ["ToolGroup"]
+
+
+class ToolGroup(BaseModel):
+    identifier: str
+
+    provider_id: str
+
+    provider_resource_id: str
+
+    type: Literal["tool_group"]
+
+    args: Optional[Dict[str, Union[bool, float, str, List[object], object, None]]] = None
+
+    mcp_endpoint: Optional[URL] = None

--- a/src/llama_stack_client/types/tool_invocation_result.py
+++ b/src/llama_stack_client/types/tool_invocation_result.py
@@ -1,0 +1,16 @@
+# File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
+
+from typing import Optional
+
+from .._models import BaseModel
+from .shared.interleaved_content import InterleavedContent
+
+__all__ = ["ToolInvocationResult"]
+
+
+class ToolInvocationResult(BaseModel):
+    content: InterleavedContent
+
+    error_code: Optional[int] = None
+
+    error_message: Optional[str] = None

--- a/src/llama_stack_client/types/tool_list_params.py
+++ b/src/llama_stack_client/types/tool_list_params.py
@@ -1,0 +1,15 @@
+# File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
+
+from __future__ import annotations
+
+from typing_extensions import Annotated, TypedDict
+
+from .._utils import PropertyInfo
+
+__all__ = ["ToolListParams"]
+
+
+class ToolListParams(TypedDict, total=False):
+    tool_group_id: str
+
+    x_llama_stack_provider_data: Annotated[str, PropertyInfo(alias="X-LlamaStack-ProviderData")]

--- a/src/llama_stack_client/types/tool_runtime_invoke_tool_params.py
+++ b/src/llama_stack_client/types/tool_runtime_invoke_tool_params.py
@@ -1,0 +1,18 @@
+# File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
+
+from __future__ import annotations
+
+from typing import Dict, Union, Iterable
+from typing_extensions import Required, Annotated, TypedDict
+
+from .._utils import PropertyInfo
+
+__all__ = ["ToolRuntimeInvokeToolParams"]
+
+
+class ToolRuntimeInvokeToolParams(TypedDict, total=False):
+    args: Required[Dict[str, Union[bool, float, str, Iterable[object], object, None]]]
+
+    tool_name: Required[str]
+
+    x_llama_stack_provider_data: Annotated[str, PropertyInfo(alias="X-LlamaStack-ProviderData")]

--- a/src/llama_stack_client/types/tool_runtime_list_tools_params.py
+++ b/src/llama_stack_client/types/tool_runtime_list_tools_params.py
@@ -1,0 +1,18 @@
+# File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
+
+from __future__ import annotations
+
+from typing_extensions import Annotated, TypedDict
+
+from .._utils import PropertyInfo
+from .shared_params.url import URL
+
+__all__ = ["ToolRuntimeListToolsParams"]
+
+
+class ToolRuntimeListToolsParams(TypedDict, total=False):
+    tool_group_id: str
+
+    mcp_endpoint: URL
+
+    x_llama_stack_provider_data: Annotated[str, PropertyInfo(alias="X-LlamaStack-ProviderData")]

--- a/src/llama_stack_client/types/toolgroup_get_params.py
+++ b/src/llama_stack_client/types/toolgroup_get_params.py
@@ -1,0 +1,15 @@
+# File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
+
+from __future__ import annotations
+
+from typing_extensions import Required, Annotated, TypedDict
+
+from .._utils import PropertyInfo
+
+__all__ = ["ToolgroupGetParams"]
+
+
+class ToolgroupGetParams(TypedDict, total=False):
+    toolgroup_id: Required[str]
+
+    x_llama_stack_provider_data: Annotated[str, PropertyInfo(alias="X-LlamaStack-ProviderData")]

--- a/src/llama_stack_client/types/toolgroup_register_params.py
+++ b/src/llama_stack_client/types/toolgroup_register_params.py
@@ -1,0 +1,23 @@
+# File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
+
+from __future__ import annotations
+
+from typing import Dict, Union, Iterable
+from typing_extensions import Required, Annotated, TypedDict
+
+from .._utils import PropertyInfo
+from .shared_params.url import URL
+
+__all__ = ["ToolgroupRegisterParams"]
+
+
+class ToolgroupRegisterParams(TypedDict, total=False):
+    provider_id: Required[str]
+
+    toolgroup_id: Required[str]
+
+    args: Dict[str, Union[bool, float, str, Iterable[object], object, None]]
+
+    mcp_endpoint: URL
+
+    x_llama_stack_provider_data: Annotated[str, PropertyInfo(alias="X-LlamaStack-ProviderData")]

--- a/src/llama_stack_client/types/toolgroup_unregister_params.py
+++ b/src/llama_stack_client/types/toolgroup_unregister_params.py
@@ -1,0 +1,15 @@
+# File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
+
+from __future__ import annotations
+
+from typing_extensions import Required, Annotated, TypedDict
+
+from .._utils import PropertyInfo
+
+__all__ = ["ToolgroupUnregisterParams"]
+
+
+class ToolgroupUnregisterParams(TypedDict, total=False):
+    tool_group_id: Required[str]
+
+    x_llama_stack_provider_data: Annotated[str, PropertyInfo(alias="X-LlamaStack-ProviderData")]

--- a/tests/api_resources/agents/test_turn.py
+++ b/tests/api_resources/agents/test_turn.py
@@ -49,13 +49,14 @@ class TestTurn:
                 }
             ],
             session_id="session_id",
-            attachments=[
+            documents=[
                 {
                     "content": "string",
                     "mime_type": "mime_type",
                 }
             ],
             stream=False,
+            toolgroups=["string"],
             x_llama_stack_provider_data="X-LlamaStack-ProviderData",
         )
         assert_matches_type(TurnCreateResponse, turn, path=["response"])
@@ -138,12 +139,13 @@ class TestTurn:
             ],
             session_id="session_id",
             stream=True,
-            attachments=[
+            documents=[
                 {
                     "content": "string",
                     "mime_type": "mime_type",
                 }
             ],
+            toolgroups=["string"],
             x_llama_stack_provider_data="X-LlamaStack-ProviderData",
         )
         turn_stream.response.close()
@@ -276,13 +278,14 @@ class TestAsyncTurn:
                 }
             ],
             session_id="session_id",
-            attachments=[
+            documents=[
                 {
                     "content": "string",
                     "mime_type": "mime_type",
                 }
             ],
             stream=False,
+            toolgroups=["string"],
             x_llama_stack_provider_data="X-LlamaStack-ProviderData",
         )
         assert_matches_type(TurnCreateResponse, turn, path=["response"])
@@ -365,12 +368,13 @@ class TestAsyncTurn:
             ],
             session_id="session_id",
             stream=True,
-            attachments=[
+            documents=[
                 {
                     "content": "string",
                     "mime_type": "mime_type",
                 }
             ],
+            toolgroups=["string"],
             x_llama_stack_provider_data="X-LlamaStack-ProviderData",
         )
         await turn_stream.response.aclose()

--- a/tests/api_resources/test_agents.py
+++ b/tests/api_resources/test_agents.py
@@ -37,6 +37,23 @@ class TestAgents:
                 "instructions": "instructions",
                 "max_infer_iters": 0,
                 "model": "model",
+                "client_tools": [
+                    {
+                        "name": "name",
+                        "description": "description",
+                        "metadata": {"foo": True},
+                        "parameters": [
+                            {
+                                "description": "description",
+                                "name": "name",
+                                "parameter_type": "parameter_type",
+                                "required": True,
+                                "default": True,
+                            }
+                        ],
+                        "tool_prompt_format": "json",
+                    }
+                ],
                 "input_shields": ["string"],
                 "output_shields": ["string"],
                 "sampling_params": {
@@ -49,22 +66,7 @@ class TestAgents:
                 },
                 "tool_choice": "auto",
                 "tool_prompt_format": "json",
-                "tools": [
-                    {
-                        "api_key": "api_key",
-                        "engine": "bing",
-                        "type": "brave_search",
-                        "input_shields": ["string"],
-                        "output_shields": ["string"],
-                        "remote_execution": {
-                            "method": "GET",
-                            "url": {"uri": "uri"},
-                            "body": {"foo": True},
-                            "headers": {"foo": True},
-                            "params": {"foo": True},
-                        },
-                    }
-                ],
+                "toolgroups": ["string"],
             },
             x_llama_stack_provider_data="X-LlamaStack-ProviderData",
         )
@@ -167,6 +169,23 @@ class TestAsyncAgents:
                 "instructions": "instructions",
                 "max_infer_iters": 0,
                 "model": "model",
+                "client_tools": [
+                    {
+                        "name": "name",
+                        "description": "description",
+                        "metadata": {"foo": True},
+                        "parameters": [
+                            {
+                                "description": "description",
+                                "name": "name",
+                                "parameter_type": "parameter_type",
+                                "required": True,
+                                "default": True,
+                            }
+                        ],
+                        "tool_prompt_format": "json",
+                    }
+                ],
                 "input_shields": ["string"],
                 "output_shields": ["string"],
                 "sampling_params": {
@@ -179,22 +198,7 @@ class TestAsyncAgents:
                 },
                 "tool_choice": "auto",
                 "tool_prompt_format": "json",
-                "tools": [
-                    {
-                        "api_key": "api_key",
-                        "engine": "bing",
-                        "type": "brave_search",
-                        "input_shields": ["string"],
-                        "output_shields": ["string"],
-                        "remote_execution": {
-                            "method": "GET",
-                            "url": {"uri": "uri"},
-                            "body": {"foo": True},
-                            "headers": {"foo": True},
-                            "params": {"foo": True},
-                        },
-                    }
-                ],
+                "toolgroups": ["string"],
             },
             x_llama_stack_provider_data="X-LlamaStack-ProviderData",
         )

--- a/tests/api_resources/test_post_training.py
+++ b/tests/api_resources/test_post_training.py
@@ -40,6 +40,7 @@ class TestPostTraining:
                 },
                 "gradient_accumulation_steps": 0,
                 "max_steps_per_epoch": 0,
+                "max_validation_steps": 0,
                 "n_epochs": 0,
                 "optimizer_config": {
                     "lr": 0,
@@ -75,6 +76,7 @@ class TestPostTraining:
                 },
                 "gradient_accumulation_steps": 0,
                 "max_steps_per_epoch": 0,
+                "max_validation_steps": 0,
                 "n_epochs": 0,
                 "optimizer_config": {
                     "lr": 0,
@@ -115,6 +117,7 @@ class TestPostTraining:
                 },
                 "gradient_accumulation_steps": 0,
                 "max_steps_per_epoch": 0,
+                "max_validation_steps": 0,
                 "n_epochs": 0,
                 "optimizer_config": {
                     "lr": 0,
@@ -151,6 +154,7 @@ class TestPostTraining:
                 },
                 "gradient_accumulation_steps": 0,
                 "max_steps_per_epoch": 0,
+                "max_validation_steps": 0,
                 "n_epochs": 0,
                 "optimizer_config": {
                     "lr": 0,
@@ -183,6 +187,7 @@ class TestPostTraining:
                 },
                 "gradient_accumulation_steps": 0,
                 "max_steps_per_epoch": 0,
+                "max_validation_steps": 0,
                 "n_epochs": 0,
                 "optimizer_config": {
                     "lr": 0,
@@ -212,6 +217,7 @@ class TestPostTraining:
                 },
                 "gradient_accumulation_steps": 0,
                 "max_steps_per_epoch": 0,
+                "max_validation_steps": 0,
                 "n_epochs": 0,
                 "optimizer_config": {
                     "lr": 0,
@@ -257,6 +263,7 @@ class TestPostTraining:
                 },
                 "gradient_accumulation_steps": 0,
                 "max_steps_per_epoch": 0,
+                "max_validation_steps": 0,
                 "n_epochs": 0,
                 "optimizer_config": {
                     "lr": 0,
@@ -287,6 +294,7 @@ class TestPostTraining:
                 },
                 "gradient_accumulation_steps": 0,
                 "max_steps_per_epoch": 0,
+                "max_validation_steps": 0,
                 "n_epochs": 0,
                 "optimizer_config": {
                     "lr": 0,
@@ -329,6 +337,7 @@ class TestAsyncPostTraining:
                 },
                 "gradient_accumulation_steps": 0,
                 "max_steps_per_epoch": 0,
+                "max_validation_steps": 0,
                 "n_epochs": 0,
                 "optimizer_config": {
                     "lr": 0,
@@ -364,6 +373,7 @@ class TestAsyncPostTraining:
                 },
                 "gradient_accumulation_steps": 0,
                 "max_steps_per_epoch": 0,
+                "max_validation_steps": 0,
                 "n_epochs": 0,
                 "optimizer_config": {
                     "lr": 0,
@@ -404,6 +414,7 @@ class TestAsyncPostTraining:
                 },
                 "gradient_accumulation_steps": 0,
                 "max_steps_per_epoch": 0,
+                "max_validation_steps": 0,
                 "n_epochs": 0,
                 "optimizer_config": {
                     "lr": 0,
@@ -440,6 +451,7 @@ class TestAsyncPostTraining:
                 },
                 "gradient_accumulation_steps": 0,
                 "max_steps_per_epoch": 0,
+                "max_validation_steps": 0,
                 "n_epochs": 0,
                 "optimizer_config": {
                     "lr": 0,
@@ -472,6 +484,7 @@ class TestAsyncPostTraining:
                 },
                 "gradient_accumulation_steps": 0,
                 "max_steps_per_epoch": 0,
+                "max_validation_steps": 0,
                 "n_epochs": 0,
                 "optimizer_config": {
                     "lr": 0,
@@ -501,6 +514,7 @@ class TestAsyncPostTraining:
                 },
                 "gradient_accumulation_steps": 0,
                 "max_steps_per_epoch": 0,
+                "max_validation_steps": 0,
                 "n_epochs": 0,
                 "optimizer_config": {
                     "lr": 0,
@@ -546,6 +560,7 @@ class TestAsyncPostTraining:
                 },
                 "gradient_accumulation_steps": 0,
                 "max_steps_per_epoch": 0,
+                "max_validation_steps": 0,
                 "n_epochs": 0,
                 "optimizer_config": {
                     "lr": 0,
@@ -576,6 +591,7 @@ class TestAsyncPostTraining:
                 },
                 "gradient_accumulation_steps": 0,
                 "max_steps_per_epoch": 0,
+                "max_validation_steps": 0,
                 "n_epochs": 0,
                 "optimizer_config": {
                     "lr": 0,

--- a/tests/api_resources/test_tool_runtime.py
+++ b/tests/api_resources/test_tool_runtime.py
@@ -1,0 +1,203 @@
+# File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
+
+from __future__ import annotations
+
+import os
+from typing import Any, cast
+
+import pytest
+
+from tests.utils import assert_matches_type
+from llama_stack_client import LlamaStackClient, AsyncLlamaStackClient
+from llama_stack_client.types import (
+    ToolDef,
+    ToolInvocationResult,
+)
+
+base_url = os.environ.get("TEST_API_BASE_URL", "http://127.0.0.1:4010")
+
+
+class TestToolRuntime:
+    parametrize = pytest.mark.parametrize("client", [False, True], indirect=True, ids=["loose", "strict"])
+
+    @parametrize
+    def test_method_invoke_tool(self, client: LlamaStackClient) -> None:
+        tool_runtime = client.tool_runtime.invoke_tool(
+            args={"foo": True},
+            tool_name="tool_name",
+        )
+        assert_matches_type(ToolInvocationResult, tool_runtime, path=["response"])
+
+    @parametrize
+    def test_method_invoke_tool_with_all_params(self, client: LlamaStackClient) -> None:
+        tool_runtime = client.tool_runtime.invoke_tool(
+            args={"foo": True},
+            tool_name="tool_name",
+            x_llama_stack_provider_data="X-LlamaStack-ProviderData",
+        )
+        assert_matches_type(ToolInvocationResult, tool_runtime, path=["response"])
+
+    @parametrize
+    def test_raw_response_invoke_tool(self, client: LlamaStackClient) -> None:
+        response = client.tool_runtime.with_raw_response.invoke_tool(
+            args={"foo": True},
+            tool_name="tool_name",
+        )
+
+        assert response.is_closed is True
+        assert response.http_request.headers.get("X-Stainless-Lang") == "python"
+        tool_runtime = response.parse()
+        assert_matches_type(ToolInvocationResult, tool_runtime, path=["response"])
+
+    @parametrize
+    def test_streaming_response_invoke_tool(self, client: LlamaStackClient) -> None:
+        with client.tool_runtime.with_streaming_response.invoke_tool(
+            args={"foo": True},
+            tool_name="tool_name",
+        ) as response:
+            assert not response.is_closed
+            assert response.http_request.headers.get("X-Stainless-Lang") == "python"
+
+            tool_runtime = response.parse()
+            assert_matches_type(ToolInvocationResult, tool_runtime, path=["response"])
+
+        assert cast(Any, response.is_closed) is True
+
+    @pytest.mark.skip(
+        reason="currently no good way to test endpoints with content type application/jsonl, Prism mock server will fail"
+    )
+    @parametrize
+    def test_method_list_tools(self, client: LlamaStackClient) -> None:
+        tool_runtime = client.tool_runtime.list_tools()
+        assert_matches_type(ToolDef, tool_runtime, path=["response"])
+
+    @pytest.mark.skip(
+        reason="currently no good way to test endpoints with content type application/jsonl, Prism mock server will fail"
+    )
+    @parametrize
+    def test_method_list_tools_with_all_params(self, client: LlamaStackClient) -> None:
+        tool_runtime = client.tool_runtime.list_tools(
+            tool_group_id="tool_group_id",
+            mcp_endpoint={"uri": "uri"},
+            x_llama_stack_provider_data="X-LlamaStack-ProviderData",
+        )
+        assert_matches_type(ToolDef, tool_runtime, path=["response"])
+
+    @pytest.mark.skip(
+        reason="currently no good way to test endpoints with content type application/jsonl, Prism mock server will fail"
+    )
+    @parametrize
+    def test_raw_response_list_tools(self, client: LlamaStackClient) -> None:
+        response = client.tool_runtime.with_raw_response.list_tools()
+
+        assert response.is_closed is True
+        assert response.http_request.headers.get("X-Stainless-Lang") == "python"
+        tool_runtime = response.parse()
+        assert_matches_type(ToolDef, tool_runtime, path=["response"])
+
+    @pytest.mark.skip(
+        reason="currently no good way to test endpoints with content type application/jsonl, Prism mock server will fail"
+    )
+    @parametrize
+    def test_streaming_response_list_tools(self, client: LlamaStackClient) -> None:
+        with client.tool_runtime.with_streaming_response.list_tools() as response:
+            assert not response.is_closed
+            assert response.http_request.headers.get("X-Stainless-Lang") == "python"
+
+            tool_runtime = response.parse()
+            assert_matches_type(ToolDef, tool_runtime, path=["response"])
+
+        assert cast(Any, response.is_closed) is True
+
+
+class TestAsyncToolRuntime:
+    parametrize = pytest.mark.parametrize("async_client", [False, True], indirect=True, ids=["loose", "strict"])
+
+    @parametrize
+    async def test_method_invoke_tool(self, async_client: AsyncLlamaStackClient) -> None:
+        tool_runtime = await async_client.tool_runtime.invoke_tool(
+            args={"foo": True},
+            tool_name="tool_name",
+        )
+        assert_matches_type(ToolInvocationResult, tool_runtime, path=["response"])
+
+    @parametrize
+    async def test_method_invoke_tool_with_all_params(self, async_client: AsyncLlamaStackClient) -> None:
+        tool_runtime = await async_client.tool_runtime.invoke_tool(
+            args={"foo": True},
+            tool_name="tool_name",
+            x_llama_stack_provider_data="X-LlamaStack-ProviderData",
+        )
+        assert_matches_type(ToolInvocationResult, tool_runtime, path=["response"])
+
+    @parametrize
+    async def test_raw_response_invoke_tool(self, async_client: AsyncLlamaStackClient) -> None:
+        response = await async_client.tool_runtime.with_raw_response.invoke_tool(
+            args={"foo": True},
+            tool_name="tool_name",
+        )
+
+        assert response.is_closed is True
+        assert response.http_request.headers.get("X-Stainless-Lang") == "python"
+        tool_runtime = await response.parse()
+        assert_matches_type(ToolInvocationResult, tool_runtime, path=["response"])
+
+    @parametrize
+    async def test_streaming_response_invoke_tool(self, async_client: AsyncLlamaStackClient) -> None:
+        async with async_client.tool_runtime.with_streaming_response.invoke_tool(
+            args={"foo": True},
+            tool_name="tool_name",
+        ) as response:
+            assert not response.is_closed
+            assert response.http_request.headers.get("X-Stainless-Lang") == "python"
+
+            tool_runtime = await response.parse()
+            assert_matches_type(ToolInvocationResult, tool_runtime, path=["response"])
+
+        assert cast(Any, response.is_closed) is True
+
+    @pytest.mark.skip(
+        reason="currently no good way to test endpoints with content type application/jsonl, Prism mock server will fail"
+    )
+    @parametrize
+    async def test_method_list_tools(self, async_client: AsyncLlamaStackClient) -> None:
+        tool_runtime = await async_client.tool_runtime.list_tools()
+        assert_matches_type(ToolDef, tool_runtime, path=["response"])
+
+    @pytest.mark.skip(
+        reason="currently no good way to test endpoints with content type application/jsonl, Prism mock server will fail"
+    )
+    @parametrize
+    async def test_method_list_tools_with_all_params(self, async_client: AsyncLlamaStackClient) -> None:
+        tool_runtime = await async_client.tool_runtime.list_tools(
+            tool_group_id="tool_group_id",
+            mcp_endpoint={"uri": "uri"},
+            x_llama_stack_provider_data="X-LlamaStack-ProviderData",
+        )
+        assert_matches_type(ToolDef, tool_runtime, path=["response"])
+
+    @pytest.mark.skip(
+        reason="currently no good way to test endpoints with content type application/jsonl, Prism mock server will fail"
+    )
+    @parametrize
+    async def test_raw_response_list_tools(self, async_client: AsyncLlamaStackClient) -> None:
+        response = await async_client.tool_runtime.with_raw_response.list_tools()
+
+        assert response.is_closed is True
+        assert response.http_request.headers.get("X-Stainless-Lang") == "python"
+        tool_runtime = await response.parse()
+        assert_matches_type(ToolDef, tool_runtime, path=["response"])
+
+    @pytest.mark.skip(
+        reason="currently no good way to test endpoints with content type application/jsonl, Prism mock server will fail"
+    )
+    @parametrize
+    async def test_streaming_response_list_tools(self, async_client: AsyncLlamaStackClient) -> None:
+        async with async_client.tool_runtime.with_streaming_response.list_tools() as response:
+            assert not response.is_closed
+            assert response.http_request.headers.get("X-Stainless-Lang") == "python"
+
+            tool_runtime = await response.parse()
+            assert_matches_type(ToolDef, tool_runtime, path=["response"])
+
+        assert cast(Any, response.is_closed) is True

--- a/tests/api_resources/test_toolgroups.py
+++ b/tests/api_resources/test_toolgroups.py
@@ -1,0 +1,358 @@
+# File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
+
+from __future__ import annotations
+
+import os
+from typing import Any, cast
+
+import pytest
+
+from tests.utils import assert_matches_type
+from llama_stack_client import LlamaStackClient, AsyncLlamaStackClient
+from llama_stack_client.types import (
+    ToolGroup,
+)
+
+base_url = os.environ.get("TEST_API_BASE_URL", "http://127.0.0.1:4010")
+
+
+class TestToolgroups:
+    parametrize = pytest.mark.parametrize("client", [False, True], indirect=True, ids=["loose", "strict"])
+
+    @pytest.mark.skip(
+        reason="currently no good way to test endpoints with content type application/jsonl, Prism mock server will fail"
+    )
+    @parametrize
+    def test_method_list(self, client: LlamaStackClient) -> None:
+        toolgroup = client.toolgroups.list()
+        assert_matches_type(ToolGroup, toolgroup, path=["response"])
+
+    @pytest.mark.skip(
+        reason="currently no good way to test endpoints with content type application/jsonl, Prism mock server will fail"
+    )
+    @parametrize
+    def test_method_list_with_all_params(self, client: LlamaStackClient) -> None:
+        toolgroup = client.toolgroups.list(
+            x_llama_stack_provider_data="X-LlamaStack-ProviderData",
+        )
+        assert_matches_type(ToolGroup, toolgroup, path=["response"])
+
+    @pytest.mark.skip(
+        reason="currently no good way to test endpoints with content type application/jsonl, Prism mock server will fail"
+    )
+    @parametrize
+    def test_raw_response_list(self, client: LlamaStackClient) -> None:
+        response = client.toolgroups.with_raw_response.list()
+
+        assert response.is_closed is True
+        assert response.http_request.headers.get("X-Stainless-Lang") == "python"
+        toolgroup = response.parse()
+        assert_matches_type(ToolGroup, toolgroup, path=["response"])
+
+    @pytest.mark.skip(
+        reason="currently no good way to test endpoints with content type application/jsonl, Prism mock server will fail"
+    )
+    @parametrize
+    def test_streaming_response_list(self, client: LlamaStackClient) -> None:
+        with client.toolgroups.with_streaming_response.list() as response:
+            assert not response.is_closed
+            assert response.http_request.headers.get("X-Stainless-Lang") == "python"
+
+            toolgroup = response.parse()
+            assert_matches_type(ToolGroup, toolgroup, path=["response"])
+
+        assert cast(Any, response.is_closed) is True
+
+    @parametrize
+    def test_method_get(self, client: LlamaStackClient) -> None:
+        toolgroup = client.toolgroups.get(
+            toolgroup_id="toolgroup_id",
+        )
+        assert_matches_type(ToolGroup, toolgroup, path=["response"])
+
+    @parametrize
+    def test_method_get_with_all_params(self, client: LlamaStackClient) -> None:
+        toolgroup = client.toolgroups.get(
+            toolgroup_id="toolgroup_id",
+            x_llama_stack_provider_data="X-LlamaStack-ProviderData",
+        )
+        assert_matches_type(ToolGroup, toolgroup, path=["response"])
+
+    @parametrize
+    def test_raw_response_get(self, client: LlamaStackClient) -> None:
+        response = client.toolgroups.with_raw_response.get(
+            toolgroup_id="toolgroup_id",
+        )
+
+        assert response.is_closed is True
+        assert response.http_request.headers.get("X-Stainless-Lang") == "python"
+        toolgroup = response.parse()
+        assert_matches_type(ToolGroup, toolgroup, path=["response"])
+
+    @parametrize
+    def test_streaming_response_get(self, client: LlamaStackClient) -> None:
+        with client.toolgroups.with_streaming_response.get(
+            toolgroup_id="toolgroup_id",
+        ) as response:
+            assert not response.is_closed
+            assert response.http_request.headers.get("X-Stainless-Lang") == "python"
+
+            toolgroup = response.parse()
+            assert_matches_type(ToolGroup, toolgroup, path=["response"])
+
+        assert cast(Any, response.is_closed) is True
+
+    @parametrize
+    def test_method_register(self, client: LlamaStackClient) -> None:
+        toolgroup = client.toolgroups.register(
+            provider_id="provider_id",
+            toolgroup_id="toolgroup_id",
+        )
+        assert toolgroup is None
+
+    @parametrize
+    def test_method_register_with_all_params(self, client: LlamaStackClient) -> None:
+        toolgroup = client.toolgroups.register(
+            provider_id="provider_id",
+            toolgroup_id="toolgroup_id",
+            args={"foo": True},
+            mcp_endpoint={"uri": "uri"},
+            x_llama_stack_provider_data="X-LlamaStack-ProviderData",
+        )
+        assert toolgroup is None
+
+    @parametrize
+    def test_raw_response_register(self, client: LlamaStackClient) -> None:
+        response = client.toolgroups.with_raw_response.register(
+            provider_id="provider_id",
+            toolgroup_id="toolgroup_id",
+        )
+
+        assert response.is_closed is True
+        assert response.http_request.headers.get("X-Stainless-Lang") == "python"
+        toolgroup = response.parse()
+        assert toolgroup is None
+
+    @parametrize
+    def test_streaming_response_register(self, client: LlamaStackClient) -> None:
+        with client.toolgroups.with_streaming_response.register(
+            provider_id="provider_id",
+            toolgroup_id="toolgroup_id",
+        ) as response:
+            assert not response.is_closed
+            assert response.http_request.headers.get("X-Stainless-Lang") == "python"
+
+            toolgroup = response.parse()
+            assert toolgroup is None
+
+        assert cast(Any, response.is_closed) is True
+
+    @parametrize
+    def test_method_unregister(self, client: LlamaStackClient) -> None:
+        toolgroup = client.toolgroups.unregister(
+            tool_group_id="tool_group_id",
+        )
+        assert toolgroup is None
+
+    @parametrize
+    def test_method_unregister_with_all_params(self, client: LlamaStackClient) -> None:
+        toolgroup = client.toolgroups.unregister(
+            tool_group_id="tool_group_id",
+            x_llama_stack_provider_data="X-LlamaStack-ProviderData",
+        )
+        assert toolgroup is None
+
+    @parametrize
+    def test_raw_response_unregister(self, client: LlamaStackClient) -> None:
+        response = client.toolgroups.with_raw_response.unregister(
+            tool_group_id="tool_group_id",
+        )
+
+        assert response.is_closed is True
+        assert response.http_request.headers.get("X-Stainless-Lang") == "python"
+        toolgroup = response.parse()
+        assert toolgroup is None
+
+    @parametrize
+    def test_streaming_response_unregister(self, client: LlamaStackClient) -> None:
+        with client.toolgroups.with_streaming_response.unregister(
+            tool_group_id="tool_group_id",
+        ) as response:
+            assert not response.is_closed
+            assert response.http_request.headers.get("X-Stainless-Lang") == "python"
+
+            toolgroup = response.parse()
+            assert toolgroup is None
+
+        assert cast(Any, response.is_closed) is True
+
+
+class TestAsyncToolgroups:
+    parametrize = pytest.mark.parametrize("async_client", [False, True], indirect=True, ids=["loose", "strict"])
+
+    @pytest.mark.skip(
+        reason="currently no good way to test endpoints with content type application/jsonl, Prism mock server will fail"
+    )
+    @parametrize
+    async def test_method_list(self, async_client: AsyncLlamaStackClient) -> None:
+        toolgroup = await async_client.toolgroups.list()
+        assert_matches_type(ToolGroup, toolgroup, path=["response"])
+
+    @pytest.mark.skip(
+        reason="currently no good way to test endpoints with content type application/jsonl, Prism mock server will fail"
+    )
+    @parametrize
+    async def test_method_list_with_all_params(self, async_client: AsyncLlamaStackClient) -> None:
+        toolgroup = await async_client.toolgroups.list(
+            x_llama_stack_provider_data="X-LlamaStack-ProviderData",
+        )
+        assert_matches_type(ToolGroup, toolgroup, path=["response"])
+
+    @pytest.mark.skip(
+        reason="currently no good way to test endpoints with content type application/jsonl, Prism mock server will fail"
+    )
+    @parametrize
+    async def test_raw_response_list(self, async_client: AsyncLlamaStackClient) -> None:
+        response = await async_client.toolgroups.with_raw_response.list()
+
+        assert response.is_closed is True
+        assert response.http_request.headers.get("X-Stainless-Lang") == "python"
+        toolgroup = await response.parse()
+        assert_matches_type(ToolGroup, toolgroup, path=["response"])
+
+    @pytest.mark.skip(
+        reason="currently no good way to test endpoints with content type application/jsonl, Prism mock server will fail"
+    )
+    @parametrize
+    async def test_streaming_response_list(self, async_client: AsyncLlamaStackClient) -> None:
+        async with async_client.toolgroups.with_streaming_response.list() as response:
+            assert not response.is_closed
+            assert response.http_request.headers.get("X-Stainless-Lang") == "python"
+
+            toolgroup = await response.parse()
+            assert_matches_type(ToolGroup, toolgroup, path=["response"])
+
+        assert cast(Any, response.is_closed) is True
+
+    @parametrize
+    async def test_method_get(self, async_client: AsyncLlamaStackClient) -> None:
+        toolgroup = await async_client.toolgroups.get(
+            toolgroup_id="toolgroup_id",
+        )
+        assert_matches_type(ToolGroup, toolgroup, path=["response"])
+
+    @parametrize
+    async def test_method_get_with_all_params(self, async_client: AsyncLlamaStackClient) -> None:
+        toolgroup = await async_client.toolgroups.get(
+            toolgroup_id="toolgroup_id",
+            x_llama_stack_provider_data="X-LlamaStack-ProviderData",
+        )
+        assert_matches_type(ToolGroup, toolgroup, path=["response"])
+
+    @parametrize
+    async def test_raw_response_get(self, async_client: AsyncLlamaStackClient) -> None:
+        response = await async_client.toolgroups.with_raw_response.get(
+            toolgroup_id="toolgroup_id",
+        )
+
+        assert response.is_closed is True
+        assert response.http_request.headers.get("X-Stainless-Lang") == "python"
+        toolgroup = await response.parse()
+        assert_matches_type(ToolGroup, toolgroup, path=["response"])
+
+    @parametrize
+    async def test_streaming_response_get(self, async_client: AsyncLlamaStackClient) -> None:
+        async with async_client.toolgroups.with_streaming_response.get(
+            toolgroup_id="toolgroup_id",
+        ) as response:
+            assert not response.is_closed
+            assert response.http_request.headers.get("X-Stainless-Lang") == "python"
+
+            toolgroup = await response.parse()
+            assert_matches_type(ToolGroup, toolgroup, path=["response"])
+
+        assert cast(Any, response.is_closed) is True
+
+    @parametrize
+    async def test_method_register(self, async_client: AsyncLlamaStackClient) -> None:
+        toolgroup = await async_client.toolgroups.register(
+            provider_id="provider_id",
+            toolgroup_id="toolgroup_id",
+        )
+        assert toolgroup is None
+
+    @parametrize
+    async def test_method_register_with_all_params(self, async_client: AsyncLlamaStackClient) -> None:
+        toolgroup = await async_client.toolgroups.register(
+            provider_id="provider_id",
+            toolgroup_id="toolgroup_id",
+            args={"foo": True},
+            mcp_endpoint={"uri": "uri"},
+            x_llama_stack_provider_data="X-LlamaStack-ProviderData",
+        )
+        assert toolgroup is None
+
+    @parametrize
+    async def test_raw_response_register(self, async_client: AsyncLlamaStackClient) -> None:
+        response = await async_client.toolgroups.with_raw_response.register(
+            provider_id="provider_id",
+            toolgroup_id="toolgroup_id",
+        )
+
+        assert response.is_closed is True
+        assert response.http_request.headers.get("X-Stainless-Lang") == "python"
+        toolgroup = await response.parse()
+        assert toolgroup is None
+
+    @parametrize
+    async def test_streaming_response_register(self, async_client: AsyncLlamaStackClient) -> None:
+        async with async_client.toolgroups.with_streaming_response.register(
+            provider_id="provider_id",
+            toolgroup_id="toolgroup_id",
+        ) as response:
+            assert not response.is_closed
+            assert response.http_request.headers.get("X-Stainless-Lang") == "python"
+
+            toolgroup = await response.parse()
+            assert toolgroup is None
+
+        assert cast(Any, response.is_closed) is True
+
+    @parametrize
+    async def test_method_unregister(self, async_client: AsyncLlamaStackClient) -> None:
+        toolgroup = await async_client.toolgroups.unregister(
+            tool_group_id="tool_group_id",
+        )
+        assert toolgroup is None
+
+    @parametrize
+    async def test_method_unregister_with_all_params(self, async_client: AsyncLlamaStackClient) -> None:
+        toolgroup = await async_client.toolgroups.unregister(
+            tool_group_id="tool_group_id",
+            x_llama_stack_provider_data="X-LlamaStack-ProviderData",
+        )
+        assert toolgroup is None
+
+    @parametrize
+    async def test_raw_response_unregister(self, async_client: AsyncLlamaStackClient) -> None:
+        response = await async_client.toolgroups.with_raw_response.unregister(
+            tool_group_id="tool_group_id",
+        )
+
+        assert response.is_closed is True
+        assert response.http_request.headers.get("X-Stainless-Lang") == "python"
+        toolgroup = await response.parse()
+        assert toolgroup is None
+
+    @parametrize
+    async def test_streaming_response_unregister(self, async_client: AsyncLlamaStackClient) -> None:
+        async with async_client.toolgroups.with_streaming_response.unregister(
+            tool_group_id="tool_group_id",
+        ) as response:
+            assert not response.is_closed
+            assert response.http_request.headers.get("X-Stainless-Lang") == "python"
+
+            toolgroup = await response.parse()
+            assert toolgroup is None
+
+        assert cast(Any, response.is_closed) is True

--- a/tests/api_resources/test_tools.py
+++ b/tests/api_resources/test_tools.py
@@ -1,0 +1,190 @@
+# File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
+
+from __future__ import annotations
+
+import os
+from typing import Any, cast
+
+import pytest
+
+from tests.utils import assert_matches_type
+from llama_stack_client import LlamaStackClient, AsyncLlamaStackClient
+from llama_stack_client.types import Tool
+
+base_url = os.environ.get("TEST_API_BASE_URL", "http://127.0.0.1:4010")
+
+
+class TestTools:
+    parametrize = pytest.mark.parametrize("client", [False, True], indirect=True, ids=["loose", "strict"])
+
+    @pytest.mark.skip(
+        reason="currently no good way to test endpoints with content type application/jsonl, Prism mock server will fail"
+    )
+    @parametrize
+    def test_method_list(self, client: LlamaStackClient) -> None:
+        tool = client.tools.list()
+        assert_matches_type(Tool, tool, path=["response"])
+
+    @pytest.mark.skip(
+        reason="currently no good way to test endpoints with content type application/jsonl, Prism mock server will fail"
+    )
+    @parametrize
+    def test_method_list_with_all_params(self, client: LlamaStackClient) -> None:
+        tool = client.tools.list(
+            tool_group_id="tool_group_id",
+            x_llama_stack_provider_data="X-LlamaStack-ProviderData",
+        )
+        assert_matches_type(Tool, tool, path=["response"])
+
+    @pytest.mark.skip(
+        reason="currently no good way to test endpoints with content type application/jsonl, Prism mock server will fail"
+    )
+    @parametrize
+    def test_raw_response_list(self, client: LlamaStackClient) -> None:
+        response = client.tools.with_raw_response.list()
+
+        assert response.is_closed is True
+        assert response.http_request.headers.get("X-Stainless-Lang") == "python"
+        tool = response.parse()
+        assert_matches_type(Tool, tool, path=["response"])
+
+    @pytest.mark.skip(
+        reason="currently no good way to test endpoints with content type application/jsonl, Prism mock server will fail"
+    )
+    @parametrize
+    def test_streaming_response_list(self, client: LlamaStackClient) -> None:
+        with client.tools.with_streaming_response.list() as response:
+            assert not response.is_closed
+            assert response.http_request.headers.get("X-Stainless-Lang") == "python"
+
+            tool = response.parse()
+            assert_matches_type(Tool, tool, path=["response"])
+
+        assert cast(Any, response.is_closed) is True
+
+    @parametrize
+    def test_method_get(self, client: LlamaStackClient) -> None:
+        tool = client.tools.get(
+            tool_name="tool_name",
+        )
+        assert_matches_type(Tool, tool, path=["response"])
+
+    @parametrize
+    def test_method_get_with_all_params(self, client: LlamaStackClient) -> None:
+        tool = client.tools.get(
+            tool_name="tool_name",
+            x_llama_stack_provider_data="X-LlamaStack-ProviderData",
+        )
+        assert_matches_type(Tool, tool, path=["response"])
+
+    @parametrize
+    def test_raw_response_get(self, client: LlamaStackClient) -> None:
+        response = client.tools.with_raw_response.get(
+            tool_name="tool_name",
+        )
+
+        assert response.is_closed is True
+        assert response.http_request.headers.get("X-Stainless-Lang") == "python"
+        tool = response.parse()
+        assert_matches_type(Tool, tool, path=["response"])
+
+    @parametrize
+    def test_streaming_response_get(self, client: LlamaStackClient) -> None:
+        with client.tools.with_streaming_response.get(
+            tool_name="tool_name",
+        ) as response:
+            assert not response.is_closed
+            assert response.http_request.headers.get("X-Stainless-Lang") == "python"
+
+            tool = response.parse()
+            assert_matches_type(Tool, tool, path=["response"])
+
+        assert cast(Any, response.is_closed) is True
+
+
+class TestAsyncTools:
+    parametrize = pytest.mark.parametrize("async_client", [False, True], indirect=True, ids=["loose", "strict"])
+
+    @pytest.mark.skip(
+        reason="currently no good way to test endpoints with content type application/jsonl, Prism mock server will fail"
+    )
+    @parametrize
+    async def test_method_list(self, async_client: AsyncLlamaStackClient) -> None:
+        tool = await async_client.tools.list()
+        assert_matches_type(Tool, tool, path=["response"])
+
+    @pytest.mark.skip(
+        reason="currently no good way to test endpoints with content type application/jsonl, Prism mock server will fail"
+    )
+    @parametrize
+    async def test_method_list_with_all_params(self, async_client: AsyncLlamaStackClient) -> None:
+        tool = await async_client.tools.list(
+            tool_group_id="tool_group_id",
+            x_llama_stack_provider_data="X-LlamaStack-ProviderData",
+        )
+        assert_matches_type(Tool, tool, path=["response"])
+
+    @pytest.mark.skip(
+        reason="currently no good way to test endpoints with content type application/jsonl, Prism mock server will fail"
+    )
+    @parametrize
+    async def test_raw_response_list(self, async_client: AsyncLlamaStackClient) -> None:
+        response = await async_client.tools.with_raw_response.list()
+
+        assert response.is_closed is True
+        assert response.http_request.headers.get("X-Stainless-Lang") == "python"
+        tool = await response.parse()
+        assert_matches_type(Tool, tool, path=["response"])
+
+    @pytest.mark.skip(
+        reason="currently no good way to test endpoints with content type application/jsonl, Prism mock server will fail"
+    )
+    @parametrize
+    async def test_streaming_response_list(self, async_client: AsyncLlamaStackClient) -> None:
+        async with async_client.tools.with_streaming_response.list() as response:
+            assert not response.is_closed
+            assert response.http_request.headers.get("X-Stainless-Lang") == "python"
+
+            tool = await response.parse()
+            assert_matches_type(Tool, tool, path=["response"])
+
+        assert cast(Any, response.is_closed) is True
+
+    @parametrize
+    async def test_method_get(self, async_client: AsyncLlamaStackClient) -> None:
+        tool = await async_client.tools.get(
+            tool_name="tool_name",
+        )
+        assert_matches_type(Tool, tool, path=["response"])
+
+    @parametrize
+    async def test_method_get_with_all_params(self, async_client: AsyncLlamaStackClient) -> None:
+        tool = await async_client.tools.get(
+            tool_name="tool_name",
+            x_llama_stack_provider_data="X-LlamaStack-ProviderData",
+        )
+        assert_matches_type(Tool, tool, path=["response"])
+
+    @parametrize
+    async def test_raw_response_get(self, async_client: AsyncLlamaStackClient) -> None:
+        response = await async_client.tools.with_raw_response.get(
+            tool_name="tool_name",
+        )
+
+        assert response.is_closed is True
+        assert response.http_request.headers.get("X-Stainless-Lang") == "python"
+        tool = await response.parse()
+        assert_matches_type(Tool, tool, path=["response"])
+
+    @parametrize
+    async def test_streaming_response_get(self, async_client: AsyncLlamaStackClient) -> None:
+        async with async_client.tools.with_streaming_response.get(
+            tool_name="tool_name",
+        ) as response:
+            assert not response.is_closed
+            assert response.http_request.headers.get("X-Stainless-Lang") == "python"
+
+            tool = await response.parse()
+            assert_matches_type(Tool, tool, path=["response"])
+
+        assert cast(Any, response.is_closed) is True

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1631,7 +1631,7 @@ class TestAsyncLlamaStackClient:
         import threading
 
         from llama_stack_client._utils import asyncify
-        from llama_stack_client._base_client import get_platform
+        from llama_stack_client._base_client import get_platform 
 
         async def test_main() -> None:
             result = await asyncify(get_platform)()


### PR DESCRIPTION
This PR updates the client SDK with latest tool and agent API changes. Adds utility to define an agent with memory, which abstracts the creation of memory bank and memory tool from the user.
Server changes: https://github.com/meta-llama/llama-stack/pull/673
Test plan:
LLAMA_STACK_CONFIG="/Users/dineshyv/.llama/distributions/llamastack-together/together-run.yaml" pytest -v tests/client-sdk/agents/test_agents.py