### PR TITLE
use FunctionCallToolDefinition from shared_params to avoid type warnings

### DIFF
--- a/src/llama_stack_client/lib/agents/custom_tool.py
+++ b/src/llama_stack_client/lib/agents/custom_tool.py
@@ -8,8 +8,11 @@ import json
 from abc import abstractmethod
 from typing import Dict, List, Union
 
-from llama_stack_client.types import (FunctionCallToolDefinition,
-                                      ToolResponseMessage, UserMessage)
+from llama_stack_client.types import (ToolResponseMessage, UserMessage)
+
+from llama_stack_client.types.shared_params.function_call_tool_definition import \
+    FunctionCallToolDefinition
+
 from llama_stack_client.types.tool_param_definition_param import \
     ToolParamDefinitionParam
 


### PR DESCRIPTION
Prevent/avoid this warning: 

<img width="929" alt="image" src="https://github.com/user-attachments/assets/324c432d-ac3e-40fd-ae8b-bbf90a4f1dfe" />
