### PR TITLE
sync SDK with /version endpoint & llama-stack-client inspect version CLI

### DIFF
--- a/src/llama_stack_client/_client.py
+++ b/src/llama_stack_client/_client.py
@@ -1,8 +1,7 @@
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
-
-import json
 from __future__ import annotations
 
+import json
 import os
 from typing import Any, Union, Mapping
 from typing_extensions import Self, override

--- a/src/llama_stack_client/_client.py
+++ b/src/llama_stack_client/_client.py
@@ -1,62 +1,61 @@
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
+import json
 from __future__ import annotations
 
-import json
 import os
-from typing import Any, Mapping, Union
-
-import httpx
+from typing import Any, Union, Mapping
 from typing_extensions import Self, override
 
+import httpx
+
 from . import _exceptions
-from ._base_client import (
-    DEFAULT_MAX_RETRIES,
-    AsyncAPIClient,
-    SyncAPIClient,
-)
-from ._exceptions import APIStatusError
 from ._qs import Querystring
-from ._streaming import AsyncStream as AsyncStream
-from ._streaming import Stream as Stream
 from ._types import (
     NOT_GIVEN,
-    NotGiven,
     Omit,
+    Timeout,
+    NotGiven,
+    Transport,
     ProxiesTypes,
     RequestOptions,
-    Timeout,
-    Transport,
 )
 from ._utils import (
-    get_async_library,
     is_given,
+    get_async_library,
 )
 from ._version import __version__
 from .resources import (
-    batch_inference,
-    datasetio,
-    datasets,
-    eval_tasks,
-    inference,
-    inspect,
+    tools,
     memory,
-    memory_banks,
     models,
-    providers,
     routes,
     safety,
+    inspect,
     scoring,
-    scoring_functions,
     shields,
-    synthetic_data_generation,
+    datasets,
+    datasetio,
+    inference,
+    providers,
     telemetry,
-    tool_runtime,
+    eval_tasks,
     toolgroups,
-    tools,
+    memory_banks,
+    tool_runtime,
+    batch_inference,
+    scoring_functions,
+    synthetic_data_generation,
 )
-from .resources.agents import agents
+from ._streaming import Stream as Stream, AsyncStream as AsyncStream
+from ._exceptions import APIStatusError
+from ._base_client import (
+    DEFAULT_MAX_RETRIES,
+    SyncAPIClient,
+    AsyncAPIClient,
+)
 from .resources.eval import eval
+from .resources.agents import agents
 from .resources.post_training import post_training
 
 __all__ = [
@@ -127,7 +126,7 @@ class LlamaStackClient(SyncAPIClient):
         if base_url is None:
             base_url = os.environ.get("LLAMA_STACK_CLIENT_BASE_URL")
         if base_url is None:
-            base_url = "http://any-hosted-llama-stack.com"
+            base_url = f"http://any-hosted-llama-stack.com"
 
         if provider_data is not None:
             if default_headers is None:
@@ -162,9 +161,7 @@ class LlamaStackClient(SyncAPIClient):
         self.routes = routes.RoutesResource(self)
         self.safety = safety.SafetyResource(self)
         self.shields = shields.ShieldsResource(self)
-        self.synthetic_data_generation = (
-            synthetic_data_generation.SyntheticDataGenerationResource(self)
-        )
+        self.synthetic_data_generation = synthetic_data_generation.SyntheticDataGenerationResource(self)
         self.telemetry = telemetry.TelemetryResource(self)
         self.datasetio = datasetio.DatasetioResource(self)
         self.scoring = scoring.ScoringResource(self)
@@ -204,14 +201,10 @@ class LlamaStackClient(SyncAPIClient):
         Create a new client instance re-using the same options given to the current client with optional overriding.
         """
         if default_headers is not None and set_default_headers is not None:
-            raise ValueError(
-                "The `default_headers` and `set_default_headers` arguments are mutually exclusive"
-            )
+            raise ValueError("The `default_headers` and `set_default_headers` arguments are mutually exclusive")
 
         if default_query is not None and set_default_query is not None:
-            raise ValueError(
-                "The `default_query` and `set_default_query` arguments are mutually exclusive"
-            )
+            raise ValueError("The `default_query` and `set_default_query` arguments are mutually exclusive")
 
         headers = self._custom_headers
         if default_headers is not None:
@@ -252,14 +245,10 @@ class LlamaStackClient(SyncAPIClient):
             return _exceptions.BadRequestError(err_msg, response=response, body=body)
 
         if response.status_code == 401:
-            return _exceptions.AuthenticationError(
-                err_msg, response=response, body=body
-            )
+            return _exceptions.AuthenticationError(err_msg, response=response, body=body)
 
         if response.status_code == 403:
-            return _exceptions.PermissionDeniedError(
-                err_msg, response=response, body=body
-            )
+            return _exceptions.PermissionDeniedError(err_msg, response=response, body=body)
 
         if response.status_code == 404:
             return _exceptions.NotFoundError(err_msg, response=response, body=body)
@@ -268,17 +257,13 @@ class LlamaStackClient(SyncAPIClient):
             return _exceptions.ConflictError(err_msg, response=response, body=body)
 
         if response.status_code == 422:
-            return _exceptions.UnprocessableEntityError(
-                err_msg, response=response, body=body
-            )
+            return _exceptions.UnprocessableEntityError(err_msg, response=response, body=body)
 
         if response.status_code == 429:
             return _exceptions.RateLimitError(err_msg, response=response, body=body)
 
         if response.status_code >= 500:
-            return _exceptions.InternalServerError(
-                err_msg, response=response, body=body
-            )
+            return _exceptions.InternalServerError(err_msg, response=response, body=body)
         return APIStatusError(err_msg, response=response, body=body)
 
 
@@ -300,9 +285,7 @@ class AsyncLlamaStackClient(AsyncAPIClient):
     routes: routes.AsyncRoutesResource
     safety: safety.AsyncSafetyResource
     shields: shields.AsyncShieldsResource
-    synthetic_data_generation: (
-        synthetic_data_generation.AsyncSyntheticDataGenerationResource
-    )
+    synthetic_data_generation: synthetic_data_generation.AsyncSyntheticDataGenerationResource
     telemetry: telemetry.AsyncTelemetryResource
     datasetio: datasetio.AsyncDatasetioResource
     scoring: scoring.AsyncScoringResource
@@ -340,7 +323,7 @@ class AsyncLlamaStackClient(AsyncAPIClient):
         if base_url is None:
             base_url = os.environ.get("LLAMA_STACK_CLIENT_BASE_URL")
         if base_url is None:
-            base_url = "http://any-hosted-llama-stack.com"
+            base_url = f"http://any-hosted-llama-stack.com"
 
         if provider_data is not None:
             if default_headers is None:
@@ -375,9 +358,7 @@ class AsyncLlamaStackClient(AsyncAPIClient):
         self.routes = routes.AsyncRoutesResource(self)
         self.safety = safety.AsyncSafetyResource(self)
         self.shields = shields.AsyncShieldsResource(self)
-        self.synthetic_data_generation = (
-            synthetic_data_generation.AsyncSyntheticDataGenerationResource(self)
-        )
+        self.synthetic_data_generation = synthetic_data_generation.AsyncSyntheticDataGenerationResource(self)
         self.telemetry = telemetry.AsyncTelemetryResource(self)
         self.datasetio = datasetio.AsyncDatasetioResource(self)
         self.scoring = scoring.AsyncScoringResource(self)
@@ -417,14 +398,10 @@ class AsyncLlamaStackClient(AsyncAPIClient):
         Create a new client instance re-using the same options given to the current client with optional overriding.
         """
         if default_headers is not None and set_default_headers is not None:
-            raise ValueError(
-                "The `default_headers` and `set_default_headers` arguments are mutually exclusive"
-            )
+            raise ValueError("The `default_headers` and `set_default_headers` arguments are mutually exclusive")
 
         if default_query is not None and set_default_query is not None:
-            raise ValueError(
-                "The `default_query` and `set_default_query` arguments are mutually exclusive"
-            )
+            raise ValueError("The `default_query` and `set_default_query` arguments are mutually exclusive")
 
         headers = self._custom_headers
         if default_headers is not None:
@@ -465,14 +442,10 @@ class AsyncLlamaStackClient(AsyncAPIClient):
             return _exceptions.BadRequestError(err_msg, response=response, body=body)
 
         if response.status_code == 401:
-            return _exceptions.AuthenticationError(
-                err_msg, response=response, body=body
-            )
+            return _exceptions.AuthenticationError(err_msg, response=response, body=body)
 
         if response.status_code == 403:
-            return _exceptions.PermissionDeniedError(
-                err_msg, response=response, body=body
-            )
+            return _exceptions.PermissionDeniedError(err_msg, response=response, body=body)
 
         if response.status_code == 404:
             return _exceptions.NotFoundError(err_msg, response=response, body=body)
@@ -481,232 +454,138 @@ class AsyncLlamaStackClient(AsyncAPIClient):
             return _exceptions.ConflictError(err_msg, response=response, body=body)
 
         if response.status_code == 422:
-            return _exceptions.UnprocessableEntityError(
-                err_msg, response=response, body=body
-            )
+            return _exceptions.UnprocessableEntityError(err_msg, response=response, body=body)
 
         if response.status_code == 429:
             return _exceptions.RateLimitError(err_msg, response=response, body=body)
 
         if response.status_code >= 500:
-            return _exceptions.InternalServerError(
-                err_msg, response=response, body=body
-            )
+            return _exceptions.InternalServerError(err_msg, response=response, body=body)
         return APIStatusError(err_msg, response=response, body=body)
 
 
 class LlamaStackClientWithRawResponse:
     def __init__(self, client: LlamaStackClient) -> None:
-        self.toolgroups = toolgroups.ToolgroupsResourceWithRawResponse(
-            client.toolgroups
-        )
+        self.toolgroups = toolgroups.ToolgroupsResourceWithRawResponse(client.toolgroups)
         self.tools = tools.ToolsResourceWithRawResponse(client.tools)
-        self.tool_runtime = tool_runtime.ToolRuntimeResourceWithRawResponse(
-            client.tool_runtime
-        )
+        self.tool_runtime = tool_runtime.ToolRuntimeResourceWithRawResponse(client.tool_runtime)
         self.agents = agents.AgentsResourceWithRawResponse(client.agents)
-        self.batch_inference = batch_inference.BatchInferenceResourceWithRawResponse(
-            client.batch_inference
-        )
+        self.batch_inference = batch_inference.BatchInferenceResourceWithRawResponse(client.batch_inference)
         self.datasets = datasets.DatasetsResourceWithRawResponse(client.datasets)
         self.eval = eval.EvalResourceWithRawResponse(client.eval)
         self.inspect = inspect.InspectResourceWithRawResponse(client.inspect)
         self.inference = inference.InferenceResourceWithRawResponse(client.inference)
         self.memory = memory.MemoryResourceWithRawResponse(client.memory)
-        self.memory_banks = memory_banks.MemoryBanksResourceWithRawResponse(
-            client.memory_banks
-        )
+        self.memory_banks = memory_banks.MemoryBanksResourceWithRawResponse(client.memory_banks)
         self.models = models.ModelsResourceWithRawResponse(client.models)
-        self.post_training = post_training.PostTrainingResourceWithRawResponse(
-            client.post_training
-        )
+        self.post_training = post_training.PostTrainingResourceWithRawResponse(client.post_training)
         self.providers = providers.ProvidersResourceWithRawResponse(client.providers)
         self.routes = routes.RoutesResourceWithRawResponse(client.routes)
         self.safety = safety.SafetyResourceWithRawResponse(client.safety)
         self.shields = shields.ShieldsResourceWithRawResponse(client.shields)
-        self.synthetic_data_generation = (
-            synthetic_data_generation.SyntheticDataGenerationResourceWithRawResponse(
-                client.synthetic_data_generation
-            )
+        self.synthetic_data_generation = synthetic_data_generation.SyntheticDataGenerationResourceWithRawResponse(
+            client.synthetic_data_generation
         )
         self.telemetry = telemetry.TelemetryResourceWithRawResponse(client.telemetry)
         self.datasetio = datasetio.DatasetioResourceWithRawResponse(client.datasetio)
         self.scoring = scoring.ScoringResourceWithRawResponse(client.scoring)
-        self.scoring_functions = (
-            scoring_functions.ScoringFunctionsResourceWithRawResponse(
-                client.scoring_functions
-            )
-        )
+        self.scoring_functions = scoring_functions.ScoringFunctionsResourceWithRawResponse(client.scoring_functions)
         self.eval_tasks = eval_tasks.EvalTasksResourceWithRawResponse(client.eval_tasks)
 
 
 class AsyncLlamaStackClientWithRawResponse:
     def __init__(self, client: AsyncLlamaStackClient) -> None:
-        self.toolgroups = toolgroups.AsyncToolgroupsResourceWithRawResponse(
-            client.toolgroups
-        )
+        self.toolgroups = toolgroups.AsyncToolgroupsResourceWithRawResponse(client.toolgroups)
         self.tools = tools.AsyncToolsResourceWithRawResponse(client.tools)
-        self.tool_runtime = tool_runtime.AsyncToolRuntimeResourceWithRawResponse(
-            client.tool_runtime
-        )
+        self.tool_runtime = tool_runtime.AsyncToolRuntimeResourceWithRawResponse(client.tool_runtime)
         self.agents = agents.AsyncAgentsResourceWithRawResponse(client.agents)
-        self.batch_inference = (
-            batch_inference.AsyncBatchInferenceResourceWithRawResponse(
-                client.batch_inference
-            )
-        )
+        self.batch_inference = batch_inference.AsyncBatchInferenceResourceWithRawResponse(client.batch_inference)
         self.datasets = datasets.AsyncDatasetsResourceWithRawResponse(client.datasets)
         self.eval = eval.AsyncEvalResourceWithRawResponse(client.eval)
         self.inspect = inspect.AsyncInspectResourceWithRawResponse(client.inspect)
-        self.inference = inference.AsyncInferenceResourceWithRawResponse(
-            client.inference
-        )
+        self.inference = inference.AsyncInferenceResourceWithRawResponse(client.inference)
         self.memory = memory.AsyncMemoryResourceWithRawResponse(client.memory)
-        self.memory_banks = memory_banks.AsyncMemoryBanksResourceWithRawResponse(
-            client.memory_banks
-        )
+        self.memory_banks = memory_banks.AsyncMemoryBanksResourceWithRawResponse(client.memory_banks)
         self.models = models.AsyncModelsResourceWithRawResponse(client.models)
-        self.post_training = post_training.AsyncPostTrainingResourceWithRawResponse(
-            client.post_training
-        )
-        self.providers = providers.AsyncProvidersResourceWithRawResponse(
-            client.providers
-        )
+        self.post_training = post_training.AsyncPostTrainingResourceWithRawResponse(client.post_training)
+        self.providers = providers.AsyncProvidersResourceWithRawResponse(client.providers)
         self.routes = routes.AsyncRoutesResourceWithRawResponse(client.routes)
         self.safety = safety.AsyncSafetyResourceWithRawResponse(client.safety)
         self.shields = shields.AsyncShieldsResourceWithRawResponse(client.shields)
         self.synthetic_data_generation = synthetic_data_generation.AsyncSyntheticDataGenerationResourceWithRawResponse(
             client.synthetic_data_generation
         )
-        self.telemetry = telemetry.AsyncTelemetryResourceWithRawResponse(
-            client.telemetry
-        )
-        self.datasetio = datasetio.AsyncDatasetioResourceWithRawResponse(
-            client.datasetio
-        )
+        self.telemetry = telemetry.AsyncTelemetryResourceWithRawResponse(client.telemetry)
+        self.datasetio = datasetio.AsyncDatasetioResourceWithRawResponse(client.datasetio)
         self.scoring = scoring.AsyncScoringResourceWithRawResponse(client.scoring)
-        self.scoring_functions = (
-            scoring_functions.AsyncScoringFunctionsResourceWithRawResponse(
-                client.scoring_functions
-            )
+        self.scoring_functions = scoring_functions.AsyncScoringFunctionsResourceWithRawResponse(
+            client.scoring_functions
         )
-        self.eval_tasks = eval_tasks.AsyncEvalTasksResourceWithRawResponse(
-            client.eval_tasks
-        )
+        self.eval_tasks = eval_tasks.AsyncEvalTasksResourceWithRawResponse(client.eval_tasks)
 
 
 class LlamaStackClientWithStreamedResponse:
     def __init__(self, client: LlamaStackClient) -> None:
-        self.toolgroups = toolgroups.ToolgroupsResourceWithStreamingResponse(
-            client.toolgroups
-        )
+        self.toolgroups = toolgroups.ToolgroupsResourceWithStreamingResponse(client.toolgroups)
         self.tools = tools.ToolsResourceWithStreamingResponse(client.tools)
-        self.tool_runtime = tool_runtime.ToolRuntimeResourceWithStreamingResponse(
-            client.tool_runtime
-        )
+        self.tool_runtime = tool_runtime.ToolRuntimeResourceWithStreamingResponse(client.tool_runtime)
         self.agents = agents.AgentsResourceWithStreamingResponse(client.agents)
-        self.batch_inference = (
-            batch_inference.BatchInferenceResourceWithStreamingResponse(
-                client.batch_inference
-            )
-        )
+        self.batch_inference = batch_inference.BatchInferenceResourceWithStreamingResponse(client.batch_inference)
         self.datasets = datasets.DatasetsResourceWithStreamingResponse(client.datasets)
         self.eval = eval.EvalResourceWithStreamingResponse(client.eval)
         self.inspect = inspect.InspectResourceWithStreamingResponse(client.inspect)
-        self.inference = inference.InferenceResourceWithStreamingResponse(
-            client.inference
-        )
+        self.inference = inference.InferenceResourceWithStreamingResponse(client.inference)
         self.memory = memory.MemoryResourceWithStreamingResponse(client.memory)
-        self.memory_banks = memory_banks.MemoryBanksResourceWithStreamingResponse(
-            client.memory_banks
-        )
+        self.memory_banks = memory_banks.MemoryBanksResourceWithStreamingResponse(client.memory_banks)
         self.models = models.ModelsResourceWithStreamingResponse(client.models)
-        self.post_training = post_training.PostTrainingResourceWithStreamingResponse(
-            client.post_training
-        )
-        self.providers = providers.ProvidersResourceWithStreamingResponse(
-            client.providers
-        )
+        self.post_training = post_training.PostTrainingResourceWithStreamingResponse(client.post_training)
+        self.providers = providers.ProvidersResourceWithStreamingResponse(client.providers)
         self.routes = routes.RoutesResourceWithStreamingResponse(client.routes)
         self.safety = safety.SafetyResourceWithStreamingResponse(client.safety)
         self.shields = shields.ShieldsResourceWithStreamingResponse(client.shields)
         self.synthetic_data_generation = synthetic_data_generation.SyntheticDataGenerationResourceWithStreamingResponse(
             client.synthetic_data_generation
         )
-        self.telemetry = telemetry.TelemetryResourceWithStreamingResponse(
-            client.telemetry
-        )
-        self.datasetio = datasetio.DatasetioResourceWithStreamingResponse(
-            client.datasetio
-        )
+        self.telemetry = telemetry.TelemetryResourceWithStreamingResponse(client.telemetry)
+        self.datasetio = datasetio.DatasetioResourceWithStreamingResponse(client.datasetio)
         self.scoring = scoring.ScoringResourceWithStreamingResponse(client.scoring)
-        self.scoring_functions = (
-            scoring_functions.ScoringFunctionsResourceWithStreamingResponse(
-                client.scoring_functions
-            )
+        self.scoring_functions = scoring_functions.ScoringFunctionsResourceWithStreamingResponse(
+            client.scoring_functions
         )
-        self.eval_tasks = eval_tasks.EvalTasksResourceWithStreamingResponse(
-            client.eval_tasks
-        )
+        self.eval_tasks = eval_tasks.EvalTasksResourceWithStreamingResponse(client.eval_tasks)
 
 
 class AsyncLlamaStackClientWithStreamedResponse:
     def __init__(self, client: AsyncLlamaStackClient) -> None:
-        self.toolgroups = toolgroups.AsyncToolgroupsResourceWithStreamingResponse(
-            client.toolgroups
-        )
+        self.toolgroups = toolgroups.AsyncToolgroupsResourceWithStreamingResponse(client.toolgroups)
         self.tools = tools.AsyncToolsResourceWithStreamingResponse(client.tools)
-        self.tool_runtime = tool_runtime.AsyncToolRuntimeResourceWithStreamingResponse(
-            client.tool_runtime
-        )
+        self.tool_runtime = tool_runtime.AsyncToolRuntimeResourceWithStreamingResponse(client.tool_runtime)
         self.agents = agents.AsyncAgentsResourceWithStreamingResponse(client.agents)
-        self.batch_inference = (
-            batch_inference.AsyncBatchInferenceResourceWithStreamingResponse(
-                client.batch_inference
-            )
-        )
-        self.datasets = datasets.AsyncDatasetsResourceWithStreamingResponse(
-            client.datasets
-        )
+        self.batch_inference = batch_inference.AsyncBatchInferenceResourceWithStreamingResponse(client.batch_inference)
+        self.datasets = datasets.AsyncDatasetsResourceWithStreamingResponse(client.datasets)
         self.eval = eval.AsyncEvalResourceWithStreamingResponse(client.eval)
         self.inspect = inspect.AsyncInspectResourceWithStreamingResponse(client.inspect)
-        self.inference = inference.AsyncInferenceResourceWithStreamingResponse(
-            client.inference
-        )
+        self.inference = inference.AsyncInferenceResourceWithStreamingResponse(client.inference)
         self.memory = memory.AsyncMemoryResourceWithStreamingResponse(client.memory)
-        self.memory_banks = memory_banks.AsyncMemoryBanksResourceWithStreamingResponse(
-            client.memory_banks
-        )
+        self.memory_banks = memory_banks.AsyncMemoryBanksResourceWithStreamingResponse(client.memory_banks)
         self.models = models.AsyncModelsResourceWithStreamingResponse(client.models)
-        self.post_training = (
-            post_training.AsyncPostTrainingResourceWithStreamingResponse(
-                client.post_training
-            )
-        )
-        self.providers = providers.AsyncProvidersResourceWithStreamingResponse(
-            client.providers
-        )
+        self.post_training = post_training.AsyncPostTrainingResourceWithStreamingResponse(client.post_training)
+        self.providers = providers.AsyncProvidersResourceWithStreamingResponse(client.providers)
         self.routes = routes.AsyncRoutesResourceWithStreamingResponse(client.routes)
         self.safety = safety.AsyncSafetyResourceWithStreamingResponse(client.safety)
         self.shields = shields.AsyncShieldsResourceWithStreamingResponse(client.shields)
-        self.synthetic_data_generation = synthetic_data_generation.AsyncSyntheticDataGenerationResourceWithStreamingResponse(
-            client.synthetic_data_generation
-        )
-        self.telemetry = telemetry.AsyncTelemetryResourceWithStreamingResponse(
-            client.telemetry
-        )
-        self.datasetio = datasetio.AsyncDatasetioResourceWithStreamingResponse(
-            client.datasetio
-        )
-        self.scoring = scoring.AsyncScoringResourceWithStreamingResponse(client.scoring)
-        self.scoring_functions = (
-            scoring_functions.AsyncScoringFunctionsResourceWithStreamingResponse(
-                client.scoring_functions
+        self.synthetic_data_generation = (
+            synthetic_data_generation.AsyncSyntheticDataGenerationResourceWithStreamingResponse(
+                client.synthetic_data_generation
             )
         )
-        self.eval_tasks = eval_tasks.AsyncEvalTasksResourceWithStreamingResponse(
-            client.eval_tasks
+        self.telemetry = telemetry.AsyncTelemetryResourceWithStreamingResponse(client.telemetry)
+        self.datasetio = datasetio.AsyncDatasetioResourceWithStreamingResponse(client.datasetio)
+        self.scoring = scoring.AsyncScoringResourceWithStreamingResponse(client.scoring)
+        self.scoring_functions = scoring_functions.AsyncScoringFunctionsResourceWithStreamingResponse(
+            client.scoring_functions
         )
+        self.eval_tasks = eval_tasks.AsyncEvalTasksResourceWithStreamingResponse(client.eval_tasks)
 
 
 Client = LlamaStackClient

--- a/src/llama_stack_client/lib/agents/agent.py
+++ b/src/llama_stack_client/lib/agents/agent.py
@@ -8,7 +8,8 @@ from typing import List, Optional, Tuple, Union
 from llama_stack_client import LlamaStackClient
 from llama_stack_client.types import ToolResponseMessage, UserMessage
 from llama_stack_client.types.agent_create_params import AgentConfig
-from llama_stack_client.types.agents.turn_create_params import Document, Toolgroup
+from llama_stack_client.types.agents.turn_create_params import (Document,
+                                                                Toolgroup)
 
 from .client_tool import ClientTool
 

--- a/src/llama_stack_client/lib/agents/client_tool.py
+++ b/src/llama_stack_client/lib/agents/client_tool.py
@@ -9,10 +9,7 @@ from abc import abstractmethod
 from typing import Dict, List, Union
 
 from llama_stack_client.types import ToolResponseMessage, UserMessage
-from llama_stack_client.types.tool_def_param import (
-    Parameter,
-    ToolDefParam,
-)
+from llama_stack_client.types.tool_def_param import Parameter, ToolDefParam
 
 
 class ClientTool:

--- a/src/llama_stack_client/lib/cli/inspect/__init__.py
+++ b/src/llama_stack_client/lib/cli/inspect/__init__.py
@@ -1,0 +1,4 @@
+from .inspect import inspect
+
+__all__ = ["inspect"]
+

--- a/src/llama_stack_client/lib/cli/inspect/inspect.py
+++ b/src/llama_stack_client/lib/cli/inspect/inspect.py
@@ -1,0 +1,13 @@
+import click
+
+from .version import inspect_version
+
+
+@click.group()
+def inspect():
+    """Query details about available versions on Llama Stack distribution."""
+    pass
+
+
+# Register subcommands
+inspect.add_command(inspect_version)

--- a/src/llama_stack_client/lib/cli/inspect/version.py
+++ b/src/llama_stack_client/lib/cli/inspect/version.py
@@ -1,0 +1,16 @@
+import click
+from rich.console import Console
+from rich.table import Table
+
+from ..common.utils import handle_client_errors
+
+
+@click.command("version")
+@click.pass_context
+@handle_client_errors("inspect version")
+def inspect_version(ctx):
+    """Show available providers on distribution endpoint"""
+    client = ctx.obj["client"]
+    console = Console()
+    version_response = client.inspect.version()
+    console.print(version_response)

--- a/src/llama_stack_client/lib/cli/llama_stack_client.py
+++ b/src/llama_stack_client/lib/cli/llama_stack_client.py
@@ -10,6 +10,7 @@ import click
 import yaml
 
 from llama_stack_client import LlamaStackClient
+from importlib.metadata import version
 
 from .configure import configure
 from .constants import get_config_file_path
@@ -23,9 +24,10 @@ from .post_training import post_training
 from .providers import providers
 from .scoring_functions import scoring_functions
 from .shields import shields
-
+from .inspect import inspect
 
 @click.group()
+@click.version_option(version=version("llama-stack-client"), prog_name="llama-stack-client")
 @click.option("--endpoint", type=str, help="Llama Stack distribution endpoint", default="")
 @click.option("--config", type=str, help="Path to config file", default=None)
 @click.pass_context
@@ -77,6 +79,7 @@ cli.add_command(scoring_functions, "scoring_functions")
 cli.add_command(eval, "eval")
 cli.add_command(inference, "inference")
 cli.add_command(post_training, "post_training")
+cli.add_command(inspect, "inspect")
 
 
 def main():

--- a/src/llama_stack_client/lib/cli/post_training/post_training.py
+++ b/src/llama_stack_client/lib/cli/post_training/post_training.py
@@ -7,12 +7,10 @@
 from typing import Optional
 
 import click
+from rich.console import Console
 
 from llama_stack_client.types.post_training_supervised_fine_tune_params import (
-    AlgorithmConfig,
-    TrainingConfig,
-)
-from rich.console import Console
+    AlgorithmConfig, TrainingConfig)
 
 from ..common.utils import handle_client_errors
 

--- a/src/llama_stack_client/resources/inspect.py
+++ b/src/llama_stack_client/resources/inspect.py
@@ -16,6 +16,7 @@ from .._response import (
 )
 from .._base_client import make_request_options
 from ..types.health_info import HealthInfo
+from ..types.version_info import VersionInfo
 
 __all__ = ["InspectResource", "AsyncInspectResource"]
 
@@ -73,6 +74,39 @@ class InspectResource(SyncAPIResource):
             cast_to=HealthInfo,
         )
 
+    def version(
+        self,
+        *,
+        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
+        # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
+        # The extra values given here take precedence over values defined on the client or passed to this method.
+        extra_headers: Headers | None = None,
+        extra_query: Query | None = None,
+        extra_body: Body | None = None,
+        timeout: float | httpx.Timeout | None | NotGiven = NOT_GIVEN,
+    ) -> VersionInfo:
+        """
+        Args:
+          extra_headers: Send extra headers
+
+          extra_query: Add additional query parameters to the request
+
+          extra_body: Add additional JSON properties to the request
+
+          timeout: Override the client-level default timeout for this request, in seconds
+        """
+        extra_headers = {
+            **strip_not_given({"X-LlamaStack-ProviderData": x_llama_stack_provider_data}),
+            **(extra_headers or {}),
+        }
+        return self._get(
+            "/alpha/version",
+            options=make_request_options(
+                extra_headers=extra_headers, extra_query=extra_query, extra_body=extra_body, timeout=timeout
+            ),
+            cast_to=VersionInfo,
+        )
+
 
 class AsyncInspectResource(AsyncAPIResource):
     @cached_property
@@ -127,6 +161,39 @@ class AsyncInspectResource(AsyncAPIResource):
             cast_to=HealthInfo,
         )
 
+    async def version(
+        self,
+        *,
+        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
+        # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
+        # The extra values given here take precedence over values defined on the client or passed to this method.
+        extra_headers: Headers | None = None,
+        extra_query: Query | None = None,
+        extra_body: Body | None = None,
+        timeout: float | httpx.Timeout | None | NotGiven = NOT_GIVEN,
+    ) -> VersionInfo:
+        """
+        Args:
+          extra_headers: Send extra headers
+
+          extra_query: Add additional query parameters to the request
+
+          extra_body: Add additional JSON properties to the request
+
+          timeout: Override the client-level default timeout for this request, in seconds
+        """
+        extra_headers = {
+            **strip_not_given({"X-LlamaStack-ProviderData": x_llama_stack_provider_data}),
+            **(extra_headers or {}),
+        }
+        return await self._get(
+            "/alpha/version",
+            options=make_request_options(
+                extra_headers=extra_headers, extra_query=extra_query, extra_body=extra_body, timeout=timeout
+            ),
+            cast_to=VersionInfo,
+        )
+
 
 class InspectResourceWithRawResponse:
     def __init__(self, inspect: InspectResource) -> None:
@@ -134,6 +201,9 @@ class InspectResourceWithRawResponse:
 
         self.health = to_raw_response_wrapper(
             inspect.health,
+        )
+        self.version = to_raw_response_wrapper(
+            inspect.version,
         )
 
 
@@ -144,6 +214,9 @@ class AsyncInspectResourceWithRawResponse:
         self.health = async_to_raw_response_wrapper(
             inspect.health,
         )
+        self.version = async_to_raw_response_wrapper(
+            inspect.version,
+        )
 
 
 class InspectResourceWithStreamingResponse:
@@ -153,6 +226,9 @@ class InspectResourceWithStreamingResponse:
         self.health = to_streamed_response_wrapper(
             inspect.health,
         )
+        self.version = to_streamed_response_wrapper(
+            inspect.version,
+        )
 
 
 class AsyncInspectResourceWithStreamingResponse:
@@ -161,4 +237,7 @@ class AsyncInspectResourceWithStreamingResponse:
 
         self.health = async_to_streamed_response_wrapper(
             inspect.health,
+        )
+        self.version = async_to_streamed_response_wrapper(
+            inspect.version,
         )

--- a/src/llama_stack_client/types/__init__.py
+++ b/src/llama_stack_client/types/__init__.py
@@ -30,6 +30,7 @@ from .route_info import RouteInfo as RouteInfo
 from .scoring_fn import ScoringFn as ScoringFn
 from .tool_group import ToolGroup as ToolGroup
 from .health_info import HealthInfo as HealthInfo
+from .version_info import VersionInfo as VersionInfo
 from .provider_info import ProviderInfo as ProviderInfo
 from .tool_response import ToolResponse as ToolResponse
 from .inference_step import InferenceStep as InferenceStep

--- a/src/llama_stack_client/types/version_info.py
+++ b/src/llama_stack_client/types/version_info.py
@@ -1,0 +1,10 @@
+# File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
+
+
+from .._models import BaseModel
+
+__all__ = ["VersionInfo"]
+
+
+class VersionInfo(BaseModel):
+    version: str

--- a/tests/api_resources/test_inspect.py
+++ b/tests/api_resources/test_inspect.py
@@ -9,7 +9,7 @@ import pytest
 
 from tests.utils import assert_matches_type
 from llama_stack_client import LlamaStackClient, AsyncLlamaStackClient
-from llama_stack_client.types import HealthInfo
+from llama_stack_client.types import HealthInfo, VersionInfo
 
 base_url = os.environ.get("TEST_API_BASE_URL", "http://127.0.0.1:4010")
 
@@ -49,6 +49,38 @@ class TestInspect:
 
         assert cast(Any, response.is_closed) is True
 
+    @parametrize
+    def test_method_version(self, client: LlamaStackClient) -> None:
+        inspect = client.inspect.version()
+        assert_matches_type(VersionInfo, inspect, path=["response"])
+
+    @parametrize
+    def test_method_version_with_all_params(self, client: LlamaStackClient) -> None:
+        inspect = client.inspect.version(
+            x_llama_stack_provider_data="X-LlamaStack-ProviderData",
+        )
+        assert_matches_type(VersionInfo, inspect, path=["response"])
+
+    @parametrize
+    def test_raw_response_version(self, client: LlamaStackClient) -> None:
+        response = client.inspect.with_raw_response.version()
+
+        assert response.is_closed is True
+        assert response.http_request.headers.get("X-Stainless-Lang") == "python"
+        inspect = response.parse()
+        assert_matches_type(VersionInfo, inspect, path=["response"])
+
+    @parametrize
+    def test_streaming_response_version(self, client: LlamaStackClient) -> None:
+        with client.inspect.with_streaming_response.version() as response:
+            assert not response.is_closed
+            assert response.http_request.headers.get("X-Stainless-Lang") == "python"
+
+            inspect = response.parse()
+            assert_matches_type(VersionInfo, inspect, path=["response"])
+
+        assert cast(Any, response.is_closed) is True
+
 
 class TestAsyncInspect:
     parametrize = pytest.mark.parametrize("async_client", [False, True], indirect=True, ids=["loose", "strict"])
@@ -82,5 +114,37 @@ class TestAsyncInspect:
 
             inspect = await response.parse()
             assert_matches_type(HealthInfo, inspect, path=["response"])
+
+        assert cast(Any, response.is_closed) is True
+
+    @parametrize
+    async def test_method_version(self, async_client: AsyncLlamaStackClient) -> None:
+        inspect = await async_client.inspect.version()
+        assert_matches_type(VersionInfo, inspect, path=["response"])
+
+    @parametrize
+    async def test_method_version_with_all_params(self, async_client: AsyncLlamaStackClient) -> None:
+        inspect = await async_client.inspect.version(
+            x_llama_stack_provider_data="X-LlamaStack-ProviderData",
+        )
+        assert_matches_type(VersionInfo, inspect, path=["response"])
+
+    @parametrize
+    async def test_raw_response_version(self, async_client: AsyncLlamaStackClient) -> None:
+        response = await async_client.inspect.with_raw_response.version()
+
+        assert response.is_closed is True
+        assert response.http_request.headers.get("X-Stainless-Lang") == "python"
+        inspect = await response.parse()
+        assert_matches_type(VersionInfo, inspect, path=["response"])
+
+    @parametrize
+    async def test_streaming_response_version(self, async_client: AsyncLlamaStackClient) -> None:
+        async with async_client.inspect.with_streaming_response.version() as response:
+            assert not response.is_closed
+            assert response.http_request.headers.get("X-Stainless-Lang") == "python"
+
+            inspect = await response.parse()
+            assert_matches_type(VersionInfo, inspect, path=["response"])
 
         assert cast(Any, response.is_closed) is True

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1631,7 +1631,7 @@ class TestAsyncLlamaStackClient:
         import threading
 
         from llama_stack_client._utils import asyncify
-        from llama_stack_client._base_client import get_platform 
+        from llama_stack_client._base_client import get_platform
 
         async def test_main() -> None:
             result = await asyncify(get_platform)()


### PR DESCRIPTION
- sync SDK with /version endpoint
- llama-stack-client inspect version CLI

**Notes on version**
```
llama-stack-client --version
```
- this print outs the version of the llama-stack-client package (equivalent to pip list | grep llama-stack-client)
<img width="336" alt="image" src="https://github.com/user-attachments/assets/5717bb3a-2828-47ee-87c4-49342d962fbc" />


```
llama-stack-client inspect version
```
- this gets the server endpoint's version
<img width="501" alt="image" src="https://github.com/user-attachments/assets/bfc04750-ae1f-456c-b0d6-83b80fea884d" />
