### PR TITLE
[CICD] testpypi workflow add repository_dispatch trigger from llama-stack

### DIFF
--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -1,12 +1,16 @@
 name: Publish Python 🐍 distribution 📦 to TestPyPI
 
 on:
+  repository_dispatch:  # on trigger from llama-stack
+    types: [build-client-package]
+
   workflow_dispatch:  # Keep manual trigger
     inputs:
       rc_version:
         description: 'RC version number (e.g., 1, 2, 3)'
         required: true
         type: string
+
   schedule:
     - cron: "0 0 * * *"  # Run every day at midnight
 
@@ -33,6 +37,11 @@ jobs:
       run: |
         sed -i 's/version = "\([^"]*\)"/version = "\1rc${{ inputs.rc_version }}"/' pyproject.toml
         sed -i 's/__version__ = "\([^"]*\)"/__version__ = "\1rc${{ inputs.rc_version }}"/' src/llama_stack_client/_version.py
+    - name: Update version for repository_dispatch
+      if: github.event_name == 'repository_dispatch' && github.event.client_payload.source == 'llama-stack-nightly'
+      run: |
+        sed -i 's/version = "\([^"]*\)"/version = "\1${{ github.event.client_payload.version }}"/' pyproject.toml
+        sed -i 's/__version__ = "\([^"]*\)"/__version__ = "\1${{ github.event.client_payload.version }}"/' src/llama_stack_client/_version.py
     - name: Set up Python
       uses: actions/setup-python@v5
       with:


### PR DESCRIPTION
# What does this PR do?

- add a workflow dispatch trigger for accepting repository_dispatch from llama-stack


## Test Plan

- After merging to master, test with llama-stack workflow trigger
```
curl -L \
  -X POST \
  -H "Accept: application/vnd.github+json" \
  -H "Authorization: Bearer PAT_TOKEN" \
  -H "X-GitHub-Api-Version: 2022-11-28" \
  https://api.github.com/repos/meta-llama/llama-stack-client-python/dispatches \
  -d '{"event_type":"build-client-package","client_payload":{"source":"llama-stack-nightly", "version": "rc234"}}'
```

## Sources

Please link relevant resources if necessary.


## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Ran pre-commit to handle lint / formatting issues.
- [ ] Read the [contributor guideline](https://github.com/meta-llama/llama-stack/blob/main/CONTRIBUTING.md),
      Pull Request section?
- [ ] Updated relevant documentation.
- [ ] Wrote necessary unit or integration tests.
