### PR TITLE
Fix import error "cannot import name 'AlgorithmConfig'"

### DIFF
--- a/src/llama_stack_client/lib/cli/post_training/post_training.py
+++ b/src/llama_stack_client/lib/cli/post_training/post_training.py
@@ -10,7 +10,7 @@ import click
 from rich.console import Console
 
 from llama_stack_client.types.post_training_supervised_fine_tune_params import (
-    AlgorithmConfig, TrainingConfig)
+    AlgorithmConfigParam, TrainingConfig)
 
 from ..common.utils import handle_client_errors
 
@@ -35,7 +35,7 @@ def supervised_fine_tune(
     ctx,
     job_uuid: str,
     model: str,
-    algorithm_config: AlgorithmConfig,
+    algorithm_config: AlgorithmConfigParam,
     training_config: TrainingConfig,
     checkpoint_dir: Optional[str],
 ):


### PR DESCRIPTION

Summary:

`llama-stack-client` was broken.

```
llama-stack-client
Traceback (most recent call last):
  File "/opt/homebrew/Caskroom/miniconda/base/envs/llama-stack/bin/llama-stack-client", line 5, in <module>
    from llama_stack_client.lib.cli.llama_stack_client import main
  File "/opt/homebrew/Caskroom/miniconda/base/envs/llama-stack/lib/python3.10/site-packages/llama_stack_client/lib/cli/llama_stack_client.py", line 23, in <module>
    from .post_training import post_training
  File "/opt/homebrew/Caskroom/miniconda/base/envs/llama-stack/lib/python3.10/site-packages/llama_stack_client/lib/cli/post_training/__init__.py", line 7, in <module>
    from .post_training import post_training
  File "/opt/homebrew/Caskroom/miniconda/base/envs/llama-stack/lib/python3.10/site-packages/llama_stack_client/lib/cli/post_training/post_training.py", line 12, in <module>
    from llama_stack_client.types.post_training_supervised_fine_tune_params import (
ImportError: cannot import name 'AlgorithmConfig' from 'llama_stack_client.types.post_training_supervised_fine_tune_params' (/opt/homebrew/Caskroom/miniconda/base/envs/llama-stack/lib/python3.10/site-packages/llama_stack_client/types/post_training_supervised_fine_tune_params.py)
(llama-stack) [25-01-28 16:18:41 1738109921]
```

Test Plan:
* Checkout this rev
* pip install .
* Run the command ``

Output
```
llama-stack-client

Usage: llama-stack-client [OPTIONS] COMMAND [ARGS]...

  Welcome to the LlamaStackClient CLI

Options:
  --version        Show the version and exit.
  --endpoint TEXT  Llama Stack distribution endpoint
  --api-key TEXT   Llama Stack distribution API key
  --config TEXT    Path to config file
  --help           Show this message and exit.

Commands:
  configure          Configure Llama Stack Client CLI
  datasets           Query details about available datasets on Llama...
  eval               Run evaluation tasks
  eval_tasks         Query details about available eval tasks type on...
  inference          Query details about available inference endpoints on...
  inspect            Query details about available versions on Llama...
  models             Query details about available models on Llama Stack...
  post_training      Query details about available post_training...
  providers          Query details about available providers on Llama...
  scoring_functions  Manage scoring functions
  shields            Query details about available safety shields on...
  toolgroups         Query details about available toolgroups on Llama...
  vector_dbs         Query details about available vector dbs on...
```
