### PR TITLE
Sync updates from stainless branch: ashwinb/dev

### DIFF
--- a/src/llama_stack_client/resources/agents/agents.py
+++ b/src/llama_stack_client/resources/agents/agents.py
@@ -32,7 +32,6 @@ from .session import (
 from ..._types import NOT_GIVEN, Body, Query, Headers, NoneType, NotGiven
 from ..._utils import (
     maybe_transform,
-    strip_not_given,
     async_maybe_transform,
 )
 from ..._compat import cached_property
@@ -86,8 +85,6 @@ class AgentsResource(SyncAPIResource):
         self,
         *,
         agent_config: AgentConfig,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -105,15 +102,6 @@ class AgentsResource(SyncAPIResource):
 
           timeout: Override the client-level default timeout for this request, in seconds
         """
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return self._post(
             "/v1/agents",
             body=maybe_transform({"agent_config": agent_config}, agent_create_params.AgentCreateParams),
@@ -127,8 +115,6 @@ class AgentsResource(SyncAPIResource):
         self,
         agent_id: str,
         *,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -149,15 +135,6 @@ class AgentsResource(SyncAPIResource):
         if not agent_id:
             raise ValueError(f"Expected a non-empty value for `agent_id` but received {agent_id!r}")
         extra_headers = {"Accept": "*/*", **(extra_headers or {})}
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return self._delete(
             f"/v1/agents/{agent_id}",
             options=make_request_options(
@@ -203,8 +180,6 @@ class AsyncAgentsResource(AsyncAPIResource):
         self,
         *,
         agent_config: AgentConfig,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -222,15 +197,6 @@ class AsyncAgentsResource(AsyncAPIResource):
 
           timeout: Override the client-level default timeout for this request, in seconds
         """
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return await self._post(
             "/v1/agents",
             body=await async_maybe_transform({"agent_config": agent_config}, agent_create_params.AgentCreateParams),
@@ -244,8 +210,6 @@ class AsyncAgentsResource(AsyncAPIResource):
         self,
         agent_id: str,
         *,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -266,15 +230,6 @@ class AsyncAgentsResource(AsyncAPIResource):
         if not agent_id:
             raise ValueError(f"Expected a non-empty value for `agent_id` but received {agent_id!r}")
         extra_headers = {"Accept": "*/*", **(extra_headers or {})}
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return await self._delete(
             f"/v1/agents/{agent_id}",
             options=make_request_options(

--- a/src/llama_stack_client/resources/agents/session.py
+++ b/src/llama_stack_client/resources/agents/session.py
@@ -9,7 +9,6 @@ import httpx
 from ..._types import NOT_GIVEN, Body, Query, Headers, NoneType, NotGiven
 from ..._utils import (
     maybe_transform,
-    strip_not_given,
     async_maybe_transform,
 )
 from ..._compat import cached_property
@@ -53,8 +52,6 @@ class SessionResource(SyncAPIResource):
         agent_id: str,
         *,
         session_name: str,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -74,15 +71,6 @@ class SessionResource(SyncAPIResource):
         """
         if not agent_id:
             raise ValueError(f"Expected a non-empty value for `agent_id` but received {agent_id!r}")
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return self._post(
             f"/v1/agents/{agent_id}/session",
             body=maybe_transform({"session_name": session_name}, session_create_params.SessionCreateParams),
@@ -98,8 +86,6 @@ class SessionResource(SyncAPIResource):
         *,
         agent_id: str,
         turn_ids: List[str] | NotGiven = NOT_GIVEN,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -121,15 +107,6 @@ class SessionResource(SyncAPIResource):
             raise ValueError(f"Expected a non-empty value for `agent_id` but received {agent_id!r}")
         if not session_id:
             raise ValueError(f"Expected a non-empty value for `session_id` but received {session_id!r}")
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return self._get(
             f"/v1/agents/{agent_id}/session/{session_id}",
             options=make_request_options(
@@ -147,8 +124,6 @@ class SessionResource(SyncAPIResource):
         session_id: str,
         *,
         agent_id: str,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -171,15 +146,6 @@ class SessionResource(SyncAPIResource):
         if not session_id:
             raise ValueError(f"Expected a non-empty value for `session_id` but received {session_id!r}")
         extra_headers = {"Accept": "*/*", **(extra_headers or {})}
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return self._delete(
             f"/v1/agents/{agent_id}/session/{session_id}",
             options=make_request_options(
@@ -214,8 +180,6 @@ class AsyncSessionResource(AsyncAPIResource):
         agent_id: str,
         *,
         session_name: str,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -235,15 +199,6 @@ class AsyncSessionResource(AsyncAPIResource):
         """
         if not agent_id:
             raise ValueError(f"Expected a non-empty value for `agent_id` but received {agent_id!r}")
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return await self._post(
             f"/v1/agents/{agent_id}/session",
             body=await async_maybe_transform({"session_name": session_name}, session_create_params.SessionCreateParams),
@@ -259,8 +214,6 @@ class AsyncSessionResource(AsyncAPIResource):
         *,
         agent_id: str,
         turn_ids: List[str] | NotGiven = NOT_GIVEN,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -282,15 +235,6 @@ class AsyncSessionResource(AsyncAPIResource):
             raise ValueError(f"Expected a non-empty value for `agent_id` but received {agent_id!r}")
         if not session_id:
             raise ValueError(f"Expected a non-empty value for `session_id` but received {session_id!r}")
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return await self._get(
             f"/v1/agents/{agent_id}/session/{session_id}",
             options=make_request_options(
@@ -310,8 +254,6 @@ class AsyncSessionResource(AsyncAPIResource):
         session_id: str,
         *,
         agent_id: str,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -334,15 +276,6 @@ class AsyncSessionResource(AsyncAPIResource):
         if not session_id:
             raise ValueError(f"Expected a non-empty value for `session_id` but received {session_id!r}")
         extra_headers = {"Accept": "*/*", **(extra_headers or {})}
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return await self._delete(
             f"/v1/agents/{agent_id}/session/{session_id}",
             options=make_request_options(

--- a/src/llama_stack_client/resources/agents/steps.py
+++ b/src/llama_stack_client/resources/agents/steps.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import httpx
 
 from ..._types import NOT_GIVEN, Body, Query, Headers, NotGiven
-from ..._utils import strip_not_given
 from ..._compat import cached_property
 from ..._resource import SyncAPIResource, AsyncAPIResource
 from ..._response import (
@@ -47,8 +46,6 @@ class StepsResource(SyncAPIResource):
         agent_id: str,
         session_id: str,
         turn_id: str,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -74,15 +71,6 @@ class StepsResource(SyncAPIResource):
             raise ValueError(f"Expected a non-empty value for `turn_id` but received {turn_id!r}")
         if not step_id:
             raise ValueError(f"Expected a non-empty value for `step_id` but received {step_id!r}")
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return self._get(
             f"/v1/agents/{agent_id}/session/{session_id}/turn/{turn_id}/step/{step_id}",
             options=make_request_options(
@@ -119,8 +107,6 @@ class AsyncStepsResource(AsyncAPIResource):
         agent_id: str,
         session_id: str,
         turn_id: str,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -146,15 +132,6 @@ class AsyncStepsResource(AsyncAPIResource):
             raise ValueError(f"Expected a non-empty value for `turn_id` but received {turn_id!r}")
         if not step_id:
             raise ValueError(f"Expected a non-empty value for `step_id` but received {step_id!r}")
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return await self._get(
             f"/v1/agents/{agent_id}/session/{session_id}/turn/{turn_id}/step/{step_id}",
             options=make_request_options(

--- a/src/llama_stack_client/resources/agents/turn.py
+++ b/src/llama_stack_client/resources/agents/turn.py
@@ -11,7 +11,6 @@ from ..._types import NOT_GIVEN, Body, Query, Headers, NotGiven
 from ..._utils import (
     required_args,
     maybe_transform,
-    strip_not_given,
     async_maybe_transform,
 )
 from ..._compat import cached_property
@@ -61,8 +60,6 @@ class TurnResource(SyncAPIResource):
         documents: Iterable[turn_create_params.Document] | NotGiven = NOT_GIVEN,
         stream: Literal[False] | NotGiven = NOT_GIVEN,
         toolgroups: List[turn_create_params.Toolgroup] | NotGiven = NOT_GIVEN,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -92,8 +89,6 @@ class TurnResource(SyncAPIResource):
         stream: Literal[True],
         documents: Iterable[turn_create_params.Document] | NotGiven = NOT_GIVEN,
         toolgroups: List[turn_create_params.Toolgroup] | NotGiven = NOT_GIVEN,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -123,8 +118,6 @@ class TurnResource(SyncAPIResource):
         stream: bool,
         documents: Iterable[turn_create_params.Document] | NotGiven = NOT_GIVEN,
         toolgroups: List[turn_create_params.Toolgroup] | NotGiven = NOT_GIVEN,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -154,8 +147,6 @@ class TurnResource(SyncAPIResource):
         documents: Iterable[turn_create_params.Document] | NotGiven = NOT_GIVEN,
         stream: Literal[False] | Literal[True] | NotGiven = NOT_GIVEN,
         toolgroups: List[turn_create_params.Toolgroup] | NotGiven = NOT_GIVEN,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -168,15 +159,6 @@ class TurnResource(SyncAPIResource):
         if not session_id:
             raise ValueError(f"Expected a non-empty value for `session_id` but received {session_id!r}")
         extra_headers = {"Accept": "text/event-stream", **(extra_headers or {})}
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return cast(
             TurnCreateResponse,
             self._post(
@@ -207,8 +189,6 @@ class TurnResource(SyncAPIResource):
         *,
         agent_id: str,
         session_id: str,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -232,15 +212,6 @@ class TurnResource(SyncAPIResource):
             raise ValueError(f"Expected a non-empty value for `session_id` but received {session_id!r}")
         if not turn_id:
             raise ValueError(f"Expected a non-empty value for `turn_id` but received {turn_id!r}")
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return self._get(
             f"/v1/agents/{agent_id}/session/{session_id}/turn/{turn_id}",
             options=make_request_options(
@@ -280,8 +251,6 @@ class AsyncTurnResource(AsyncAPIResource):
         documents: Iterable[turn_create_params.Document] | NotGiven = NOT_GIVEN,
         stream: Literal[False] | NotGiven = NOT_GIVEN,
         toolgroups: List[turn_create_params.Toolgroup] | NotGiven = NOT_GIVEN,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -311,8 +280,6 @@ class AsyncTurnResource(AsyncAPIResource):
         stream: Literal[True],
         documents: Iterable[turn_create_params.Document] | NotGiven = NOT_GIVEN,
         toolgroups: List[turn_create_params.Toolgroup] | NotGiven = NOT_GIVEN,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -342,8 +309,6 @@ class AsyncTurnResource(AsyncAPIResource):
         stream: bool,
         documents: Iterable[turn_create_params.Document] | NotGiven = NOT_GIVEN,
         toolgroups: List[turn_create_params.Toolgroup] | NotGiven = NOT_GIVEN,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -373,8 +338,6 @@ class AsyncTurnResource(AsyncAPIResource):
         documents: Iterable[turn_create_params.Document] | NotGiven = NOT_GIVEN,
         stream: Literal[False] | Literal[True] | NotGiven = NOT_GIVEN,
         toolgroups: List[turn_create_params.Toolgroup] | NotGiven = NOT_GIVEN,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -387,15 +350,6 @@ class AsyncTurnResource(AsyncAPIResource):
         if not session_id:
             raise ValueError(f"Expected a non-empty value for `session_id` but received {session_id!r}")
         extra_headers = {"Accept": "text/event-stream", **(extra_headers or {})}
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return cast(
             TurnCreateResponse,
             await self._post(
@@ -426,8 +380,6 @@ class AsyncTurnResource(AsyncAPIResource):
         *,
         agent_id: str,
         session_id: str,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -451,15 +403,6 @@ class AsyncTurnResource(AsyncAPIResource):
             raise ValueError(f"Expected a non-empty value for `session_id` but received {session_id!r}")
         if not turn_id:
             raise ValueError(f"Expected a non-empty value for `turn_id` but received {turn_id!r}")
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return await self._get(
             f"/v1/agents/{agent_id}/session/{session_id}/turn/{turn_id}",
             options=make_request_options(

--- a/src/llama_stack_client/resources/batch_inference.py
+++ b/src/llama_stack_client/resources/batch_inference.py
@@ -11,7 +11,6 @@ from ..types import batch_inference_completion_params, batch_inference_chat_comp
 from .._types import NOT_GIVEN, Body, Query, Headers, NotGiven
 from .._utils import (
     maybe_transform,
-    strip_not_given,
     async_maybe_transform,
 )
 from .._compat import cached_property
@@ -25,6 +24,7 @@ from .._response import (
 from .._base_client import make_request_options
 from ..types.shared_params.message import Message
 from ..types.shared.batch_completion import BatchCompletion
+from ..types.shared_params.response_format import ResponseFormat
 from ..types.shared_params.sampling_params import SamplingParams
 from ..types.shared_params.interleaved_content import InterleavedContent
 from ..types.batch_inference_chat_completion_response import BatchInferenceChatCompletionResponse
@@ -58,12 +58,11 @@ class BatchInferenceResource(SyncAPIResource):
         messages_batch: Iterable[Iterable[Message]],
         model: str,
         logprobs: batch_inference_chat_completion_params.Logprobs | NotGiven = NOT_GIVEN,
+        response_format: ResponseFormat | NotGiven = NOT_GIVEN,
         sampling_params: SamplingParams | NotGiven = NOT_GIVEN,
         tool_choice: Literal["auto", "required"] | NotGiven = NOT_GIVEN,
         tool_prompt_format: Literal["json", "function_tag", "python_list"] | NotGiven = NOT_GIVEN,
         tools: Iterable[batch_inference_chat_completion_params.Tool] | NotGiven = NOT_GIVEN,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -73,16 +72,6 @@ class BatchInferenceResource(SyncAPIResource):
     ) -> BatchInferenceChatCompletionResponse:
         """
         Args:
-          tool_prompt_format: `json` -- Refers to the json format for calling tools. The json format takes the
-              form like { "type": "function", "function" : { "name": "function_name",
-              "description": "function_description", "parameters": {...} } }
-
-              `function_tag` -- This is an example of how you could define your own user
-              defined format for making tool calls. The function_tag format looks like this,
-              <function=function_name>(parameters)</function>
-
-              The detailed prompts for each of these formats are added to llama cli
-
           extra_headers: Send extra headers
 
           extra_query: Add additional query parameters to the request
@@ -91,15 +80,6 @@ class BatchInferenceResource(SyncAPIResource):
 
           timeout: Override the client-level default timeout for this request, in seconds
         """
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return self._post(
             "/v1/batch-inference/chat-completion",
             body=maybe_transform(
@@ -107,6 +87,7 @@ class BatchInferenceResource(SyncAPIResource):
                     "messages_batch": messages_batch,
                     "model": model,
                     "logprobs": logprobs,
+                    "response_format": response_format,
                     "sampling_params": sampling_params,
                     "tool_choice": tool_choice,
                     "tool_prompt_format": tool_prompt_format,
@@ -126,9 +107,8 @@ class BatchInferenceResource(SyncAPIResource):
         content_batch: List[InterleavedContent],
         model: str,
         logprobs: batch_inference_completion_params.Logprobs | NotGiven = NOT_GIVEN,
+        response_format: ResponseFormat | NotGiven = NOT_GIVEN,
         sampling_params: SamplingParams | NotGiven = NOT_GIVEN,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -146,15 +126,6 @@ class BatchInferenceResource(SyncAPIResource):
 
           timeout: Override the client-level default timeout for this request, in seconds
         """
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return self._post(
             "/v1/batch-inference/completion",
             body=maybe_transform(
@@ -162,6 +133,7 @@ class BatchInferenceResource(SyncAPIResource):
                     "content_batch": content_batch,
                     "model": model,
                     "logprobs": logprobs,
+                    "response_format": response_format,
                     "sampling_params": sampling_params,
                 },
                 batch_inference_completion_params.BatchInferenceCompletionParams,
@@ -199,12 +171,11 @@ class AsyncBatchInferenceResource(AsyncAPIResource):
         messages_batch: Iterable[Iterable[Message]],
         model: str,
         logprobs: batch_inference_chat_completion_params.Logprobs | NotGiven = NOT_GIVEN,
+        response_format: ResponseFormat | NotGiven = NOT_GIVEN,
         sampling_params: SamplingParams | NotGiven = NOT_GIVEN,
         tool_choice: Literal["auto", "required"] | NotGiven = NOT_GIVEN,
         tool_prompt_format: Literal["json", "function_tag", "python_list"] | NotGiven = NOT_GIVEN,
         tools: Iterable[batch_inference_chat_completion_params.Tool] | NotGiven = NOT_GIVEN,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -214,16 +185,6 @@ class AsyncBatchInferenceResource(AsyncAPIResource):
     ) -> BatchInferenceChatCompletionResponse:
         """
         Args:
-          tool_prompt_format: `json` -- Refers to the json format for calling tools. The json format takes the
-              form like { "type": "function", "function" : { "name": "function_name",
-              "description": "function_description", "parameters": {...} } }
-
-              `function_tag` -- This is an example of how you could define your own user
-              defined format for making tool calls. The function_tag format looks like this,
-              <function=function_name>(parameters)</function>
-
-              The detailed prompts for each of these formats are added to llama cli
-
           extra_headers: Send extra headers
 
           extra_query: Add additional query parameters to the request
@@ -232,15 +193,6 @@ class AsyncBatchInferenceResource(AsyncAPIResource):
 
           timeout: Override the client-level default timeout for this request, in seconds
         """
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return await self._post(
             "/v1/batch-inference/chat-completion",
             body=await async_maybe_transform(
@@ -248,6 +200,7 @@ class AsyncBatchInferenceResource(AsyncAPIResource):
                     "messages_batch": messages_batch,
                     "model": model,
                     "logprobs": logprobs,
+                    "response_format": response_format,
                     "sampling_params": sampling_params,
                     "tool_choice": tool_choice,
                     "tool_prompt_format": tool_prompt_format,
@@ -267,9 +220,8 @@ class AsyncBatchInferenceResource(AsyncAPIResource):
         content_batch: List[InterleavedContent],
         model: str,
         logprobs: batch_inference_completion_params.Logprobs | NotGiven = NOT_GIVEN,
+        response_format: ResponseFormat | NotGiven = NOT_GIVEN,
         sampling_params: SamplingParams | NotGiven = NOT_GIVEN,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -287,15 +239,6 @@ class AsyncBatchInferenceResource(AsyncAPIResource):
 
           timeout: Override the client-level default timeout for this request, in seconds
         """
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return await self._post(
             "/v1/batch-inference/completion",
             body=await async_maybe_transform(
@@ -303,6 +246,7 @@ class AsyncBatchInferenceResource(AsyncAPIResource):
                     "content_batch": content_batch,
                     "model": model,
                     "logprobs": logprobs,
+                    "response_format": response_format,
                     "sampling_params": sampling_params,
                 },
                 batch_inference_completion_params.BatchInferenceCompletionParams,

--- a/src/llama_stack_client/resources/datasetio.py
+++ b/src/llama_stack_client/resources/datasetio.py
@@ -10,7 +10,6 @@ from ..types import datasetio_append_rows_params, datasetio_get_rows_paginated_p
 from .._types import NOT_GIVEN, Body, Query, Headers, NoneType, NotGiven
 from .._utils import (
     maybe_transform,
-    strip_not_given,
     async_maybe_transform,
 )
 from .._compat import cached_property
@@ -52,8 +51,6 @@ class DatasetioResource(SyncAPIResource):
         *,
         dataset_id: str,
         rows: Iterable[Dict[str, Union[bool, float, str, Iterable[object], object, None]]],
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -72,15 +69,6 @@ class DatasetioResource(SyncAPIResource):
           timeout: Override the client-level default timeout for this request, in seconds
         """
         extra_headers = {"Accept": "*/*", **(extra_headers or {})}
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return self._post(
             "/v1/datasetio/rows",
             body=maybe_transform(
@@ -103,8 +91,6 @@ class DatasetioResource(SyncAPIResource):
         rows_in_page: int,
         filter_condition: str | NotGiven = NOT_GIVEN,
         page_token: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -122,15 +108,6 @@ class DatasetioResource(SyncAPIResource):
 
           timeout: Override the client-level default timeout for this request, in seconds
         """
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return self._get(
             "/v1/datasetio/rows",
             options=make_request_options(
@@ -177,8 +154,6 @@ class AsyncDatasetioResource(AsyncAPIResource):
         *,
         dataset_id: str,
         rows: Iterable[Dict[str, Union[bool, float, str, Iterable[object], object, None]]],
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -197,15 +172,6 @@ class AsyncDatasetioResource(AsyncAPIResource):
           timeout: Override the client-level default timeout for this request, in seconds
         """
         extra_headers = {"Accept": "*/*", **(extra_headers or {})}
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return await self._post(
             "/v1/datasetio/rows",
             body=await async_maybe_transform(
@@ -228,8 +194,6 @@ class AsyncDatasetioResource(AsyncAPIResource):
         rows_in_page: int,
         filter_condition: str | NotGiven = NOT_GIVEN,
         page_token: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -247,15 +211,6 @@ class AsyncDatasetioResource(AsyncAPIResource):
 
           timeout: Override the client-level default timeout for this request, in seconds
         """
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return await self._get(
             "/v1/datasetio/rows",
             options=make_request_options(

--- a/src/llama_stack_client/resources/datasets.py
+++ b/src/llama_stack_client/resources/datasets.py
@@ -10,7 +10,6 @@ from ..types import dataset_register_params
 from .._types import NOT_GIVEN, Body, Query, Headers, NoneType, NotGiven
 from .._utils import (
     maybe_transform,
-    strip_not_given,
     async_maybe_transform,
 )
 from .._compat import cached_property
@@ -55,8 +54,6 @@ class DatasetsResource(SyncAPIResource):
         self,
         dataset_id: str,
         *,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -76,15 +73,6 @@ class DatasetsResource(SyncAPIResource):
         """
         if not dataset_id:
             raise ValueError(f"Expected a non-empty value for `dataset_id` but received {dataset_id!r}")
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return self._get(
             f"/v1/datasets/{dataset_id}",
             options=make_request_options(
@@ -96,8 +84,6 @@ class DatasetsResource(SyncAPIResource):
     def list(
         self,
         *,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -105,25 +91,6 @@ class DatasetsResource(SyncAPIResource):
         extra_body: Body | None = None,
         timeout: float | httpx.Timeout | None | NotGiven = NOT_GIVEN,
     ) -> DatasetListResponse:
-        """
-        Args:
-          extra_headers: Send extra headers
-
-          extra_query: Add additional query parameters to the request
-
-          extra_body: Add additional JSON properties to the request
-
-          timeout: Override the client-level default timeout for this request, in seconds
-        """
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return self._get(
             "/v1/datasets",
             options=make_request_options(
@@ -145,8 +112,6 @@ class DatasetsResource(SyncAPIResource):
         metadata: Dict[str, Union[bool, float, str, Iterable[object], object, None]] | NotGiven = NOT_GIVEN,
         provider_dataset_id: str | NotGiven = NOT_GIVEN,
         provider_id: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -165,15 +130,6 @@ class DatasetsResource(SyncAPIResource):
           timeout: Override the client-level default timeout for this request, in seconds
         """
         extra_headers = {"Accept": "*/*", **(extra_headers or {})}
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return self._post(
             "/v1/datasets",
             body=maybe_transform(
@@ -197,8 +153,6 @@ class DatasetsResource(SyncAPIResource):
         self,
         dataset_id: str,
         *,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -219,15 +173,6 @@ class DatasetsResource(SyncAPIResource):
         if not dataset_id:
             raise ValueError(f"Expected a non-empty value for `dataset_id` but received {dataset_id!r}")
         extra_headers = {"Accept": "*/*", **(extra_headers or {})}
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return self._delete(
             f"/v1/datasets/{dataset_id}",
             options=make_request_options(
@@ -261,8 +206,6 @@ class AsyncDatasetsResource(AsyncAPIResource):
         self,
         dataset_id: str,
         *,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -282,15 +225,6 @@ class AsyncDatasetsResource(AsyncAPIResource):
         """
         if not dataset_id:
             raise ValueError(f"Expected a non-empty value for `dataset_id` but received {dataset_id!r}")
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return await self._get(
             f"/v1/datasets/{dataset_id}",
             options=make_request_options(
@@ -302,8 +236,6 @@ class AsyncDatasetsResource(AsyncAPIResource):
     async def list(
         self,
         *,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -311,25 +243,6 @@ class AsyncDatasetsResource(AsyncAPIResource):
         extra_body: Body | None = None,
         timeout: float | httpx.Timeout | None | NotGiven = NOT_GIVEN,
     ) -> DatasetListResponse:
-        """
-        Args:
-          extra_headers: Send extra headers
-
-          extra_query: Add additional query parameters to the request
-
-          extra_body: Add additional JSON properties to the request
-
-          timeout: Override the client-level default timeout for this request, in seconds
-        """
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return await self._get(
             "/v1/datasets",
             options=make_request_options(
@@ -351,8 +264,6 @@ class AsyncDatasetsResource(AsyncAPIResource):
         metadata: Dict[str, Union[bool, float, str, Iterable[object], object, None]] | NotGiven = NOT_GIVEN,
         provider_dataset_id: str | NotGiven = NOT_GIVEN,
         provider_id: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -371,15 +282,6 @@ class AsyncDatasetsResource(AsyncAPIResource):
           timeout: Override the client-level default timeout for this request, in seconds
         """
         extra_headers = {"Accept": "*/*", **(extra_headers or {})}
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return await self._post(
             "/v1/datasets",
             body=await async_maybe_transform(
@@ -403,8 +305,6 @@ class AsyncDatasetsResource(AsyncAPIResource):
         self,
         dataset_id: str,
         *,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -425,15 +325,6 @@ class AsyncDatasetsResource(AsyncAPIResource):
         if not dataset_id:
             raise ValueError(f"Expected a non-empty value for `dataset_id` but received {dataset_id!r}")
         extra_headers = {"Accept": "*/*", **(extra_headers or {})}
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return await self._delete(
             f"/v1/datasets/{dataset_id}",
             options=make_request_options(

--- a/src/llama_stack_client/resources/eval/eval.py
+++ b/src/llama_stack_client/resources/eval/eval.py
@@ -18,7 +18,6 @@ from ...types import eval_run_eval_params, eval_evaluate_rows_params
 from ..._types import NOT_GIVEN, Body, Query, Headers, NotGiven
 from ..._utils import (
     maybe_transform,
-    strip_not_given,
     async_maybe_transform,
 )
 from ..._compat import cached_property
@@ -68,8 +67,6 @@ class EvalResource(SyncAPIResource):
         input_rows: Iterable[Dict[str, Union[bool, float, str, Iterable[object], object, None]]],
         scoring_functions: List[str],
         task_config: EvalTaskConfigParam,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -89,15 +86,6 @@ class EvalResource(SyncAPIResource):
         """
         if not task_id:
             raise ValueError(f"Expected a non-empty value for `task_id` but received {task_id!r}")
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return self._post(
             f"/v1/eval/tasks/{task_id}/evaluations",
             body=maybe_transform(
@@ -119,8 +107,6 @@ class EvalResource(SyncAPIResource):
         task_id: str,
         *,
         task_config: EvalTaskConfigParam,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -140,15 +126,6 @@ class EvalResource(SyncAPIResource):
         """
         if not task_id:
             raise ValueError(f"Expected a non-empty value for `task_id` but received {task_id!r}")
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return self._post(
             f"/v1/eval/tasks/{task_id}/jobs",
             body=maybe_transform({"task_config": task_config}, eval_run_eval_params.EvalRunEvalParams),
@@ -190,8 +167,6 @@ class AsyncEvalResource(AsyncAPIResource):
         input_rows: Iterable[Dict[str, Union[bool, float, str, Iterable[object], object, None]]],
         scoring_functions: List[str],
         task_config: EvalTaskConfigParam,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -211,15 +186,6 @@ class AsyncEvalResource(AsyncAPIResource):
         """
         if not task_id:
             raise ValueError(f"Expected a non-empty value for `task_id` but received {task_id!r}")
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return await self._post(
             f"/v1/eval/tasks/{task_id}/evaluations",
             body=await async_maybe_transform(
@@ -241,8 +207,6 @@ class AsyncEvalResource(AsyncAPIResource):
         task_id: str,
         *,
         task_config: EvalTaskConfigParam,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -262,15 +226,6 @@ class AsyncEvalResource(AsyncAPIResource):
         """
         if not task_id:
             raise ValueError(f"Expected a non-empty value for `task_id` but received {task_id!r}")
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return await self._post(
             f"/v1/eval/tasks/{task_id}/jobs",
             body=await async_maybe_transform({"task_config": task_config}, eval_run_eval_params.EvalRunEvalParams),

--- a/src/llama_stack_client/resources/eval/jobs.py
+++ b/src/llama_stack_client/resources/eval/jobs.py
@@ -7,7 +7,6 @@ from typing import Optional
 import httpx
 
 from ..._types import NOT_GIVEN, Body, Query, Headers, NoneType, NotGiven
-from ..._utils import strip_not_given
 from ..._compat import cached_property
 from ..._resource import SyncAPIResource, AsyncAPIResource
 from ..._response import (
@@ -48,8 +47,6 @@ class JobsResource(SyncAPIResource):
         job_id: str,
         *,
         task_id: str,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -71,15 +68,6 @@ class JobsResource(SyncAPIResource):
             raise ValueError(f"Expected a non-empty value for `task_id` but received {task_id!r}")
         if not job_id:
             raise ValueError(f"Expected a non-empty value for `job_id` but received {job_id!r}")
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return self._get(
             f"/v1/eval/tasks/{task_id}/jobs/{job_id}/result",
             options=make_request_options(
@@ -93,8 +81,6 @@ class JobsResource(SyncAPIResource):
         job_id: str,
         *,
         task_id: str,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -117,15 +103,6 @@ class JobsResource(SyncAPIResource):
         if not job_id:
             raise ValueError(f"Expected a non-empty value for `job_id` but received {job_id!r}")
         extra_headers = {"Accept": "*/*", **(extra_headers or {})}
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return self._delete(
             f"/v1/eval/tasks/{task_id}/jobs/{job_id}",
             options=make_request_options(
@@ -139,8 +116,6 @@ class JobsResource(SyncAPIResource):
         job_id: str,
         *,
         task_id: str,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -162,15 +137,6 @@ class JobsResource(SyncAPIResource):
             raise ValueError(f"Expected a non-empty value for `task_id` but received {task_id!r}")
         if not job_id:
             raise ValueError(f"Expected a non-empty value for `job_id` but received {job_id!r}")
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return self._get(
             f"/v1/eval/tasks/{task_id}/jobs/{job_id}",
             options=make_request_options(
@@ -205,8 +171,6 @@ class AsyncJobsResource(AsyncAPIResource):
         job_id: str,
         *,
         task_id: str,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -228,15 +192,6 @@ class AsyncJobsResource(AsyncAPIResource):
             raise ValueError(f"Expected a non-empty value for `task_id` but received {task_id!r}")
         if not job_id:
             raise ValueError(f"Expected a non-empty value for `job_id` but received {job_id!r}")
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return await self._get(
             f"/v1/eval/tasks/{task_id}/jobs/{job_id}/result",
             options=make_request_options(
@@ -250,8 +205,6 @@ class AsyncJobsResource(AsyncAPIResource):
         job_id: str,
         *,
         task_id: str,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -274,15 +227,6 @@ class AsyncJobsResource(AsyncAPIResource):
         if not job_id:
             raise ValueError(f"Expected a non-empty value for `job_id` but received {job_id!r}")
         extra_headers = {"Accept": "*/*", **(extra_headers or {})}
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return await self._delete(
             f"/v1/eval/tasks/{task_id}/jobs/{job_id}",
             options=make_request_options(
@@ -296,8 +240,6 @@ class AsyncJobsResource(AsyncAPIResource):
         job_id: str,
         *,
         task_id: str,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -319,15 +261,6 @@ class AsyncJobsResource(AsyncAPIResource):
             raise ValueError(f"Expected a non-empty value for `task_id` but received {task_id!r}")
         if not job_id:
             raise ValueError(f"Expected a non-empty value for `job_id` but received {job_id!r}")
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return await self._get(
             f"/v1/eval/tasks/{task_id}/jobs/{job_id}",
             options=make_request_options(

--- a/src/llama_stack_client/resources/eval_tasks.py
+++ b/src/llama_stack_client/resources/eval_tasks.py
@@ -10,7 +10,6 @@ from ..types import eval_task_register_params
 from .._types import NOT_GIVEN, Body, Query, Headers, NoneType, NotGiven
 from .._utils import (
     maybe_transform,
-    strip_not_given,
     async_maybe_transform,
 )
 from .._compat import cached_property
@@ -53,8 +52,6 @@ class EvalTasksResource(SyncAPIResource):
         self,
         eval_task_id: str,
         *,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -74,15 +71,6 @@ class EvalTasksResource(SyncAPIResource):
         """
         if not eval_task_id:
             raise ValueError(f"Expected a non-empty value for `eval_task_id` but received {eval_task_id!r}")
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return self._get(
             f"/v1/eval-tasks/{eval_task_id}",
             options=make_request_options(
@@ -94,8 +82,6 @@ class EvalTasksResource(SyncAPIResource):
     def list(
         self,
         *,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -103,25 +89,6 @@ class EvalTasksResource(SyncAPIResource):
         extra_body: Body | None = None,
         timeout: float | httpx.Timeout | None | NotGiven = NOT_GIVEN,
     ) -> EvalTaskListResponse:
-        """
-        Args:
-          extra_headers: Send extra headers
-
-          extra_query: Add additional query parameters to the request
-
-          extra_body: Add additional JSON properties to the request
-
-          timeout: Override the client-level default timeout for this request, in seconds
-        """
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return self._get(
             "/v1/eval-tasks",
             options=make_request_options(
@@ -143,8 +110,6 @@ class EvalTasksResource(SyncAPIResource):
         metadata: Dict[str, Union[bool, float, str, Iterable[object], object, None]] | NotGiven = NOT_GIVEN,
         provider_eval_task_id: str | NotGiven = NOT_GIVEN,
         provider_id: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -163,15 +128,6 @@ class EvalTasksResource(SyncAPIResource):
           timeout: Override the client-level default timeout for this request, in seconds
         """
         extra_headers = {"Accept": "*/*", **(extra_headers or {})}
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return self._post(
             "/v1/eval-tasks",
             body=maybe_transform(
@@ -216,8 +172,6 @@ class AsyncEvalTasksResource(AsyncAPIResource):
         self,
         eval_task_id: str,
         *,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -237,15 +191,6 @@ class AsyncEvalTasksResource(AsyncAPIResource):
         """
         if not eval_task_id:
             raise ValueError(f"Expected a non-empty value for `eval_task_id` but received {eval_task_id!r}")
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return await self._get(
             f"/v1/eval-tasks/{eval_task_id}",
             options=make_request_options(
@@ -257,8 +202,6 @@ class AsyncEvalTasksResource(AsyncAPIResource):
     async def list(
         self,
         *,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -266,25 +209,6 @@ class AsyncEvalTasksResource(AsyncAPIResource):
         extra_body: Body | None = None,
         timeout: float | httpx.Timeout | None | NotGiven = NOT_GIVEN,
     ) -> EvalTaskListResponse:
-        """
-        Args:
-          extra_headers: Send extra headers
-
-          extra_query: Add additional query parameters to the request
-
-          extra_body: Add additional JSON properties to the request
-
-          timeout: Override the client-level default timeout for this request, in seconds
-        """
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return await self._get(
             "/v1/eval-tasks",
             options=make_request_options(
@@ -306,8 +230,6 @@ class AsyncEvalTasksResource(AsyncAPIResource):
         metadata: Dict[str, Union[bool, float, str, Iterable[object], object, None]] | NotGiven = NOT_GIVEN,
         provider_eval_task_id: str | NotGiven = NOT_GIVEN,
         provider_id: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -326,15 +248,6 @@ class AsyncEvalTasksResource(AsyncAPIResource):
           timeout: Override the client-level default timeout for this request, in seconds
         """
         extra_headers = {"Accept": "*/*", **(extra_headers or {})}
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return await self._post(
             "/v1/eval-tasks",
             body=await async_maybe_transform(

--- a/src/llama_stack_client/resources/inference.py
+++ b/src/llama_stack_client/resources/inference.py
@@ -16,7 +16,6 @@ from .._types import NOT_GIVEN, Body, Query, Headers, NotGiven
 from .._utils import (
     required_args,
     maybe_transform,
-    strip_not_given,
     async_maybe_transform,
 )
 from .._compat import cached_property
@@ -73,8 +72,6 @@ class InferenceResource(SyncAPIResource):
         tool_choice: Literal["auto", "required"] | NotGiven = NOT_GIVEN,
         tool_prompt_format: Literal["json", "function_tag", "python_list"] | NotGiven = NOT_GIVEN,
         tools: Iterable[inference_chat_completion_params.Tool] | NotGiven = NOT_GIVEN,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -83,16 +80,38 @@ class InferenceResource(SyncAPIResource):
         timeout: float | httpx.Timeout | None | NotGiven = NOT_GIVEN,
     ) -> InferenceChatCompletionResponse:
         """
+        Generate a chat completion for the given messages using the specified model.
+
         Args:
-          tool_prompt_format: `json` -- Refers to the json format for calling tools. The json format takes the
-              form like { "type": "function", "function" : { "name": "function_name",
-              "description": "function_description", "parameters": {...} } }
+          messages: List of messages in the conversation
 
-              `function_tag` -- This is an example of how you could define your own user
-              defined format for making tool calls. The function_tag format looks like this,
-              <function=function_name>(parameters)</function>
+          model_id: The identifier of the model to use. The model must be registered with Llama
+              Stack and available via the /models endpoint.
 
-              The detailed prompts for each of these formats are added to llama cli
+          logprobs: (Optional) If specified, log probabilities for each token position will be
+              returned.
+
+          response_format: (Optional) Grammar specification for guided (structured) decoding. There are two
+              options: - `ResponseFormat.json_schema`: The grammar is a JSON schema. Most
+              providers support this format. - `ResponseFormat.grammar`: The grammar is a BNF
+              grammar. This format is more flexible, but not all providers support it.
+
+          sampling_params: Parameters to control the sampling strategy
+
+          stream: (Optional) If True, generate an SSE event stream of the response. Defaults to
+              False.
+
+          tool_choice: (Optional) Whether tool use is required or automatic. Defaults to
+              ToolChoice.auto.
+
+          tool_prompt_format: (Optional) Instructs the model how to format tool calls. By default, Llama Stack
+              will attempt to use a format that is best adapted to the model. -
+              `ToolPromptFormat.json`: The tool calls are formatted as a JSON object. -
+              `ToolPromptFormat.function_tag`: The tool calls are enclosed in a
+              <function=function_name> tag. - `ToolPromptFormat.python_list`: The tool calls
+              are output as Python syntax -- a list of function calls.
+
+          tools: (Optional) List of tool definitions available to the model
 
           extra_headers: Send extra headers
 
@@ -117,8 +136,6 @@ class InferenceResource(SyncAPIResource):
         tool_choice: Literal["auto", "required"] | NotGiven = NOT_GIVEN,
         tool_prompt_format: Literal["json", "function_tag", "python_list"] | NotGiven = NOT_GIVEN,
         tools: Iterable[inference_chat_completion_params.Tool] | NotGiven = NOT_GIVEN,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -127,16 +144,38 @@ class InferenceResource(SyncAPIResource):
         timeout: float | httpx.Timeout | None | NotGiven = NOT_GIVEN,
     ) -> Stream[InferenceChatCompletionResponse]:
         """
+        Generate a chat completion for the given messages using the specified model.
+
         Args:
-          tool_prompt_format: `json` -- Refers to the json format for calling tools. The json format takes the
-              form like { "type": "function", "function" : { "name": "function_name",
-              "description": "function_description", "parameters": {...} } }
+          messages: List of messages in the conversation
 
-              `function_tag` -- This is an example of how you could define your own user
-              defined format for making tool calls. The function_tag format looks like this,
-              <function=function_name>(parameters)</function>
+          model_id: The identifier of the model to use. The model must be registered with Llama
+              Stack and available via the /models endpoint.
 
-              The detailed prompts for each of these formats are added to llama cli
+          stream: (Optional) If True, generate an SSE event stream of the response. Defaults to
+              False.
+
+          logprobs: (Optional) If specified, log probabilities for each token position will be
+              returned.
+
+          response_format: (Optional) Grammar specification for guided (structured) decoding. There are two
+              options: - `ResponseFormat.json_schema`: The grammar is a JSON schema. Most
+              providers support this format. - `ResponseFormat.grammar`: The grammar is a BNF
+              grammar. This format is more flexible, but not all providers support it.
+
+          sampling_params: Parameters to control the sampling strategy
+
+          tool_choice: (Optional) Whether tool use is required or automatic. Defaults to
+              ToolChoice.auto.
+
+          tool_prompt_format: (Optional) Instructs the model how to format tool calls. By default, Llama Stack
+              will attempt to use a format that is best adapted to the model. -
+              `ToolPromptFormat.json`: The tool calls are formatted as a JSON object. -
+              `ToolPromptFormat.function_tag`: The tool calls are enclosed in a
+              <function=function_name> tag. - `ToolPromptFormat.python_list`: The tool calls
+              are output as Python syntax -- a list of function calls.
+
+          tools: (Optional) List of tool definitions available to the model
 
           extra_headers: Send extra headers
 
@@ -161,8 +200,6 @@ class InferenceResource(SyncAPIResource):
         tool_choice: Literal["auto", "required"] | NotGiven = NOT_GIVEN,
         tool_prompt_format: Literal["json", "function_tag", "python_list"] | NotGiven = NOT_GIVEN,
         tools: Iterable[inference_chat_completion_params.Tool] | NotGiven = NOT_GIVEN,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -171,16 +208,38 @@ class InferenceResource(SyncAPIResource):
         timeout: float | httpx.Timeout | None | NotGiven = NOT_GIVEN,
     ) -> InferenceChatCompletionResponse | Stream[InferenceChatCompletionResponse]:
         """
+        Generate a chat completion for the given messages using the specified model.
+
         Args:
-          tool_prompt_format: `json` -- Refers to the json format for calling tools. The json format takes the
-              form like { "type": "function", "function" : { "name": "function_name",
-              "description": "function_description", "parameters": {...} } }
+          messages: List of messages in the conversation
 
-              `function_tag` -- This is an example of how you could define your own user
-              defined format for making tool calls. The function_tag format looks like this,
-              <function=function_name>(parameters)</function>
+          model_id: The identifier of the model to use. The model must be registered with Llama
+              Stack and available via the /models endpoint.
 
-              The detailed prompts for each of these formats are added to llama cli
+          stream: (Optional) If True, generate an SSE event stream of the response. Defaults to
+              False.
+
+          logprobs: (Optional) If specified, log probabilities for each token position will be
+              returned.
+
+          response_format: (Optional) Grammar specification for guided (structured) decoding. There are two
+              options: - `ResponseFormat.json_schema`: The grammar is a JSON schema. Most
+              providers support this format. - `ResponseFormat.grammar`: The grammar is a BNF
+              grammar. This format is more flexible, but not all providers support it.
+
+          sampling_params: Parameters to control the sampling strategy
+
+          tool_choice: (Optional) Whether tool use is required or automatic. Defaults to
+              ToolChoice.auto.
+
+          tool_prompt_format: (Optional) Instructs the model how to format tool calls. By default, Llama Stack
+              will attempt to use a format that is best adapted to the model. -
+              `ToolPromptFormat.json`: The tool calls are formatted as a JSON object. -
+              `ToolPromptFormat.function_tag`: The tool calls are enclosed in a
+              <function=function_name> tag. - `ToolPromptFormat.python_list`: The tool calls
+              are output as Python syntax -- a list of function calls.
+
+          tools: (Optional) List of tool definitions available to the model
 
           extra_headers: Send extra headers
 
@@ -205,8 +264,6 @@ class InferenceResource(SyncAPIResource):
         tool_choice: Literal["auto", "required"] | NotGiven = NOT_GIVEN,
         tool_prompt_format: Literal["json", "function_tag", "python_list"] | NotGiven = NOT_GIVEN,
         tools: Iterable[inference_chat_completion_params.Tool] | NotGiven = NOT_GIVEN,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -215,15 +272,6 @@ class InferenceResource(SyncAPIResource):
         timeout: float | httpx.Timeout | None | NotGiven = NOT_GIVEN,
     ) -> InferenceChatCompletionResponse | Stream[InferenceChatCompletionResponse]:
         extra_headers = {"Accept": "text/event-stream", **(extra_headers or {})}
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return cast(
             InferenceChatCompletionResponse,
             self._post(
@@ -263,8 +311,6 @@ class InferenceResource(SyncAPIResource):
         response_format: ResponseFormat | NotGiven = NOT_GIVEN,
         sampling_params: SamplingParams | NotGiven = NOT_GIVEN,
         stream: Literal[False] | NotGiven = NOT_GIVEN,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -273,7 +319,24 @@ class InferenceResource(SyncAPIResource):
         timeout: float | httpx.Timeout | None | NotGiven = NOT_GIVEN,
     ) -> InferenceCompletionResponse:
         """
+        Generate a completion for the given content using the specified model.
+
         Args:
+          content: The content to generate a completion for
+
+          model_id: The identifier of the model to use. The model must be registered with Llama
+              Stack and available via the /models endpoint.
+
+          logprobs: (Optional) If specified, log probabilities for each token position will be
+              returned.
+
+          response_format: (Optional) Grammar specification for guided (structured) decoding
+
+          sampling_params: (Optional) Parameters to control the sampling strategy
+
+          stream: (Optional) If True, generate an SSE event stream of the response. Defaults to
+              False.
+
           extra_headers: Send extra headers
 
           extra_query: Add additional query parameters to the request
@@ -294,8 +357,6 @@ class InferenceResource(SyncAPIResource):
         logprobs: inference_completion_params.Logprobs | NotGiven = NOT_GIVEN,
         response_format: ResponseFormat | NotGiven = NOT_GIVEN,
         sampling_params: SamplingParams | NotGiven = NOT_GIVEN,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -304,7 +365,24 @@ class InferenceResource(SyncAPIResource):
         timeout: float | httpx.Timeout | None | NotGiven = NOT_GIVEN,
     ) -> Stream[InferenceCompletionResponse]:
         """
+        Generate a completion for the given content using the specified model.
+
         Args:
+          content: The content to generate a completion for
+
+          model_id: The identifier of the model to use. The model must be registered with Llama
+              Stack and available via the /models endpoint.
+
+          stream: (Optional) If True, generate an SSE event stream of the response. Defaults to
+              False.
+
+          logprobs: (Optional) If specified, log probabilities for each token position will be
+              returned.
+
+          response_format: (Optional) Grammar specification for guided (structured) decoding
+
+          sampling_params: (Optional) Parameters to control the sampling strategy
+
           extra_headers: Send extra headers
 
           extra_query: Add additional query parameters to the request
@@ -325,8 +403,6 @@ class InferenceResource(SyncAPIResource):
         logprobs: inference_completion_params.Logprobs | NotGiven = NOT_GIVEN,
         response_format: ResponseFormat | NotGiven = NOT_GIVEN,
         sampling_params: SamplingParams | NotGiven = NOT_GIVEN,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -335,7 +411,24 @@ class InferenceResource(SyncAPIResource):
         timeout: float | httpx.Timeout | None | NotGiven = NOT_GIVEN,
     ) -> InferenceCompletionResponse | Stream[InferenceCompletionResponse]:
         """
+        Generate a completion for the given content using the specified model.
+
         Args:
+          content: The content to generate a completion for
+
+          model_id: The identifier of the model to use. The model must be registered with Llama
+              Stack and available via the /models endpoint.
+
+          stream: (Optional) If True, generate an SSE event stream of the response. Defaults to
+              False.
+
+          logprobs: (Optional) If specified, log probabilities for each token position will be
+              returned.
+
+          response_format: (Optional) Grammar specification for guided (structured) decoding
+
+          sampling_params: (Optional) Parameters to control the sampling strategy
+
           extra_headers: Send extra headers
 
           extra_query: Add additional query parameters to the request
@@ -356,8 +449,6 @@ class InferenceResource(SyncAPIResource):
         response_format: ResponseFormat | NotGiven = NOT_GIVEN,
         sampling_params: SamplingParams | NotGiven = NOT_GIVEN,
         stream: Literal[False] | Literal[True] | NotGiven = NOT_GIVEN,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -366,15 +457,6 @@ class InferenceResource(SyncAPIResource):
         timeout: float | httpx.Timeout | None | NotGiven = NOT_GIVEN,
     ) -> InferenceCompletionResponse | Stream[InferenceCompletionResponse]:
         extra_headers = {"Accept": "text/event-stream", **(extra_headers or {})}
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return cast(
             InferenceCompletionResponse,
             self._post(
@@ -406,8 +488,6 @@ class InferenceResource(SyncAPIResource):
         *,
         contents: List[InterleavedContent],
         model_id: str,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -416,7 +496,16 @@ class InferenceResource(SyncAPIResource):
         timeout: float | httpx.Timeout | None | NotGiven = NOT_GIVEN,
     ) -> EmbeddingsResponse:
         """
+        Generate embeddings for content pieces using the specified model.
+
         Args:
+          contents: List of contents to generate embeddings for. Note that content can be
+              multimodal. The behavior depends on the model and provider. Some models may only
+              support text.
+
+          model_id: The identifier of the model to use. The model must be an embedding model
+              registered with Llama Stack and available via the /models endpoint.
+
           extra_headers: Send extra headers
 
           extra_query: Add additional query parameters to the request
@@ -425,15 +514,6 @@ class InferenceResource(SyncAPIResource):
 
           timeout: Override the client-level default timeout for this request, in seconds
         """
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return self._post(
             "/v1/inference/embeddings",
             body=maybe_transform(
@@ -483,8 +563,6 @@ class AsyncInferenceResource(AsyncAPIResource):
         tool_choice: Literal["auto", "required"] | NotGiven = NOT_GIVEN,
         tool_prompt_format: Literal["json", "function_tag", "python_list"] | NotGiven = NOT_GIVEN,
         tools: Iterable[inference_chat_completion_params.Tool] | NotGiven = NOT_GIVEN,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -493,16 +571,38 @@ class AsyncInferenceResource(AsyncAPIResource):
         timeout: float | httpx.Timeout | None | NotGiven = NOT_GIVEN,
     ) -> InferenceChatCompletionResponse:
         """
+        Generate a chat completion for the given messages using the specified model.
+
         Args:
-          tool_prompt_format: `json` -- Refers to the json format for calling tools. The json format takes the
-              form like { "type": "function", "function" : { "name": "function_name",
-              "description": "function_description", "parameters": {...} } }
+          messages: List of messages in the conversation
 
-              `function_tag` -- This is an example of how you could define your own user
-              defined format for making tool calls. The function_tag format looks like this,
-              <function=function_name>(parameters)</function>
+          model_id: The identifier of the model to use. The model must be registered with Llama
+              Stack and available via the /models endpoint.
 
-              The detailed prompts for each of these formats are added to llama cli
+          logprobs: (Optional) If specified, log probabilities for each token position will be
+              returned.
+
+          response_format: (Optional) Grammar specification for guided (structured) decoding. There are two
+              options: - `ResponseFormat.json_schema`: The grammar is a JSON schema. Most
+              providers support this format. - `ResponseFormat.grammar`: The grammar is a BNF
+              grammar. This format is more flexible, but not all providers support it.
+
+          sampling_params: Parameters to control the sampling strategy
+
+          stream: (Optional) If True, generate an SSE event stream of the response. Defaults to
+              False.
+
+          tool_choice: (Optional) Whether tool use is required or automatic. Defaults to
+              ToolChoice.auto.
+
+          tool_prompt_format: (Optional) Instructs the model how to format tool calls. By default, Llama Stack
+              will attempt to use a format that is best adapted to the model. -
+              `ToolPromptFormat.json`: The tool calls are formatted as a JSON object. -
+              `ToolPromptFormat.function_tag`: The tool calls are enclosed in a
+              <function=function_name> tag. - `ToolPromptFormat.python_list`: The tool calls
+              are output as Python syntax -- a list of function calls.
+
+          tools: (Optional) List of tool definitions available to the model
 
           extra_headers: Send extra headers
 
@@ -527,8 +627,6 @@ class AsyncInferenceResource(AsyncAPIResource):
         tool_choice: Literal["auto", "required"] | NotGiven = NOT_GIVEN,
         tool_prompt_format: Literal["json", "function_tag", "python_list"] | NotGiven = NOT_GIVEN,
         tools: Iterable[inference_chat_completion_params.Tool] | NotGiven = NOT_GIVEN,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -537,16 +635,38 @@ class AsyncInferenceResource(AsyncAPIResource):
         timeout: float | httpx.Timeout | None | NotGiven = NOT_GIVEN,
     ) -> AsyncStream[InferenceChatCompletionResponse]:
         """
+        Generate a chat completion for the given messages using the specified model.
+
         Args:
-          tool_prompt_format: `json` -- Refers to the json format for calling tools. The json format takes the
-              form like { "type": "function", "function" : { "name": "function_name",
-              "description": "function_description", "parameters": {...} } }
+          messages: List of messages in the conversation
 
-              `function_tag` -- This is an example of how you could define your own user
-              defined format for making tool calls. The function_tag format looks like this,
-              <function=function_name>(parameters)</function>
+          model_id: The identifier of the model to use. The model must be registered with Llama
+              Stack and available via the /models endpoint.
 
-              The detailed prompts for each of these formats are added to llama cli
+          stream: (Optional) If True, generate an SSE event stream of the response. Defaults to
+              False.
+
+          logprobs: (Optional) If specified, log probabilities for each token position will be
+              returned.
+
+          response_format: (Optional) Grammar specification for guided (structured) decoding. There are two
+              options: - `ResponseFormat.json_schema`: The grammar is a JSON schema. Most
+              providers support this format. - `ResponseFormat.grammar`: The grammar is a BNF
+              grammar. This format is more flexible, but not all providers support it.
+
+          sampling_params: Parameters to control the sampling strategy
+
+          tool_choice: (Optional) Whether tool use is required or automatic. Defaults to
+              ToolChoice.auto.
+
+          tool_prompt_format: (Optional) Instructs the model how to format tool calls. By default, Llama Stack
+              will attempt to use a format that is best adapted to the model. -
+              `ToolPromptFormat.json`: The tool calls are formatted as a JSON object. -
+              `ToolPromptFormat.function_tag`: The tool calls are enclosed in a
+              <function=function_name> tag. - `ToolPromptFormat.python_list`: The tool calls
+              are output as Python syntax -- a list of function calls.
+
+          tools: (Optional) List of tool definitions available to the model
 
           extra_headers: Send extra headers
 
@@ -571,8 +691,6 @@ class AsyncInferenceResource(AsyncAPIResource):
         tool_choice: Literal["auto", "required"] | NotGiven = NOT_GIVEN,
         tool_prompt_format: Literal["json", "function_tag", "python_list"] | NotGiven = NOT_GIVEN,
         tools: Iterable[inference_chat_completion_params.Tool] | NotGiven = NOT_GIVEN,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -581,16 +699,38 @@ class AsyncInferenceResource(AsyncAPIResource):
         timeout: float | httpx.Timeout | None | NotGiven = NOT_GIVEN,
     ) -> InferenceChatCompletionResponse | AsyncStream[InferenceChatCompletionResponse]:
         """
+        Generate a chat completion for the given messages using the specified model.
+
         Args:
-          tool_prompt_format: `json` -- Refers to the json format for calling tools. The json format takes the
-              form like { "type": "function", "function" : { "name": "function_name",
-              "description": "function_description", "parameters": {...} } }
+          messages: List of messages in the conversation
 
-              `function_tag` -- This is an example of how you could define your own user
-              defined format for making tool calls. The function_tag format looks like this,
-              <function=function_name>(parameters)</function>
+          model_id: The identifier of the model to use. The model must be registered with Llama
+              Stack and available via the /models endpoint.
 
-              The detailed prompts for each of these formats are added to llama cli
+          stream: (Optional) If True, generate an SSE event stream of the response. Defaults to
+              False.
+
+          logprobs: (Optional) If specified, log probabilities for each token position will be
+              returned.
+
+          response_format: (Optional) Grammar specification for guided (structured) decoding. There are two
+              options: - `ResponseFormat.json_schema`: The grammar is a JSON schema. Most
+              providers support this format. - `ResponseFormat.grammar`: The grammar is a BNF
+              grammar. This format is more flexible, but not all providers support it.
+
+          sampling_params: Parameters to control the sampling strategy
+
+          tool_choice: (Optional) Whether tool use is required or automatic. Defaults to
+              ToolChoice.auto.
+
+          tool_prompt_format: (Optional) Instructs the model how to format tool calls. By default, Llama Stack
+              will attempt to use a format that is best adapted to the model. -
+              `ToolPromptFormat.json`: The tool calls are formatted as a JSON object. -
+              `ToolPromptFormat.function_tag`: The tool calls are enclosed in a
+              <function=function_name> tag. - `ToolPromptFormat.python_list`: The tool calls
+              are output as Python syntax -- a list of function calls.
+
+          tools: (Optional) List of tool definitions available to the model
 
           extra_headers: Send extra headers
 
@@ -615,8 +755,6 @@ class AsyncInferenceResource(AsyncAPIResource):
         tool_choice: Literal["auto", "required"] | NotGiven = NOT_GIVEN,
         tool_prompt_format: Literal["json", "function_tag", "python_list"] | NotGiven = NOT_GIVEN,
         tools: Iterable[inference_chat_completion_params.Tool] | NotGiven = NOT_GIVEN,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -625,15 +763,6 @@ class AsyncInferenceResource(AsyncAPIResource):
         timeout: float | httpx.Timeout | None | NotGiven = NOT_GIVEN,
     ) -> InferenceChatCompletionResponse | AsyncStream[InferenceChatCompletionResponse]:
         extra_headers = {"Accept": "text/event-stream", **(extra_headers or {})}
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return cast(
             InferenceChatCompletionResponse,
             await self._post(
@@ -673,8 +802,6 @@ class AsyncInferenceResource(AsyncAPIResource):
         response_format: ResponseFormat | NotGiven = NOT_GIVEN,
         sampling_params: SamplingParams | NotGiven = NOT_GIVEN,
         stream: Literal[False] | NotGiven = NOT_GIVEN,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -683,7 +810,24 @@ class AsyncInferenceResource(AsyncAPIResource):
         timeout: float | httpx.Timeout | None | NotGiven = NOT_GIVEN,
     ) -> InferenceCompletionResponse:
         """
+        Generate a completion for the given content using the specified model.
+
         Args:
+          content: The content to generate a completion for
+
+          model_id: The identifier of the model to use. The model must be registered with Llama
+              Stack and available via the /models endpoint.
+
+          logprobs: (Optional) If specified, log probabilities for each token position will be
+              returned.
+
+          response_format: (Optional) Grammar specification for guided (structured) decoding
+
+          sampling_params: (Optional) Parameters to control the sampling strategy
+
+          stream: (Optional) If True, generate an SSE event stream of the response. Defaults to
+              False.
+
           extra_headers: Send extra headers
 
           extra_query: Add additional query parameters to the request
@@ -704,8 +848,6 @@ class AsyncInferenceResource(AsyncAPIResource):
         logprobs: inference_completion_params.Logprobs | NotGiven = NOT_GIVEN,
         response_format: ResponseFormat | NotGiven = NOT_GIVEN,
         sampling_params: SamplingParams | NotGiven = NOT_GIVEN,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -714,7 +856,24 @@ class AsyncInferenceResource(AsyncAPIResource):
         timeout: float | httpx.Timeout | None | NotGiven = NOT_GIVEN,
     ) -> AsyncStream[InferenceCompletionResponse]:
         """
+        Generate a completion for the given content using the specified model.
+
         Args:
+          content: The content to generate a completion for
+
+          model_id: The identifier of the model to use. The model must be registered with Llama
+              Stack and available via the /models endpoint.
+
+          stream: (Optional) If True, generate an SSE event stream of the response. Defaults to
+              False.
+
+          logprobs: (Optional) If specified, log probabilities for each token position will be
+              returned.
+
+          response_format: (Optional) Grammar specification for guided (structured) decoding
+
+          sampling_params: (Optional) Parameters to control the sampling strategy
+
           extra_headers: Send extra headers
 
           extra_query: Add additional query parameters to the request
@@ -735,8 +894,6 @@ class AsyncInferenceResource(AsyncAPIResource):
         logprobs: inference_completion_params.Logprobs | NotGiven = NOT_GIVEN,
         response_format: ResponseFormat | NotGiven = NOT_GIVEN,
         sampling_params: SamplingParams | NotGiven = NOT_GIVEN,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -745,7 +902,24 @@ class AsyncInferenceResource(AsyncAPIResource):
         timeout: float | httpx.Timeout | None | NotGiven = NOT_GIVEN,
     ) -> InferenceCompletionResponse | AsyncStream[InferenceCompletionResponse]:
         """
+        Generate a completion for the given content using the specified model.
+
         Args:
+          content: The content to generate a completion for
+
+          model_id: The identifier of the model to use. The model must be registered with Llama
+              Stack and available via the /models endpoint.
+
+          stream: (Optional) If True, generate an SSE event stream of the response. Defaults to
+              False.
+
+          logprobs: (Optional) If specified, log probabilities for each token position will be
+              returned.
+
+          response_format: (Optional) Grammar specification for guided (structured) decoding
+
+          sampling_params: (Optional) Parameters to control the sampling strategy
+
           extra_headers: Send extra headers
 
           extra_query: Add additional query parameters to the request
@@ -766,8 +940,6 @@ class AsyncInferenceResource(AsyncAPIResource):
         response_format: ResponseFormat | NotGiven = NOT_GIVEN,
         sampling_params: SamplingParams | NotGiven = NOT_GIVEN,
         stream: Literal[False] | Literal[True] | NotGiven = NOT_GIVEN,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -776,15 +948,6 @@ class AsyncInferenceResource(AsyncAPIResource):
         timeout: float | httpx.Timeout | None | NotGiven = NOT_GIVEN,
     ) -> InferenceCompletionResponse | AsyncStream[InferenceCompletionResponse]:
         extra_headers = {"Accept": "text/event-stream", **(extra_headers or {})}
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return cast(
             InferenceCompletionResponse,
             await self._post(
@@ -816,8 +979,6 @@ class AsyncInferenceResource(AsyncAPIResource):
         *,
         contents: List[InterleavedContent],
         model_id: str,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -826,7 +987,16 @@ class AsyncInferenceResource(AsyncAPIResource):
         timeout: float | httpx.Timeout | None | NotGiven = NOT_GIVEN,
     ) -> EmbeddingsResponse:
         """
+        Generate embeddings for content pieces using the specified model.
+
         Args:
+          contents: List of contents to generate embeddings for. Note that content can be
+              multimodal. The behavior depends on the model and provider. Some models may only
+              support text.
+
+          model_id: The identifier of the model to use. The model must be an embedding model
+              registered with Llama Stack and available via the /models endpoint.
+
           extra_headers: Send extra headers
 
           extra_query: Add additional query parameters to the request
@@ -835,15 +1005,6 @@ class AsyncInferenceResource(AsyncAPIResource):
 
           timeout: Override the client-level default timeout for this request, in seconds
         """
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return await self._post(
             "/v1/inference/embeddings",
             body=await async_maybe_transform(

--- a/src/llama_stack_client/resources/inspect.py
+++ b/src/llama_stack_client/resources/inspect.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import httpx
 
 from .._types import NOT_GIVEN, Body, Query, Headers, NotGiven
-from .._utils import strip_not_given
 from .._compat import cached_property
 from .._resource import SyncAPIResource, AsyncAPIResource
 from .._response import (
@@ -44,8 +43,6 @@ class InspectResource(SyncAPIResource):
     def health(
         self,
         *,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -53,25 +50,6 @@ class InspectResource(SyncAPIResource):
         extra_body: Body | None = None,
         timeout: float | httpx.Timeout | None | NotGiven = NOT_GIVEN,
     ) -> HealthInfo:
-        """
-        Args:
-          extra_headers: Send extra headers
-
-          extra_query: Add additional query parameters to the request
-
-          extra_body: Add additional JSON properties to the request
-
-          timeout: Override the client-level default timeout for this request, in seconds
-        """
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return self._get(
             "/v1/health",
             options=make_request_options(
@@ -83,8 +61,6 @@ class InspectResource(SyncAPIResource):
     def version(
         self,
         *,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -92,25 +68,6 @@ class InspectResource(SyncAPIResource):
         extra_body: Body | None = None,
         timeout: float | httpx.Timeout | None | NotGiven = NOT_GIVEN,
     ) -> VersionInfo:
-        """
-        Args:
-          extra_headers: Send extra headers
-
-          extra_query: Add additional query parameters to the request
-
-          extra_body: Add additional JSON properties to the request
-
-          timeout: Override the client-level default timeout for this request, in seconds
-        """
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return self._get(
             "/v1/version",
             options=make_request_options(
@@ -143,8 +100,6 @@ class AsyncInspectResource(AsyncAPIResource):
     async def health(
         self,
         *,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -152,25 +107,6 @@ class AsyncInspectResource(AsyncAPIResource):
         extra_body: Body | None = None,
         timeout: float | httpx.Timeout | None | NotGiven = NOT_GIVEN,
     ) -> HealthInfo:
-        """
-        Args:
-          extra_headers: Send extra headers
-
-          extra_query: Add additional query parameters to the request
-
-          extra_body: Add additional JSON properties to the request
-
-          timeout: Override the client-level default timeout for this request, in seconds
-        """
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return await self._get(
             "/v1/health",
             options=make_request_options(
@@ -182,8 +118,6 @@ class AsyncInspectResource(AsyncAPIResource):
     async def version(
         self,
         *,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -191,25 +125,6 @@ class AsyncInspectResource(AsyncAPIResource):
         extra_body: Body | None = None,
         timeout: float | httpx.Timeout | None | NotGiven = NOT_GIVEN,
     ) -> VersionInfo:
-        """
-        Args:
-          extra_headers: Send extra headers
-
-          extra_query: Add additional query parameters to the request
-
-          extra_body: Add additional JSON properties to the request
-
-          timeout: Override the client-level default timeout for this request, in seconds
-        """
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return await self._get(
             "/v1/version",
             options=make_request_options(

--- a/src/llama_stack_client/resources/models.py
+++ b/src/llama_stack_client/resources/models.py
@@ -11,7 +11,6 @@ from ..types import model_register_params
 from .._types import NOT_GIVEN, Body, Query, Headers, NoneType, NotGiven
 from .._utils import (
     maybe_transform,
-    strip_not_given,
     async_maybe_transform,
 )
 from .._compat import cached_property
@@ -54,8 +53,6 @@ class ModelsResource(SyncAPIResource):
         self,
         model_id: str,
         *,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -75,15 +72,6 @@ class ModelsResource(SyncAPIResource):
         """
         if not model_id:
             raise ValueError(f"Expected a non-empty value for `model_id` but received {model_id!r}")
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return self._get(
             f"/v1/models/{model_id}",
             options=make_request_options(
@@ -95,8 +83,6 @@ class ModelsResource(SyncAPIResource):
     def list(
         self,
         *,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -104,25 +90,6 @@ class ModelsResource(SyncAPIResource):
         extra_body: Body | None = None,
         timeout: float | httpx.Timeout | None | NotGiven = NOT_GIVEN,
     ) -> ModelListResponse:
-        """
-        Args:
-          extra_headers: Send extra headers
-
-          extra_query: Add additional query parameters to the request
-
-          extra_body: Add additional JSON properties to the request
-
-          timeout: Override the client-level default timeout for this request, in seconds
-        """
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return self._get(
             "/v1/models",
             options=make_request_options(
@@ -143,8 +110,6 @@ class ModelsResource(SyncAPIResource):
         model_type: Literal["llm", "embedding"] | NotGiven = NOT_GIVEN,
         provider_id: str | NotGiven = NOT_GIVEN,
         provider_model_id: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -162,15 +127,6 @@ class ModelsResource(SyncAPIResource):
 
           timeout: Override the client-level default timeout for this request, in seconds
         """
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return self._post(
             "/v1/models",
             body=maybe_transform(
@@ -193,8 +149,6 @@ class ModelsResource(SyncAPIResource):
         self,
         model_id: str,
         *,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -215,15 +169,6 @@ class ModelsResource(SyncAPIResource):
         if not model_id:
             raise ValueError(f"Expected a non-empty value for `model_id` but received {model_id!r}")
         extra_headers = {"Accept": "*/*", **(extra_headers or {})}
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return self._delete(
             f"/v1/models/{model_id}",
             options=make_request_options(
@@ -257,8 +202,6 @@ class AsyncModelsResource(AsyncAPIResource):
         self,
         model_id: str,
         *,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -278,15 +221,6 @@ class AsyncModelsResource(AsyncAPIResource):
         """
         if not model_id:
             raise ValueError(f"Expected a non-empty value for `model_id` but received {model_id!r}")
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return await self._get(
             f"/v1/models/{model_id}",
             options=make_request_options(
@@ -298,8 +232,6 @@ class AsyncModelsResource(AsyncAPIResource):
     async def list(
         self,
         *,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -307,25 +239,6 @@ class AsyncModelsResource(AsyncAPIResource):
         extra_body: Body | None = None,
         timeout: float | httpx.Timeout | None | NotGiven = NOT_GIVEN,
     ) -> ModelListResponse:
-        """
-        Args:
-          extra_headers: Send extra headers
-
-          extra_query: Add additional query parameters to the request
-
-          extra_body: Add additional JSON properties to the request
-
-          timeout: Override the client-level default timeout for this request, in seconds
-        """
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return await self._get(
             "/v1/models",
             options=make_request_options(
@@ -346,8 +259,6 @@ class AsyncModelsResource(AsyncAPIResource):
         model_type: Literal["llm", "embedding"] | NotGiven = NOT_GIVEN,
         provider_id: str | NotGiven = NOT_GIVEN,
         provider_model_id: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -365,15 +276,6 @@ class AsyncModelsResource(AsyncAPIResource):
 
           timeout: Override the client-level default timeout for this request, in seconds
         """
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return await self._post(
             "/v1/models",
             body=await async_maybe_transform(
@@ -396,8 +298,6 @@ class AsyncModelsResource(AsyncAPIResource):
         self,
         model_id: str,
         *,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -418,15 +318,6 @@ class AsyncModelsResource(AsyncAPIResource):
         if not model_id:
             raise ValueError(f"Expected a non-empty value for `model_id` but received {model_id!r}")
         extra_headers = {"Accept": "*/*", **(extra_headers or {})}
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return await self._delete(
             f"/v1/models/{model_id}",
             options=make_request_options(

--- a/src/llama_stack_client/resources/post_training/job.py
+++ b/src/llama_stack_client/resources/post_training/job.py
@@ -9,7 +9,6 @@ import httpx
 from ..._types import NOT_GIVEN, Body, Query, Headers, NoneType, NotGiven
 from ..._utils import (
     maybe_transform,
-    strip_not_given,
     async_maybe_transform,
 )
 from ..._compat import cached_property
@@ -53,8 +52,6 @@ class JobResource(SyncAPIResource):
     def list(
         self,
         *,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -62,25 +59,6 @@ class JobResource(SyncAPIResource):
         extra_body: Body | None = None,
         timeout: float | httpx.Timeout | None | NotGiven = NOT_GIVEN,
     ) -> JobListResponse:
-        """
-        Args:
-          extra_headers: Send extra headers
-
-          extra_query: Add additional query parameters to the request
-
-          extra_body: Add additional JSON properties to the request
-
-          timeout: Override the client-level default timeout for this request, in seconds
-        """
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return self._get(
             "/v1/post-training/jobs",
             options=make_request_options(
@@ -97,8 +75,6 @@ class JobResource(SyncAPIResource):
         self,
         *,
         job_uuid: str,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -116,15 +92,6 @@ class JobResource(SyncAPIResource):
 
           timeout: Override the client-level default timeout for this request, in seconds
         """
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return self._get(
             "/v1/post-training/job/artifacts",
             options=make_request_options(
@@ -141,8 +108,6 @@ class JobResource(SyncAPIResource):
         self,
         *,
         job_uuid: str,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -161,15 +126,6 @@ class JobResource(SyncAPIResource):
           timeout: Override the client-level default timeout for this request, in seconds
         """
         extra_headers = {"Accept": "*/*", **(extra_headers or {})}
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return self._post(
             "/v1/post-training/job/cancel",
             body=maybe_transform({"job_uuid": job_uuid}, job_cancel_params.JobCancelParams),
@@ -183,8 +139,6 @@ class JobResource(SyncAPIResource):
         self,
         *,
         job_uuid: str,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -202,15 +156,6 @@ class JobResource(SyncAPIResource):
 
           timeout: Override the client-level default timeout for this request, in seconds
         """
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return self._get(
             "/v1/post-training/job/status",
             options=make_request_options(
@@ -247,8 +192,6 @@ class AsyncJobResource(AsyncAPIResource):
     async def list(
         self,
         *,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -256,25 +199,6 @@ class AsyncJobResource(AsyncAPIResource):
         extra_body: Body | None = None,
         timeout: float | httpx.Timeout | None | NotGiven = NOT_GIVEN,
     ) -> JobListResponse:
-        """
-        Args:
-          extra_headers: Send extra headers
-
-          extra_query: Add additional query parameters to the request
-
-          extra_body: Add additional JSON properties to the request
-
-          timeout: Override the client-level default timeout for this request, in seconds
-        """
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return await self._get(
             "/v1/post-training/jobs",
             options=make_request_options(
@@ -291,8 +215,6 @@ class AsyncJobResource(AsyncAPIResource):
         self,
         *,
         job_uuid: str,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -310,15 +232,6 @@ class AsyncJobResource(AsyncAPIResource):
 
           timeout: Override the client-level default timeout for this request, in seconds
         """
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return await self._get(
             "/v1/post-training/job/artifacts",
             options=make_request_options(
@@ -335,8 +248,6 @@ class AsyncJobResource(AsyncAPIResource):
         self,
         *,
         job_uuid: str,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -355,15 +266,6 @@ class AsyncJobResource(AsyncAPIResource):
           timeout: Override the client-level default timeout for this request, in seconds
         """
         extra_headers = {"Accept": "*/*", **(extra_headers or {})}
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return await self._post(
             "/v1/post-training/job/cancel",
             body=await async_maybe_transform({"job_uuid": job_uuid}, job_cancel_params.JobCancelParams),
@@ -377,8 +279,6 @@ class AsyncJobResource(AsyncAPIResource):
         self,
         *,
         job_uuid: str,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -396,15 +296,6 @@ class AsyncJobResource(AsyncAPIResource):
 
           timeout: Override the client-level default timeout for this request, in seconds
         """
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return await self._get(
             "/v1/post-training/job/status",
             options=make_request_options(

--- a/src/llama_stack_client/resources/post_training/post_training.py
+++ b/src/llama_stack_client/resources/post_training/post_training.py
@@ -21,7 +21,6 @@ from ...types import (
 from ..._types import NOT_GIVEN, Body, Query, Headers, NotGiven
 from ..._utils import (
     maybe_transform,
-    strip_not_given,
     async_maybe_transform,
 )
 from ..._compat import cached_property
@@ -72,8 +71,6 @@ class PostTrainingResource(SyncAPIResource):
         job_uuid: str,
         logger_config: Dict[str, Union[bool, float, str, Iterable[object], object, None]],
         training_config: post_training_preference_optimize_params.TrainingConfig,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -91,15 +88,6 @@ class PostTrainingResource(SyncAPIResource):
 
           timeout: Override the client-level default timeout for this request, in seconds
         """
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return self._post(
             "/v1/post-training/preference-optimize",
             body=maybe_transform(
@@ -129,8 +117,6 @@ class PostTrainingResource(SyncAPIResource):
         training_config: post_training_supervised_fine_tune_params.TrainingConfig,
         algorithm_config: AlgorithmConfigParam | NotGiven = NOT_GIVEN,
         checkpoint_dir: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -148,15 +134,6 @@ class PostTrainingResource(SyncAPIResource):
 
           timeout: Override the client-level default timeout for this request, in seconds
         """
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return self._post(
             "/v1/post-training/supervised-fine-tune",
             body=maybe_transform(
@@ -211,8 +188,6 @@ class AsyncPostTrainingResource(AsyncAPIResource):
         job_uuid: str,
         logger_config: Dict[str, Union[bool, float, str, Iterable[object], object, None]],
         training_config: post_training_preference_optimize_params.TrainingConfig,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -230,15 +205,6 @@ class AsyncPostTrainingResource(AsyncAPIResource):
 
           timeout: Override the client-level default timeout for this request, in seconds
         """
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return await self._post(
             "/v1/post-training/preference-optimize",
             body=await async_maybe_transform(
@@ -268,8 +234,6 @@ class AsyncPostTrainingResource(AsyncAPIResource):
         training_config: post_training_supervised_fine_tune_params.TrainingConfig,
         algorithm_config: AlgorithmConfigParam | NotGiven = NOT_GIVEN,
         checkpoint_dir: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -287,15 +251,6 @@ class AsyncPostTrainingResource(AsyncAPIResource):
 
           timeout: Override the client-level default timeout for this request, in seconds
         """
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return await self._post(
             "/v1/post-training/supervised-fine-tune",
             body=await async_maybe_transform(

--- a/src/llama_stack_client/resources/providers.py
+++ b/src/llama_stack_client/resources/providers.py
@@ -7,7 +7,6 @@ from typing import Type, cast
 import httpx
 
 from .._types import NOT_GIVEN, Body, Query, Headers, NotGiven
-from .._utils import strip_not_given
 from .._compat import cached_property
 from .._resource import SyncAPIResource, AsyncAPIResource
 from .._response import (
@@ -46,8 +45,6 @@ class ProvidersResource(SyncAPIResource):
     def list(
         self,
         *,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -55,25 +52,6 @@ class ProvidersResource(SyncAPIResource):
         extra_body: Body | None = None,
         timeout: float | httpx.Timeout | None | NotGiven = NOT_GIVEN,
     ) -> ProviderListResponse:
-        """
-        Args:
-          extra_headers: Send extra headers
-
-          extra_query: Add additional query parameters to the request
-
-          extra_body: Add additional JSON properties to the request
-
-          timeout: Override the client-level default timeout for this request, in seconds
-        """
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return self._get(
             "/v1/inspect/providers",
             options=make_request_options(
@@ -110,8 +88,6 @@ class AsyncProvidersResource(AsyncAPIResource):
     async def list(
         self,
         *,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -119,25 +95,6 @@ class AsyncProvidersResource(AsyncAPIResource):
         extra_body: Body | None = None,
         timeout: float | httpx.Timeout | None | NotGiven = NOT_GIVEN,
     ) -> ProviderListResponse:
-        """
-        Args:
-          extra_headers: Send extra headers
-
-          extra_query: Add additional query parameters to the request
-
-          extra_body: Add additional JSON properties to the request
-
-          timeout: Override the client-level default timeout for this request, in seconds
-        """
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return await self._get(
             "/v1/inspect/providers",
             options=make_request_options(

--- a/src/llama_stack_client/resources/routes.py
+++ b/src/llama_stack_client/resources/routes.py
@@ -7,7 +7,6 @@ from typing import Type, cast
 import httpx
 
 from .._types import NOT_GIVEN, Body, Query, Headers, NotGiven
-from .._utils import strip_not_given
 from .._compat import cached_property
 from .._resource import SyncAPIResource, AsyncAPIResource
 from .._response import (
@@ -46,8 +45,6 @@ class RoutesResource(SyncAPIResource):
     def list(
         self,
         *,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -55,25 +52,6 @@ class RoutesResource(SyncAPIResource):
         extra_body: Body | None = None,
         timeout: float | httpx.Timeout | None | NotGiven = NOT_GIVEN,
     ) -> RouteListResponse:
-        """
-        Args:
-          extra_headers: Send extra headers
-
-          extra_query: Add additional query parameters to the request
-
-          extra_body: Add additional JSON properties to the request
-
-          timeout: Override the client-level default timeout for this request, in seconds
-        """
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return self._get(
             "/v1/inspect/routes",
             options=make_request_options(
@@ -110,8 +88,6 @@ class AsyncRoutesResource(AsyncAPIResource):
     async def list(
         self,
         *,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -119,25 +95,6 @@ class AsyncRoutesResource(AsyncAPIResource):
         extra_body: Body | None = None,
         timeout: float | httpx.Timeout | None | NotGiven = NOT_GIVEN,
     ) -> RouteListResponse:
-        """
-        Args:
-          extra_headers: Send extra headers
-
-          extra_query: Add additional query parameters to the request
-
-          extra_body: Add additional JSON properties to the request
-
-          timeout: Override the client-level default timeout for this request, in seconds
-        """
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return await self._get(
             "/v1/inspect/routes",
             options=make_request_options(

--- a/src/llama_stack_client/resources/safety.py
+++ b/src/llama_stack_client/resources/safety.py
@@ -10,7 +10,6 @@ from ..types import safety_run_shield_params
 from .._types import NOT_GIVEN, Body, Query, Headers, NotGiven
 from .._utils import (
     maybe_transform,
-    strip_not_given,
     async_maybe_transform,
 )
 from .._compat import cached_property
@@ -54,8 +53,6 @@ class SafetyResource(SyncAPIResource):
         messages: Iterable[Message],
         params: Dict[str, Union[bool, float, str, Iterable[object], object, None]],
         shield_id: str,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -73,15 +70,6 @@ class SafetyResource(SyncAPIResource):
 
           timeout: Override the client-level default timeout for this request, in seconds
         """
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return self._post(
             "/v1/safety/run-shield",
             body=maybe_transform(
@@ -125,8 +113,6 @@ class AsyncSafetyResource(AsyncAPIResource):
         messages: Iterable[Message],
         params: Dict[str, Union[bool, float, str, Iterable[object], object, None]],
         shield_id: str,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -144,15 +130,6 @@ class AsyncSafetyResource(AsyncAPIResource):
 
           timeout: Override the client-level default timeout for this request, in seconds
         """
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return await self._post(
             "/v1/safety/run-shield",
             body=await async_maybe_transform(

--- a/src/llama_stack_client/resources/scoring.py
+++ b/src/llama_stack_client/resources/scoring.py
@@ -10,7 +10,6 @@ from ..types import scoring_score_params, scoring_score_batch_params
 from .._types import NOT_GIVEN, Body, Query, Headers, NotGiven
 from .._utils import (
     maybe_transform,
-    strip_not_given,
     async_maybe_transform,
 )
 from .._compat import cached_property
@@ -54,8 +53,6 @@ class ScoringResource(SyncAPIResource):
         *,
         input_rows: Iterable[Dict[str, Union[bool, float, str, Iterable[object], object, None]]],
         scoring_functions: Dict[str, Optional[ScoringFnParamsParam]],
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -73,15 +70,6 @@ class ScoringResource(SyncAPIResource):
 
           timeout: Override the client-level default timeout for this request, in seconds
         """
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return self._post(
             "/v1/scoring/score",
             body=maybe_transform(
@@ -103,8 +91,6 @@ class ScoringResource(SyncAPIResource):
         dataset_id: str,
         save_results_dataset: bool,
         scoring_functions: Dict[str, Optional[ScoringFnParamsParam]],
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -122,15 +108,6 @@ class ScoringResource(SyncAPIResource):
 
           timeout: Override the client-level default timeout for this request, in seconds
         """
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return self._post(
             "/v1/scoring/score-batch",
             body=maybe_transform(
@@ -173,8 +150,6 @@ class AsyncScoringResource(AsyncAPIResource):
         *,
         input_rows: Iterable[Dict[str, Union[bool, float, str, Iterable[object], object, None]]],
         scoring_functions: Dict[str, Optional[ScoringFnParamsParam]],
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -192,15 +167,6 @@ class AsyncScoringResource(AsyncAPIResource):
 
           timeout: Override the client-level default timeout for this request, in seconds
         """
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return await self._post(
             "/v1/scoring/score",
             body=await async_maybe_transform(
@@ -222,8 +188,6 @@ class AsyncScoringResource(AsyncAPIResource):
         dataset_id: str,
         save_results_dataset: bool,
         scoring_functions: Dict[str, Optional[ScoringFnParamsParam]],
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -241,15 +205,6 @@ class AsyncScoringResource(AsyncAPIResource):
 
           timeout: Override the client-level default timeout for this request, in seconds
         """
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return await self._post(
             "/v1/scoring/score-batch",
             body=await async_maybe_transform(

--- a/src/llama_stack_client/resources/scoring_functions.py
+++ b/src/llama_stack_client/resources/scoring_functions.py
@@ -10,7 +10,6 @@ from ..types import scoring_function_register_params
 from .._types import NOT_GIVEN, Body, Query, Headers, NoneType, NotGiven
 from .._utils import (
     maybe_transform,
-    strip_not_given,
     async_maybe_transform,
 )
 from .._compat import cached_property
@@ -55,8 +54,6 @@ class ScoringFunctionsResource(SyncAPIResource):
         self,
         scoring_fn_id: str,
         *,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -76,15 +73,6 @@ class ScoringFunctionsResource(SyncAPIResource):
         """
         if not scoring_fn_id:
             raise ValueError(f"Expected a non-empty value for `scoring_fn_id` but received {scoring_fn_id!r}")
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return self._get(
             f"/v1/scoring-functions/{scoring_fn_id}",
             options=make_request_options(
@@ -96,8 +84,6 @@ class ScoringFunctionsResource(SyncAPIResource):
     def list(
         self,
         *,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -105,25 +91,6 @@ class ScoringFunctionsResource(SyncAPIResource):
         extra_body: Body | None = None,
         timeout: float | httpx.Timeout | None | NotGiven = NOT_GIVEN,
     ) -> ScoringFunctionListResponse:
-        """
-        Args:
-          extra_headers: Send extra headers
-
-          extra_query: Add additional query parameters to the request
-
-          extra_body: Add additional JSON properties to the request
-
-          timeout: Override the client-level default timeout for this request, in seconds
-        """
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return self._get(
             "/v1/scoring-functions",
             options=make_request_options(
@@ -145,8 +112,6 @@ class ScoringFunctionsResource(SyncAPIResource):
         params: ScoringFnParamsParam | NotGiven = NOT_GIVEN,
         provider_id: str | NotGiven = NOT_GIVEN,
         provider_scoring_fn_id: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -165,15 +130,6 @@ class ScoringFunctionsResource(SyncAPIResource):
           timeout: Override the client-level default timeout for this request, in seconds
         """
         extra_headers = {"Accept": "*/*", **(extra_headers or {})}
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return self._post(
             "/v1/scoring-functions",
             body=maybe_transform(
@@ -218,8 +174,6 @@ class AsyncScoringFunctionsResource(AsyncAPIResource):
         self,
         scoring_fn_id: str,
         *,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -239,15 +193,6 @@ class AsyncScoringFunctionsResource(AsyncAPIResource):
         """
         if not scoring_fn_id:
             raise ValueError(f"Expected a non-empty value for `scoring_fn_id` but received {scoring_fn_id!r}")
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return await self._get(
             f"/v1/scoring-functions/{scoring_fn_id}",
             options=make_request_options(
@@ -259,8 +204,6 @@ class AsyncScoringFunctionsResource(AsyncAPIResource):
     async def list(
         self,
         *,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -268,25 +211,6 @@ class AsyncScoringFunctionsResource(AsyncAPIResource):
         extra_body: Body | None = None,
         timeout: float | httpx.Timeout | None | NotGiven = NOT_GIVEN,
     ) -> ScoringFunctionListResponse:
-        """
-        Args:
-          extra_headers: Send extra headers
-
-          extra_query: Add additional query parameters to the request
-
-          extra_body: Add additional JSON properties to the request
-
-          timeout: Override the client-level default timeout for this request, in seconds
-        """
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return await self._get(
             "/v1/scoring-functions",
             options=make_request_options(
@@ -308,8 +232,6 @@ class AsyncScoringFunctionsResource(AsyncAPIResource):
         params: ScoringFnParamsParam | NotGiven = NOT_GIVEN,
         provider_id: str | NotGiven = NOT_GIVEN,
         provider_scoring_fn_id: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -328,15 +250,6 @@ class AsyncScoringFunctionsResource(AsyncAPIResource):
           timeout: Override the client-level default timeout for this request, in seconds
         """
         extra_headers = {"Accept": "*/*", **(extra_headers or {})}
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return await self._post(
             "/v1/scoring-functions",
             body=await async_maybe_transform(

--- a/src/llama_stack_client/resources/shields.py
+++ b/src/llama_stack_client/resources/shields.py
@@ -10,7 +10,6 @@ from ..types import shield_register_params
 from .._types import NOT_GIVEN, Body, Query, Headers, NotGiven
 from .._utils import (
     maybe_transform,
-    strip_not_given,
     async_maybe_transform,
 )
 from .._compat import cached_property
@@ -53,8 +52,6 @@ class ShieldsResource(SyncAPIResource):
         self,
         identifier: str,
         *,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -74,15 +71,6 @@ class ShieldsResource(SyncAPIResource):
         """
         if not identifier:
             raise ValueError(f"Expected a non-empty value for `identifier` but received {identifier!r}")
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return self._get(
             f"/v1/shields/{identifier}",
             options=make_request_options(
@@ -94,8 +82,6 @@ class ShieldsResource(SyncAPIResource):
     def list(
         self,
         *,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -103,25 +89,6 @@ class ShieldsResource(SyncAPIResource):
         extra_body: Body | None = None,
         timeout: float | httpx.Timeout | None | NotGiven = NOT_GIVEN,
     ) -> ShieldListResponse:
-        """
-        Args:
-          extra_headers: Send extra headers
-
-          extra_query: Add additional query parameters to the request
-
-          extra_body: Add additional JSON properties to the request
-
-          timeout: Override the client-level default timeout for this request, in seconds
-        """
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return self._get(
             "/v1/shields",
             options=make_request_options(
@@ -141,8 +108,6 @@ class ShieldsResource(SyncAPIResource):
         params: Dict[str, Union[bool, float, str, Iterable[object], object, None]] | NotGiven = NOT_GIVEN,
         provider_id: str | NotGiven = NOT_GIVEN,
         provider_shield_id: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -160,15 +125,6 @@ class ShieldsResource(SyncAPIResource):
 
           timeout: Override the client-level default timeout for this request, in seconds
         """
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return self._post(
             "/v1/shields",
             body=maybe_transform(
@@ -211,8 +167,6 @@ class AsyncShieldsResource(AsyncAPIResource):
         self,
         identifier: str,
         *,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -232,15 +186,6 @@ class AsyncShieldsResource(AsyncAPIResource):
         """
         if not identifier:
             raise ValueError(f"Expected a non-empty value for `identifier` but received {identifier!r}")
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return await self._get(
             f"/v1/shields/{identifier}",
             options=make_request_options(
@@ -252,8 +197,6 @@ class AsyncShieldsResource(AsyncAPIResource):
     async def list(
         self,
         *,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -261,25 +204,6 @@ class AsyncShieldsResource(AsyncAPIResource):
         extra_body: Body | None = None,
         timeout: float | httpx.Timeout | None | NotGiven = NOT_GIVEN,
     ) -> ShieldListResponse:
-        """
-        Args:
-          extra_headers: Send extra headers
-
-          extra_query: Add additional query parameters to the request
-
-          extra_body: Add additional JSON properties to the request
-
-          timeout: Override the client-level default timeout for this request, in seconds
-        """
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return await self._get(
             "/v1/shields",
             options=make_request_options(
@@ -299,8 +223,6 @@ class AsyncShieldsResource(AsyncAPIResource):
         params: Dict[str, Union[bool, float, str, Iterable[object], object, None]] | NotGiven = NOT_GIVEN,
         provider_id: str | NotGiven = NOT_GIVEN,
         provider_shield_id: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -318,15 +240,6 @@ class AsyncShieldsResource(AsyncAPIResource):
 
           timeout: Override the client-level default timeout for this request, in seconds
         """
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return await self._post(
             "/v1/shields",
             body=await async_maybe_transform(

--- a/src/llama_stack_client/resources/synthetic_data_generation.py
+++ b/src/llama_stack_client/resources/synthetic_data_generation.py
@@ -11,7 +11,6 @@ from ..types import synthetic_data_generation_generate_params
 from .._types import NOT_GIVEN, Body, Query, Headers, NotGiven
 from .._utils import (
     maybe_transform,
-    strip_not_given,
     async_maybe_transform,
 )
 from .._compat import cached_property
@@ -55,8 +54,6 @@ class SyntheticDataGenerationResource(SyncAPIResource):
         dialogs: Iterable[Message],
         filtering_function: Literal["none", "random", "top_k", "top_p", "top_k_top_p", "sigmoid"],
         model: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -74,15 +71,6 @@ class SyntheticDataGenerationResource(SyncAPIResource):
 
           timeout: Override the client-level default timeout for this request, in seconds
         """
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return self._post(
             "/v1/synthetic-data-generation/generate",
             body=maybe_transform(
@@ -126,8 +114,6 @@ class AsyncSyntheticDataGenerationResource(AsyncAPIResource):
         dialogs: Iterable[Message],
         filtering_function: Literal["none", "random", "top_k", "top_p", "top_k_top_p", "sigmoid"],
         model: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -145,15 +131,6 @@ class AsyncSyntheticDataGenerationResource(AsyncAPIResource):
 
           timeout: Override the client-level default timeout for this request, in seconds
         """
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return await self._post(
             "/v1/synthetic-data-generation/generate",
             body=await async_maybe_transform(

--- a/src/llama_stack_client/resources/telemetry.py
+++ b/src/llama_stack_client/resources/telemetry.py
@@ -16,7 +16,6 @@ from ..types import (
 from .._types import NOT_GIVEN, Body, Query, Headers, NoneType, NotGiven
 from .._utils import (
     maybe_transform,
-    strip_not_given,
     async_maybe_transform,
 )
 from .._compat import cached_property
@@ -65,8 +64,6 @@ class TelemetryResource(SyncAPIResource):
         span_id: str,
         *,
         trace_id: str,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -88,15 +85,6 @@ class TelemetryResource(SyncAPIResource):
             raise ValueError(f"Expected a non-empty value for `trace_id` but received {trace_id!r}")
         if not span_id:
             raise ValueError(f"Expected a non-empty value for `span_id` but received {span_id!r}")
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return self._get(
             f"/v1/telemetry/traces/{trace_id}/spans/{span_id}",
             options=make_request_options(
@@ -111,8 +99,6 @@ class TelemetryResource(SyncAPIResource):
         *,
         attributes_to_return: List[str] | NotGiven = NOT_GIVEN,
         max_depth: int | NotGiven = NOT_GIVEN,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -132,15 +118,6 @@ class TelemetryResource(SyncAPIResource):
         """
         if not span_id:
             raise ValueError(f"Expected a non-empty value for `span_id` but received {span_id!r}")
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return self._get(
             f"/v1/telemetry/spans/{span_id}/tree",
             options=make_request_options(
@@ -164,8 +141,6 @@ class TelemetryResource(SyncAPIResource):
         self,
         trace_id: str,
         *,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -185,15 +160,6 @@ class TelemetryResource(SyncAPIResource):
         """
         if not trace_id:
             raise ValueError(f"Expected a non-empty value for `trace_id` but received {trace_id!r}")
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return self._get(
             f"/v1/telemetry/traces/{trace_id}",
             options=make_request_options(
@@ -207,8 +173,6 @@ class TelemetryResource(SyncAPIResource):
         *,
         event: EventParam,
         ttl_seconds: int,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -227,15 +191,6 @@ class TelemetryResource(SyncAPIResource):
           timeout: Override the client-level default timeout for this request, in seconds
         """
         extra_headers = {"Accept": "*/*", **(extra_headers or {})}
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return self._post(
             "/v1/telemetry/events",
             body=maybe_transform(
@@ -257,8 +212,6 @@ class TelemetryResource(SyncAPIResource):
         attribute_filters: Iterable[QueryConditionParam],
         attributes_to_return: List[str],
         max_depth: int | NotGiven = NOT_GIVEN,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -276,15 +229,6 @@ class TelemetryResource(SyncAPIResource):
 
           timeout: Override the client-level default timeout for this request, in seconds
         """
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return self._get(
             "/v1/telemetry/spans",
             options=make_request_options(
@@ -312,8 +256,6 @@ class TelemetryResource(SyncAPIResource):
         limit: int | NotGiven = NOT_GIVEN,
         offset: int | NotGiven = NOT_GIVEN,
         order_by: List[str] | NotGiven = NOT_GIVEN,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -331,15 +273,6 @@ class TelemetryResource(SyncAPIResource):
 
           timeout: Override the client-level default timeout for this request, in seconds
         """
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return self._get(
             "/v1/telemetry/traces",
             options=make_request_options(
@@ -368,8 +301,6 @@ class TelemetryResource(SyncAPIResource):
         attributes_to_save: List[str],
         dataset_id: str,
         max_depth: int | NotGiven = NOT_GIVEN,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -388,15 +319,6 @@ class TelemetryResource(SyncAPIResource):
           timeout: Override the client-level default timeout for this request, in seconds
         """
         extra_headers = {"Accept": "*/*", **(extra_headers or {})}
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return self._post(
             "/v1/telemetry/spans/export",
             body=maybe_transform(
@@ -440,8 +362,6 @@ class AsyncTelemetryResource(AsyncAPIResource):
         span_id: str,
         *,
         trace_id: str,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -463,15 +383,6 @@ class AsyncTelemetryResource(AsyncAPIResource):
             raise ValueError(f"Expected a non-empty value for `trace_id` but received {trace_id!r}")
         if not span_id:
             raise ValueError(f"Expected a non-empty value for `span_id` but received {span_id!r}")
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return await self._get(
             f"/v1/telemetry/traces/{trace_id}/spans/{span_id}",
             options=make_request_options(
@@ -486,8 +397,6 @@ class AsyncTelemetryResource(AsyncAPIResource):
         *,
         attributes_to_return: List[str] | NotGiven = NOT_GIVEN,
         max_depth: int | NotGiven = NOT_GIVEN,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -507,15 +416,6 @@ class AsyncTelemetryResource(AsyncAPIResource):
         """
         if not span_id:
             raise ValueError(f"Expected a non-empty value for `span_id` but received {span_id!r}")
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return await self._get(
             f"/v1/telemetry/spans/{span_id}/tree",
             options=make_request_options(
@@ -539,8 +439,6 @@ class AsyncTelemetryResource(AsyncAPIResource):
         self,
         trace_id: str,
         *,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -560,15 +458,6 @@ class AsyncTelemetryResource(AsyncAPIResource):
         """
         if not trace_id:
             raise ValueError(f"Expected a non-empty value for `trace_id` but received {trace_id!r}")
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return await self._get(
             f"/v1/telemetry/traces/{trace_id}",
             options=make_request_options(
@@ -582,8 +471,6 @@ class AsyncTelemetryResource(AsyncAPIResource):
         *,
         event: EventParam,
         ttl_seconds: int,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -602,15 +489,6 @@ class AsyncTelemetryResource(AsyncAPIResource):
           timeout: Override the client-level default timeout for this request, in seconds
         """
         extra_headers = {"Accept": "*/*", **(extra_headers or {})}
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return await self._post(
             "/v1/telemetry/events",
             body=await async_maybe_transform(
@@ -632,8 +510,6 @@ class AsyncTelemetryResource(AsyncAPIResource):
         attribute_filters: Iterable[QueryConditionParam],
         attributes_to_return: List[str],
         max_depth: int | NotGiven = NOT_GIVEN,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -651,15 +527,6 @@ class AsyncTelemetryResource(AsyncAPIResource):
 
           timeout: Override the client-level default timeout for this request, in seconds
         """
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return await self._get(
             "/v1/telemetry/spans",
             options=make_request_options(
@@ -687,8 +554,6 @@ class AsyncTelemetryResource(AsyncAPIResource):
         limit: int | NotGiven = NOT_GIVEN,
         offset: int | NotGiven = NOT_GIVEN,
         order_by: List[str] | NotGiven = NOT_GIVEN,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -706,15 +571,6 @@ class AsyncTelemetryResource(AsyncAPIResource):
 
           timeout: Override the client-level default timeout for this request, in seconds
         """
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return await self._get(
             "/v1/telemetry/traces",
             options=make_request_options(
@@ -743,8 +599,6 @@ class AsyncTelemetryResource(AsyncAPIResource):
         attributes_to_save: List[str],
         dataset_id: str,
         max_depth: int | NotGiven = NOT_GIVEN,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -763,15 +617,6 @@ class AsyncTelemetryResource(AsyncAPIResource):
           timeout: Override the client-level default timeout for this request, in seconds
         """
         extra_headers = {"Accept": "*/*", **(extra_headers or {})}
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return await self._post(
             "/v1/telemetry/spans/export",
             body=await async_maybe_transform(

--- a/src/llama_stack_client/resources/tool_runtime/rag_tool.py
+++ b/src/llama_stack_client/resources/tool_runtime/rag_tool.py
@@ -9,7 +9,6 @@ import httpx
 from ..._types import NOT_GIVEN, Body, Query, Headers, NoneType, NotGiven
 from ..._utils import (
     maybe_transform,
-    strip_not_given,
     async_maybe_transform,
 )
 from ..._compat import cached_property
@@ -56,8 +55,6 @@ class RagToolResource(SyncAPIResource):
         chunk_size_in_tokens: int,
         documents: Iterable[Document],
         vector_db_id: str,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -78,15 +75,6 @@ class RagToolResource(SyncAPIResource):
           timeout: Override the client-level default timeout for this request, in seconds
         """
         extra_headers = {"Accept": "*/*", **(extra_headers or {})}
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return self._post(
             "/v1/tool-runtime/rag-tool/insert",
             body=maybe_transform(
@@ -109,8 +97,6 @@ class RagToolResource(SyncAPIResource):
         content: InterleavedContent,
         vector_db_ids: List[str],
         query_config: QueryConfig | NotGiven = NOT_GIVEN,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -130,15 +116,6 @@ class RagToolResource(SyncAPIResource):
 
           timeout: Override the client-level default timeout for this request, in seconds
         """
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return self._post(
             "/v1/tool-runtime/rag-tool/query",
             body=maybe_transform(
@@ -182,8 +159,6 @@ class AsyncRagToolResource(AsyncAPIResource):
         chunk_size_in_tokens: int,
         documents: Iterable[Document],
         vector_db_id: str,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -204,15 +179,6 @@ class AsyncRagToolResource(AsyncAPIResource):
           timeout: Override the client-level default timeout for this request, in seconds
         """
         extra_headers = {"Accept": "*/*", **(extra_headers or {})}
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return await self._post(
             "/v1/tool-runtime/rag-tool/insert",
             body=await async_maybe_transform(
@@ -235,8 +201,6 @@ class AsyncRagToolResource(AsyncAPIResource):
         content: InterleavedContent,
         vector_db_ids: List[str],
         query_config: QueryConfig | NotGiven = NOT_GIVEN,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -256,15 +220,6 @@ class AsyncRagToolResource(AsyncAPIResource):
 
           timeout: Override the client-level default timeout for this request, in seconds
         """
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return await self._post(
             "/v1/tool-runtime/rag-tool/query",
             body=await async_maybe_transform(

--- a/src/llama_stack_client/resources/tool_runtime/tool_runtime.py
+++ b/src/llama_stack_client/resources/tool_runtime/tool_runtime.py
@@ -10,7 +10,6 @@ from ...types import tool_runtime_list_tools_params, tool_runtime_invoke_tool_pa
 from ..._types import NOT_GIVEN, Body, Query, Headers, NotGiven
 from ..._utils import (
     maybe_transform,
-    strip_not_given,
     async_maybe_transform,
 )
 from .rag_tool import (
@@ -67,8 +66,6 @@ class ToolRuntimeResource(SyncAPIResource):
         *,
         kwargs: Dict[str, Union[bool, float, str, Iterable[object], object, None]],
         tool_name: str,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -88,15 +85,6 @@ class ToolRuntimeResource(SyncAPIResource):
 
           timeout: Override the client-level default timeout for this request, in seconds
         """
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return self._post(
             "/v1/tool-runtime/invoke",
             body=maybe_transform(
@@ -117,8 +105,6 @@ class ToolRuntimeResource(SyncAPIResource):
         *,
         mcp_endpoint: URL | NotGiven = NOT_GIVEN,
         tool_group_id: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -137,15 +123,6 @@ class ToolRuntimeResource(SyncAPIResource):
           timeout: Override the client-level default timeout for this request, in seconds
         """
         extra_headers = {"Accept": "application/jsonl", **(extra_headers or {})}
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return self._get(
             "/v1/tool-runtime/list-tools",
             options=make_request_options(
@@ -195,8 +172,6 @@ class AsyncToolRuntimeResource(AsyncAPIResource):
         *,
         kwargs: Dict[str, Union[bool, float, str, Iterable[object], object, None]],
         tool_name: str,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -216,15 +191,6 @@ class AsyncToolRuntimeResource(AsyncAPIResource):
 
           timeout: Override the client-level default timeout for this request, in seconds
         """
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return await self._post(
             "/v1/tool-runtime/invoke",
             body=await async_maybe_transform(
@@ -245,8 +211,6 @@ class AsyncToolRuntimeResource(AsyncAPIResource):
         *,
         mcp_endpoint: URL | NotGiven = NOT_GIVEN,
         tool_group_id: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -265,15 +229,6 @@ class AsyncToolRuntimeResource(AsyncAPIResource):
           timeout: Override the client-level default timeout for this request, in seconds
         """
         extra_headers = {"Accept": "application/jsonl", **(extra_headers or {})}
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return await self._get(
             "/v1/tool-runtime/list-tools",
             options=make_request_options(

--- a/src/llama_stack_client/resources/toolgroups.py
+++ b/src/llama_stack_client/resources/toolgroups.py
@@ -10,7 +10,6 @@ from ..types import toolgroup_register_params
 from .._types import NOT_GIVEN, Body, Query, Headers, NoneType, NotGiven
 from .._utils import (
     maybe_transform,
-    strip_not_given,
     async_maybe_transform,
 )
 from .._compat import cached_property
@@ -53,8 +52,6 @@ class ToolgroupsResource(SyncAPIResource):
     def list(
         self,
         *,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -62,27 +59,7 @@ class ToolgroupsResource(SyncAPIResource):
         extra_body: Body | None = None,
         timeout: float | httpx.Timeout | None | NotGiven = NOT_GIVEN,
     ) -> ToolgroupListResponse:
-        """
-        List tool groups with optional provider
-
-        Args:
-          extra_headers: Send extra headers
-
-          extra_query: Add additional query parameters to the request
-
-          extra_body: Add additional JSON properties to the request
-
-          timeout: Override the client-level default timeout for this request, in seconds
-        """
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
+        """List tool groups with optional provider"""
         return self._get(
             "/v1/toolgroups",
             options=make_request_options(
@@ -99,8 +76,6 @@ class ToolgroupsResource(SyncAPIResource):
         self,
         toolgroup_id: str,
         *,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -120,15 +95,6 @@ class ToolgroupsResource(SyncAPIResource):
         """
         if not toolgroup_id:
             raise ValueError(f"Expected a non-empty value for `toolgroup_id` but received {toolgroup_id!r}")
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return self._get(
             f"/v1/toolgroups/{toolgroup_id}",
             options=make_request_options(
@@ -144,8 +110,6 @@ class ToolgroupsResource(SyncAPIResource):
         toolgroup_id: str,
         args: Dict[str, Union[bool, float, str, Iterable[object], object, None]] | NotGiven = NOT_GIVEN,
         mcp_endpoint: URL | NotGiven = NOT_GIVEN,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -166,15 +130,6 @@ class ToolgroupsResource(SyncAPIResource):
           timeout: Override the client-level default timeout for this request, in seconds
         """
         extra_headers = {"Accept": "*/*", **(extra_headers or {})}
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return self._post(
             "/v1/toolgroups",
             body=maybe_transform(
@@ -196,8 +151,6 @@ class ToolgroupsResource(SyncAPIResource):
         self,
         toolgroup_id: str,
         *,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -220,15 +173,6 @@ class ToolgroupsResource(SyncAPIResource):
         if not toolgroup_id:
             raise ValueError(f"Expected a non-empty value for `toolgroup_id` but received {toolgroup_id!r}")
         extra_headers = {"Accept": "*/*", **(extra_headers or {})}
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return self._delete(
             f"/v1/toolgroups/{toolgroup_id}",
             options=make_request_options(
@@ -261,8 +205,6 @@ class AsyncToolgroupsResource(AsyncAPIResource):
     async def list(
         self,
         *,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -270,27 +212,7 @@ class AsyncToolgroupsResource(AsyncAPIResource):
         extra_body: Body | None = None,
         timeout: float | httpx.Timeout | None | NotGiven = NOT_GIVEN,
     ) -> ToolgroupListResponse:
-        """
-        List tool groups with optional provider
-
-        Args:
-          extra_headers: Send extra headers
-
-          extra_query: Add additional query parameters to the request
-
-          extra_body: Add additional JSON properties to the request
-
-          timeout: Override the client-level default timeout for this request, in seconds
-        """
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
+        """List tool groups with optional provider"""
         return await self._get(
             "/v1/toolgroups",
             options=make_request_options(
@@ -307,8 +229,6 @@ class AsyncToolgroupsResource(AsyncAPIResource):
         self,
         toolgroup_id: str,
         *,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -328,15 +248,6 @@ class AsyncToolgroupsResource(AsyncAPIResource):
         """
         if not toolgroup_id:
             raise ValueError(f"Expected a non-empty value for `toolgroup_id` but received {toolgroup_id!r}")
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return await self._get(
             f"/v1/toolgroups/{toolgroup_id}",
             options=make_request_options(
@@ -352,8 +263,6 @@ class AsyncToolgroupsResource(AsyncAPIResource):
         toolgroup_id: str,
         args: Dict[str, Union[bool, float, str, Iterable[object], object, None]] | NotGiven = NOT_GIVEN,
         mcp_endpoint: URL | NotGiven = NOT_GIVEN,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -374,15 +283,6 @@ class AsyncToolgroupsResource(AsyncAPIResource):
           timeout: Override the client-level default timeout for this request, in seconds
         """
         extra_headers = {"Accept": "*/*", **(extra_headers or {})}
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return await self._post(
             "/v1/toolgroups",
             body=await async_maybe_transform(
@@ -404,8 +304,6 @@ class AsyncToolgroupsResource(AsyncAPIResource):
         self,
         toolgroup_id: str,
         *,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -428,15 +326,6 @@ class AsyncToolgroupsResource(AsyncAPIResource):
         if not toolgroup_id:
             raise ValueError(f"Expected a non-empty value for `toolgroup_id` but received {toolgroup_id!r}")
         extra_headers = {"Accept": "*/*", **(extra_headers or {})}
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return await self._delete(
             f"/v1/toolgroups/{toolgroup_id}",
             options=make_request_options(

--- a/src/llama_stack_client/resources/tools.py
+++ b/src/llama_stack_client/resources/tools.py
@@ -10,7 +10,6 @@ from ..types import tool_list_params
 from .._types import NOT_GIVEN, Body, Query, Headers, NotGiven
 from .._utils import (
     maybe_transform,
-    strip_not_given,
     async_maybe_transform,
 )
 from .._compat import cached_property
@@ -53,8 +52,6 @@ class ToolsResource(SyncAPIResource):
         self,
         *,
         toolgroup_id: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -74,15 +71,6 @@ class ToolsResource(SyncAPIResource):
 
           timeout: Override the client-level default timeout for this request, in seconds
         """
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return self._get(
             "/v1/tools",
             options=make_request_options(
@@ -100,8 +88,6 @@ class ToolsResource(SyncAPIResource):
         self,
         tool_name: str,
         *,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -121,15 +107,6 @@ class ToolsResource(SyncAPIResource):
         """
         if not tool_name:
             raise ValueError(f"Expected a non-empty value for `tool_name` but received {tool_name!r}")
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return self._get(
             f"/v1/tools/{tool_name}",
             options=make_request_options(
@@ -163,8 +140,6 @@ class AsyncToolsResource(AsyncAPIResource):
         self,
         *,
         toolgroup_id: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -184,15 +159,6 @@ class AsyncToolsResource(AsyncAPIResource):
 
           timeout: Override the client-level default timeout for this request, in seconds
         """
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return await self._get(
             "/v1/tools",
             options=make_request_options(
@@ -210,8 +176,6 @@ class AsyncToolsResource(AsyncAPIResource):
         self,
         tool_name: str,
         *,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -231,15 +195,6 @@ class AsyncToolsResource(AsyncAPIResource):
         """
         if not tool_name:
             raise ValueError(f"Expected a non-empty value for `tool_name` but received {tool_name!r}")
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return await self._get(
             f"/v1/tools/{tool_name}",
             options=make_request_options(

--- a/src/llama_stack_client/resources/vector_dbs.py
+++ b/src/llama_stack_client/resources/vector_dbs.py
@@ -10,7 +10,6 @@ from ..types import vector_db_register_params
 from .._types import NOT_GIVEN, Body, Query, Headers, NoneType, NotGiven
 from .._utils import (
     maybe_transform,
-    strip_not_given,
     async_maybe_transform,
 )
 from .._compat import cached_property
@@ -54,8 +53,6 @@ class VectorDBsResource(SyncAPIResource):
         self,
         vector_db_id: str,
         *,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -75,15 +72,6 @@ class VectorDBsResource(SyncAPIResource):
         """
         if not vector_db_id:
             raise ValueError(f"Expected a non-empty value for `vector_db_id` but received {vector_db_id!r}")
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return self._get(
             f"/v1/vector-dbs/{vector_db_id}",
             options=make_request_options(
@@ -95,8 +83,6 @@ class VectorDBsResource(SyncAPIResource):
     def list(
         self,
         *,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -104,25 +90,6 @@ class VectorDBsResource(SyncAPIResource):
         extra_body: Body | None = None,
         timeout: float | httpx.Timeout | None | NotGiven = NOT_GIVEN,
     ) -> VectorDBListResponse:
-        """
-        Args:
-          extra_headers: Send extra headers
-
-          extra_query: Add additional query parameters to the request
-
-          extra_body: Add additional JSON properties to the request
-
-          timeout: Override the client-level default timeout for this request, in seconds
-        """
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return self._get(
             "/v1/vector-dbs",
             options=make_request_options(
@@ -143,8 +110,6 @@ class VectorDBsResource(SyncAPIResource):
         embedding_dimension: int | NotGiven = NOT_GIVEN,
         provider_id: str | NotGiven = NOT_GIVEN,
         provider_vector_db_id: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -162,15 +127,6 @@ class VectorDBsResource(SyncAPIResource):
 
           timeout: Override the client-level default timeout for this request, in seconds
         """
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return self._post(
             "/v1/vector-dbs",
             body=maybe_transform(
@@ -193,8 +149,6 @@ class VectorDBsResource(SyncAPIResource):
         self,
         vector_db_id: str,
         *,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -215,15 +169,6 @@ class VectorDBsResource(SyncAPIResource):
         if not vector_db_id:
             raise ValueError(f"Expected a non-empty value for `vector_db_id` but received {vector_db_id!r}")
         extra_headers = {"Accept": "*/*", **(extra_headers or {})}
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return self._delete(
             f"/v1/vector-dbs/{vector_db_id}",
             options=make_request_options(
@@ -257,8 +202,6 @@ class AsyncVectorDBsResource(AsyncAPIResource):
         self,
         vector_db_id: str,
         *,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -278,15 +221,6 @@ class AsyncVectorDBsResource(AsyncAPIResource):
         """
         if not vector_db_id:
             raise ValueError(f"Expected a non-empty value for `vector_db_id` but received {vector_db_id!r}")
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return await self._get(
             f"/v1/vector-dbs/{vector_db_id}",
             options=make_request_options(
@@ -298,8 +232,6 @@ class AsyncVectorDBsResource(AsyncAPIResource):
     async def list(
         self,
         *,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -307,25 +239,6 @@ class AsyncVectorDBsResource(AsyncAPIResource):
         extra_body: Body | None = None,
         timeout: float | httpx.Timeout | None | NotGiven = NOT_GIVEN,
     ) -> VectorDBListResponse:
-        """
-        Args:
-          extra_headers: Send extra headers
-
-          extra_query: Add additional query parameters to the request
-
-          extra_body: Add additional JSON properties to the request
-
-          timeout: Override the client-level default timeout for this request, in seconds
-        """
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return await self._get(
             "/v1/vector-dbs",
             options=make_request_options(
@@ -346,8 +259,6 @@ class AsyncVectorDBsResource(AsyncAPIResource):
         embedding_dimension: int | NotGiven = NOT_GIVEN,
         provider_id: str | NotGiven = NOT_GIVEN,
         provider_vector_db_id: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -365,15 +276,6 @@ class AsyncVectorDBsResource(AsyncAPIResource):
 
           timeout: Override the client-level default timeout for this request, in seconds
         """
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return await self._post(
             "/v1/vector-dbs",
             body=await async_maybe_transform(
@@ -396,8 +298,6 @@ class AsyncVectorDBsResource(AsyncAPIResource):
         self,
         vector_db_id: str,
         *,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -418,15 +318,6 @@ class AsyncVectorDBsResource(AsyncAPIResource):
         if not vector_db_id:
             raise ValueError(f"Expected a non-empty value for `vector_db_id` but received {vector_db_id!r}")
         extra_headers = {"Accept": "*/*", **(extra_headers or {})}
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return await self._delete(
             f"/v1/vector-dbs/{vector_db_id}",
             options=make_request_options(

--- a/src/llama_stack_client/resources/vector_io.py
+++ b/src/llama_stack_client/resources/vector_io.py
@@ -10,7 +10,6 @@ from ..types import vector_io_query_params, vector_io_insert_params
 from .._types import NOT_GIVEN, Body, Query, Headers, NoneType, NotGiven
 from .._utils import (
     maybe_transform,
-    strip_not_given,
     async_maybe_transform,
 )
 from .._compat import cached_property
@@ -54,8 +53,6 @@ class VectorIoResource(SyncAPIResource):
         chunks: Iterable[vector_io_insert_params.Chunk],
         vector_db_id: str,
         ttl_seconds: int | NotGiven = NOT_GIVEN,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -74,15 +71,6 @@ class VectorIoResource(SyncAPIResource):
           timeout: Override the client-level default timeout for this request, in seconds
         """
         extra_headers = {"Accept": "*/*", **(extra_headers or {})}
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return self._post(
             "/v1/vector-io/insert",
             body=maybe_transform(
@@ -105,8 +93,6 @@ class VectorIoResource(SyncAPIResource):
         query: InterleavedContent,
         vector_db_id: str,
         params: Dict[str, Union[bool, float, str, Iterable[object], object, None]] | NotGiven = NOT_GIVEN,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -124,15 +110,6 @@ class VectorIoResource(SyncAPIResource):
 
           timeout: Override the client-level default timeout for this request, in seconds
         """
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return self._post(
             "/v1/vector-io/query",
             body=maybe_transform(
@@ -176,8 +153,6 @@ class AsyncVectorIoResource(AsyncAPIResource):
         chunks: Iterable[vector_io_insert_params.Chunk],
         vector_db_id: str,
         ttl_seconds: int | NotGiven = NOT_GIVEN,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -196,15 +171,6 @@ class AsyncVectorIoResource(AsyncAPIResource):
           timeout: Override the client-level default timeout for this request, in seconds
         """
         extra_headers = {"Accept": "*/*", **(extra_headers or {})}
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return await self._post(
             "/v1/vector-io/insert",
             body=await async_maybe_transform(
@@ -227,8 +193,6 @@ class AsyncVectorIoResource(AsyncAPIResource):
         query: InterleavedContent,
         vector_db_id: str,
         params: Dict[str, Union[bool, float, str, Iterable[object], object, None]] | NotGiven = NOT_GIVEN,
-        x_llama_stack_client_version: str | NotGiven = NOT_GIVEN,
-        x_llama_stack_provider_data: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -246,15 +210,6 @@ class AsyncVectorIoResource(AsyncAPIResource):
 
           timeout: Override the client-level default timeout for this request, in seconds
         """
-        extra_headers = {
-            **strip_not_given(
-                {
-                    "X-LlamaStack-Client-Version": x_llama_stack_client_version,
-                    "X-LlamaStack-Provider-Data": x_llama_stack_provider_data,
-                }
-            ),
-            **(extra_headers or {}),
-        }
         return await self._post(
             "/v1/vector-io/query",
             body=await async_maybe_transform(

--- a/src/llama_stack_client/types/agent_create_params.py
+++ b/src/llama_stack_client/types/agent_create_params.py
@@ -2,9 +2,8 @@
 
 from __future__ import annotations
 
-from typing_extensions import Required, Annotated, TypedDict
+from typing_extensions import Required, TypedDict
 
-from .._utils import PropertyInfo
 from .shared_params.agent_config import AgentConfig
 
 __all__ = ["AgentCreateParams"]
@@ -12,7 +11,3 @@ __all__ = ["AgentCreateParams"]
 
 class AgentCreateParams(TypedDict, total=False):
     agent_config: Required[AgentConfig]
-
-    x_llama_stack_client_version: Annotated[str, PropertyInfo(alias="X-LlamaStack-Client-Version")]
-
-    x_llama_stack_provider_data: Annotated[str, PropertyInfo(alias="X-LlamaStack-Provider-Data")]

--- a/src/llama_stack_client/types/agents/session_create_params.py
+++ b/src/llama_stack_client/types/agents/session_create_params.py
@@ -2,16 +2,10 @@
 
 from __future__ import annotations
 
-from typing_extensions import Required, Annotated, TypedDict
-
-from ..._utils import PropertyInfo
+from typing_extensions import Required, TypedDict
 
 __all__ = ["SessionCreateParams"]
 
 
 class SessionCreateParams(TypedDict, total=False):
     session_name: Required[str]
-
-    x_llama_stack_client_version: Annotated[str, PropertyInfo(alias="X-LlamaStack-Client-Version")]
-
-    x_llama_stack_provider_data: Annotated[str, PropertyInfo(alias="X-LlamaStack-Provider-Data")]

--- a/src/llama_stack_client/types/agents/session_retrieve_params.py
+++ b/src/llama_stack_client/types/agents/session_retrieve_params.py
@@ -3,9 +3,7 @@
 from __future__ import annotations
 
 from typing import List
-from typing_extensions import Required, Annotated, TypedDict
-
-from ..._utils import PropertyInfo
+from typing_extensions import Required, TypedDict
 
 __all__ = ["SessionRetrieveParams"]
 
@@ -14,7 +12,3 @@ class SessionRetrieveParams(TypedDict, total=False):
     agent_id: Required[str]
 
     turn_ids: List[str]
-
-    x_llama_stack_client_version: Annotated[str, PropertyInfo(alias="X-LlamaStack-Client-Version")]
-
-    x_llama_stack_provider_data: Annotated[str, PropertyInfo(alias="X-LlamaStack-Provider-Data")]

--- a/src/llama_stack_client/types/agents/turn_create_params.py
+++ b/src/llama_stack_client/types/agents/turn_create_params.py
@@ -3,9 +3,8 @@
 from __future__ import annotations
 
 from typing import Dict, List, Union, Iterable
-from typing_extensions import Literal, Required, Annotated, TypeAlias, TypedDict
+from typing_extensions import Literal, Required, TypeAlias, TypedDict
 
-from ..._utils import PropertyInfo
 from ..shared_params.url import URL
 from ..shared_params.user_message import UserMessage
 from ..shared_params.tool_response_message import ToolResponseMessage
@@ -34,10 +33,6 @@ class TurnCreateParamsBase(TypedDict, total=False):
     documents: Iterable[Document]
 
     toolgroups: List[Toolgroup]
-
-    x_llama_stack_client_version: Annotated[str, PropertyInfo(alias="X-LlamaStack-Client-Version")]
-
-    x_llama_stack_provider_data: Annotated[str, PropertyInfo(alias="X-LlamaStack-Provider-Data")]
 
 
 Message: TypeAlias = Union[UserMessage, ToolResponseMessage]

--- a/src/llama_stack_client/types/batch_inference_chat_completion_params.py
+++ b/src/llama_stack_client/types/batch_inference_chat_completion_params.py
@@ -3,10 +3,10 @@
 from __future__ import annotations
 
 from typing import Dict, Union, Iterable
-from typing_extensions import Literal, Required, Annotated, TypedDict
+from typing_extensions import Literal, Required, TypedDict
 
-from .._utils import PropertyInfo
 from .shared_params.message import Message
+from .shared_params.response_format import ResponseFormat
 from .shared_params.sampling_params import SamplingParams
 from .shared_params.tool_param_definition import ToolParamDefinition
 
@@ -20,32 +20,20 @@ class BatchInferenceChatCompletionParams(TypedDict, total=False):
 
     logprobs: Logprobs
 
+    response_format: ResponseFormat
+
     sampling_params: SamplingParams
 
     tool_choice: Literal["auto", "required"]
 
     tool_prompt_format: Literal["json", "function_tag", "python_list"]
-    """
-    `json` -- Refers to the json format for calling tools. The json format takes the
-    form like { "type": "function", "function" : { "name": "function_name",
-    "description": "function_description", "parameters": {...} } }
-
-    `function_tag` -- This is an example of how you could define your own user
-    defined format for making tool calls. The function_tag format looks like this,
-    <function=function_name>(parameters)</function>
-
-    The detailed prompts for each of these formats are added to llama cli
-    """
 
     tools: Iterable[Tool]
-
-    x_llama_stack_client_version: Annotated[str, PropertyInfo(alias="X-LlamaStack-Client-Version")]
-
-    x_llama_stack_provider_data: Annotated[str, PropertyInfo(alias="X-LlamaStack-Provider-Data")]
 
 
 class Logprobs(TypedDict, total=False):
     top_k: int
+    """How many tokens (for each position) to return log probabilities for."""
 
 
 class Tool(TypedDict, total=False):

--- a/src/llama_stack_client/types/batch_inference_chat_completion_response.py
+++ b/src/llama_stack_client/types/batch_inference_chat_completion_response.py
@@ -1,12 +1,21 @@
 # File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
 
-from typing import List
+from typing import List, Optional
 
 from .._models import BaseModel
+from .token_log_probs import TokenLogProbs
 from .shared.completion_message import CompletionMessage
 
-__all__ = ["BatchInferenceChatCompletionResponse"]
+__all__ = ["BatchInferenceChatCompletionResponse", "Batch"]
+
+
+class Batch(BaseModel):
+    completion_message: CompletionMessage
+    """The complete response message"""
+
+    logprobs: Optional[List[TokenLogProbs]] = None
+    """Optional log probabilities for generated tokens"""
 
 
 class BatchInferenceChatCompletionResponse(BaseModel):
-    completion_message_batch: List[CompletionMessage]
+    batch: List[Batch]

--- a/src/llama_stack_client/types/batch_inference_completion_params.py
+++ b/src/llama_stack_client/types/batch_inference_completion_params.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 from typing import List
-from typing_extensions import Required, Annotated, TypedDict
+from typing_extensions import Required, TypedDict
 
-from .._utils import PropertyInfo
+from .shared_params.response_format import ResponseFormat
 from .shared_params.sampling_params import SamplingParams
 from .shared_params.interleaved_content import InterleavedContent
 
@@ -19,12 +19,11 @@ class BatchInferenceCompletionParams(TypedDict, total=False):
 
     logprobs: Logprobs
 
+    response_format: ResponseFormat
+
     sampling_params: SamplingParams
-
-    x_llama_stack_client_version: Annotated[str, PropertyInfo(alias="X-LlamaStack-Client-Version")]
-
-    x_llama_stack_provider_data: Annotated[str, PropertyInfo(alias="X-LlamaStack-Provider-Data")]
 
 
 class Logprobs(TypedDict, total=False):
     top_k: int
+    """How many tokens (for each position) to return log probabilities for."""

--- a/src/llama_stack_client/types/completion_response.py
+++ b/src/llama_stack_client/types/completion_response.py
@@ -11,7 +11,10 @@ __all__ = ["CompletionResponse"]
 
 class CompletionResponse(BaseModel):
     content: str
+    """The generated completion text"""
 
     stop_reason: Literal["end_of_turn", "end_of_message", "out_of_tokens"]
+    """Reason why generation stopped"""
 
     logprobs: Optional[List[TokenLogProbs]] = None
+    """Optional log probabilities for generated tokens"""

--- a/src/llama_stack_client/types/dataset_register_params.py
+++ b/src/llama_stack_client/types/dataset_register_params.py
@@ -3,9 +3,8 @@
 from __future__ import annotations
 
 from typing import Dict, Union, Iterable
-from typing_extensions import Required, Annotated, TypedDict
+from typing_extensions import Required, TypedDict
 
-from .._utils import PropertyInfo
 from .shared_params.url import URL
 from .shared_params.param_type import ParamType
 
@@ -24,7 +23,3 @@ class DatasetRegisterParams(TypedDict, total=False):
     provider_dataset_id: str
 
     provider_id: str
-
-    x_llama_stack_client_version: Annotated[str, PropertyInfo(alias="X-LlamaStack-Client-Version")]
-
-    x_llama_stack_provider_data: Annotated[str, PropertyInfo(alias="X-LlamaStack-Provider-Data")]

--- a/src/llama_stack_client/types/datasetio_append_rows_params.py
+++ b/src/llama_stack_client/types/datasetio_append_rows_params.py
@@ -3,9 +3,7 @@
 from __future__ import annotations
 
 from typing import Dict, Union, Iterable
-from typing_extensions import Required, Annotated, TypedDict
-
-from .._utils import PropertyInfo
+from typing_extensions import Required, TypedDict
 
 __all__ = ["DatasetioAppendRowsParams"]
 
@@ -14,7 +12,3 @@ class DatasetioAppendRowsParams(TypedDict, total=False):
     dataset_id: Required[str]
 
     rows: Required[Iterable[Dict[str, Union[bool, float, str, Iterable[object], object, None]]]]
-
-    x_llama_stack_client_version: Annotated[str, PropertyInfo(alias="X-LlamaStack-Client-Version")]
-
-    x_llama_stack_provider_data: Annotated[str, PropertyInfo(alias="X-LlamaStack-Provider-Data")]

--- a/src/llama_stack_client/types/datasetio_get_rows_paginated_params.py
+++ b/src/llama_stack_client/types/datasetio_get_rows_paginated_params.py
@@ -2,9 +2,7 @@
 
 from __future__ import annotations
 
-from typing_extensions import Required, Annotated, TypedDict
-
-from .._utils import PropertyInfo
+from typing_extensions import Required, TypedDict
 
 __all__ = ["DatasetioGetRowsPaginatedParams"]
 
@@ -17,7 +15,3 @@ class DatasetioGetRowsPaginatedParams(TypedDict, total=False):
     filter_condition: str
 
     page_token: str
-
-    x_llama_stack_client_version: Annotated[str, PropertyInfo(alias="X-LlamaStack-Client-Version")]
-
-    x_llama_stack_provider_data: Annotated[str, PropertyInfo(alias="X-LlamaStack-Provider-Data")]

--- a/src/llama_stack_client/types/embeddings_response.py
+++ b/src/llama_stack_client/types/embeddings_response.py
@@ -9,3 +9,8 @@ __all__ = ["EmbeddingsResponse"]
 
 class EmbeddingsResponse(BaseModel):
     embeddings: List[List[float]]
+    """List of embedding vectors, one per input content.
+
+    Each embedding is a list of floats. The dimensionality of the embedding is
+    model-specific; you can check model metadata using /models/{model_id}
+    """

--- a/src/llama_stack_client/types/eval_evaluate_rows_params.py
+++ b/src/llama_stack_client/types/eval_evaluate_rows_params.py
@@ -3,9 +3,8 @@
 from __future__ import annotations
 
 from typing import Dict, List, Union, Iterable
-from typing_extensions import Required, Annotated, TypedDict
+from typing_extensions import Required, TypedDict
 
-from .._utils import PropertyInfo
 from .eval_task_config_param import EvalTaskConfigParam
 
 __all__ = ["EvalEvaluateRowsParams"]
@@ -17,7 +16,3 @@ class EvalEvaluateRowsParams(TypedDict, total=False):
     scoring_functions: Required[List[str]]
 
     task_config: Required[EvalTaskConfigParam]
-
-    x_llama_stack_client_version: Annotated[str, PropertyInfo(alias="X-LlamaStack-Client-Version")]
-
-    x_llama_stack_provider_data: Annotated[str, PropertyInfo(alias="X-LlamaStack-Provider-Data")]

--- a/src/llama_stack_client/types/eval_run_eval_params.py
+++ b/src/llama_stack_client/types/eval_run_eval_params.py
@@ -2,9 +2,8 @@
 
 from __future__ import annotations
 
-from typing_extensions import Required, Annotated, TypedDict
+from typing_extensions import Required, TypedDict
 
-from .._utils import PropertyInfo
 from .eval_task_config_param import EvalTaskConfigParam
 
 __all__ = ["EvalRunEvalParams"]
@@ -12,7 +11,3 @@ __all__ = ["EvalRunEvalParams"]
 
 class EvalRunEvalParams(TypedDict, total=False):
     task_config: Required[EvalTaskConfigParam]
-
-    x_llama_stack_client_version: Annotated[str, PropertyInfo(alias="X-LlamaStack-Client-Version")]
-
-    x_llama_stack_provider_data: Annotated[str, PropertyInfo(alias="X-LlamaStack-Provider-Data")]

--- a/src/llama_stack_client/types/eval_task_register_params.py
+++ b/src/llama_stack_client/types/eval_task_register_params.py
@@ -3,9 +3,7 @@
 from __future__ import annotations
 
 from typing import Dict, List, Union, Iterable
-from typing_extensions import Required, Annotated, TypedDict
-
-from .._utils import PropertyInfo
+from typing_extensions import Required, TypedDict
 
 __all__ = ["EvalTaskRegisterParams"]
 
@@ -22,7 +20,3 @@ class EvalTaskRegisterParams(TypedDict, total=False):
     provider_eval_task_id: str
 
     provider_id: str
-
-    x_llama_stack_client_version: Annotated[str, PropertyInfo(alias="X-LlamaStack-Client-Version")]
-
-    x_llama_stack_provider_data: Annotated[str, PropertyInfo(alias="X-LlamaStack-Provider-Data")]

--- a/src/llama_stack_client/types/inference_chat_completion_params.py
+++ b/src/llama_stack_client/types/inference_chat_completion_params.py
@@ -3,9 +3,8 @@
 from __future__ import annotations
 
 from typing import Dict, Union, Iterable
-from typing_extensions import Literal, Required, Annotated, TypedDict
+from typing_extensions import Literal, Required, TypedDict
 
-from .._utils import PropertyInfo
 from .shared_params.message import Message
 from .shared_params.response_format import ResponseFormat
 from .shared_params.sampling_params import SamplingParams
@@ -22,39 +21,56 @@ __all__ = [
 
 class InferenceChatCompletionParamsBase(TypedDict, total=False):
     messages: Required[Iterable[Message]]
+    """List of messages in the conversation"""
 
     model_id: Required[str]
+    """The identifier of the model to use.
+
+    The model must be registered with Llama Stack and available via the /models
+    endpoint.
+    """
 
     logprobs: Logprobs
+    """
+    (Optional) If specified, log probabilities for each token position will be
+    returned.
+    """
 
     response_format: ResponseFormat
+    """(Optional) Grammar specification for guided (structured) decoding.
+
+    There are two options: - `ResponseFormat.json_schema`: The grammar is a JSON
+    schema. Most providers support this format. - `ResponseFormat.grammar`: The
+    grammar is a BNF grammar. This format is more flexible, but not all providers
+    support it.
+    """
 
     sampling_params: SamplingParams
+    """Parameters to control the sampling strategy"""
 
     tool_choice: Literal["auto", "required"]
+    """(Optional) Whether tool use is required or automatic.
+
+    Defaults to ToolChoice.auto.
+    """
 
     tool_prompt_format: Literal["json", "function_tag", "python_list"]
-    """
-    `json` -- Refers to the json format for calling tools. The json format takes the
-    form like { "type": "function", "function" : { "name": "function_name",
-    "description": "function_description", "parameters": {...} } }
+    """(Optional) Instructs the model how to format tool calls.
 
-    `function_tag` -- This is an example of how you could define your own user
-    defined format for making tool calls. The function_tag format looks like this,
-    <function=function_name>(parameters)</function>
-
-    The detailed prompts for each of these formats are added to llama cli
+    By default, Llama Stack will attempt to use a format that is best adapted to the
+    model. - `ToolPromptFormat.json`: The tool calls are formatted as a JSON
+    object. - `ToolPromptFormat.function_tag`: The tool calls are enclosed in a
+    <function=function_name> tag. - `ToolPromptFormat.python_list`: The tool calls
+    are output as Python syntax -- a list of function calls.
     """
 
     tools: Iterable[Tool]
-
-    x_llama_stack_client_version: Annotated[str, PropertyInfo(alias="X-LlamaStack-Client-Version")]
-
-    x_llama_stack_provider_data: Annotated[str, PropertyInfo(alias="X-LlamaStack-Provider-Data")]
+    """(Optional) List of tool definitions available to the model"""
 
 
 class Logprobs(TypedDict, total=False):
     top_k: int
+    """How many tokens (for each position) to return log probabilities for."""
 
 
 class Tool(TypedDict, total=False):
@@ -67,10 +83,18 @@ class Tool(TypedDict, total=False):
 
 class InferenceChatCompletionParamsNonStreaming(InferenceChatCompletionParamsBase, total=False):
     stream: Literal[False]
+    """(Optional) If True, generate an SSE event stream of the response.
+
+    Defaults to False.
+    """
 
 
 class InferenceChatCompletionParamsStreaming(InferenceChatCompletionParamsBase):
     stream: Required[Literal[True]]
+    """(Optional) If True, generate an SSE event stream of the response.
+
+    Defaults to False.
+    """
 
 
 InferenceChatCompletionParams = Union[InferenceChatCompletionParamsNonStreaming, InferenceChatCompletionParamsStreaming]

--- a/src/llama_stack_client/types/inference_chat_completion_response.py
+++ b/src/llama_stack_client/types/inference_chat_completion_response.py
@@ -18,22 +18,32 @@ __all__ = [
 
 class ChatCompletionResponse(BaseModel):
     completion_message: CompletionMessage
+    """The complete response message"""
 
     logprobs: Optional[List[TokenLogProbs]] = None
+    """Optional log probabilities for generated tokens"""
 
 
 class ChatCompletionResponseStreamChunkEvent(BaseModel):
     delta: ContentDelta
+    """Content generated since last event.
+
+    This can be one or more tokens, or a tool call.
+    """
 
     event_type: Literal["start", "complete", "progress"]
+    """Type of the event"""
 
     logprobs: Optional[List[TokenLogProbs]] = None
+    """Optional log probabilities for generated tokens"""
 
     stop_reason: Optional[Literal["end_of_turn", "end_of_message", "out_of_tokens"]] = None
+    """Optional reason why generation stopped, if complete"""
 
 
 class ChatCompletionResponseStreamChunk(BaseModel):
     event: ChatCompletionResponseStreamChunkEvent
+    """The event containing the new content"""
 
 
 InferenceChatCompletionResponse: TypeAlias = Union[ChatCompletionResponse, ChatCompletionResponseStreamChunk]

--- a/src/llama_stack_client/types/inference_completion_params.py
+++ b/src/llama_stack_client/types/inference_completion_params.py
@@ -3,9 +3,8 @@
 from __future__ import annotations
 
 from typing import Union
-from typing_extensions import Literal, Required, Annotated, TypedDict
+from typing_extensions import Literal, Required, TypedDict
 
-from .._utils import PropertyInfo
 from .shared_params.response_format import ResponseFormat
 from .shared_params.sampling_params import SamplingParams
 from .shared_params.interleaved_content import InterleavedContent
@@ -20,30 +19,47 @@ __all__ = [
 
 class InferenceCompletionParamsBase(TypedDict, total=False):
     content: Required[InterleavedContent]
+    """The content to generate a completion for"""
 
     model_id: Required[str]
+    """The identifier of the model to use.
+
+    The model must be registered with Llama Stack and available via the /models
+    endpoint.
+    """
 
     logprobs: Logprobs
+    """
+    (Optional) If specified, log probabilities for each token position will be
+    returned.
+    """
 
     response_format: ResponseFormat
+    """(Optional) Grammar specification for guided (structured) decoding"""
 
     sampling_params: SamplingParams
-
-    x_llama_stack_client_version: Annotated[str, PropertyInfo(alias="X-LlamaStack-Client-Version")]
-
-    x_llama_stack_provider_data: Annotated[str, PropertyInfo(alias="X-LlamaStack-Provider-Data")]
+    """(Optional) Parameters to control the sampling strategy"""
 
 
 class Logprobs(TypedDict, total=False):
     top_k: int
+    """How many tokens (for each position) to return log probabilities for."""
 
 
 class InferenceCompletionParamsNonStreaming(InferenceCompletionParamsBase, total=False):
     stream: Literal[False]
+    """(Optional) If True, generate an SSE event stream of the response.
+
+    Defaults to False.
+    """
 
 
 class InferenceCompletionParamsStreaming(InferenceCompletionParamsBase):
     stream: Required[Literal[True]]
+    """(Optional) If True, generate an SSE event stream of the response.
+
+    Defaults to False.
+    """
 
 
 InferenceCompletionParams = Union[InferenceCompletionParamsNonStreaming, InferenceCompletionParamsStreaming]

--- a/src/llama_stack_client/types/inference_completion_response.py
+++ b/src/llama_stack_client/types/inference_completion_response.py
@@ -12,10 +12,13 @@ __all__ = ["InferenceCompletionResponse", "CompletionResponseStreamChunk"]
 
 class CompletionResponseStreamChunk(BaseModel):
     delta: str
+    """New content generated since last chunk. This can be one or more tokens."""
 
     logprobs: Optional[List[TokenLogProbs]] = None
+    """Optional log probabilities for generated tokens"""
 
     stop_reason: Optional[Literal["end_of_turn", "end_of_message", "out_of_tokens"]] = None
+    """Optional reason why generation stopped, if complete"""
 
 
 InferenceCompletionResponse: TypeAlias = Union[CompletionResponse, CompletionResponseStreamChunk]

--- a/src/llama_stack_client/types/inference_embeddings_params.py
+++ b/src/llama_stack_client/types/inference_embeddings_params.py
@@ -3,9 +3,8 @@
 from __future__ import annotations
 
 from typing import List
-from typing_extensions import Required, Annotated, TypedDict
+from typing_extensions import Required, TypedDict
 
-from .._utils import PropertyInfo
 from .shared_params.interleaved_content import InterleavedContent
 
 __all__ = ["InferenceEmbeddingsParams"]
@@ -13,9 +12,15 @@ __all__ = ["InferenceEmbeddingsParams"]
 
 class InferenceEmbeddingsParams(TypedDict, total=False):
     contents: Required[List[InterleavedContent]]
+    """List of contents to generate embeddings for.
+
+    Note that content can be multimodal. The behavior depends on the model and
+    provider. Some models may only support text.
+    """
 
     model_id: Required[str]
+    """The identifier of the model to use.
 
-    x_llama_stack_client_version: Annotated[str, PropertyInfo(alias="X-LlamaStack-Client-Version")]
-
-    x_llama_stack_provider_data: Annotated[str, PropertyInfo(alias="X-LlamaStack-Provider-Data")]
+    The model must be an embedding model registered with Llama Stack and available
+    via the /models endpoint.
+    """

--- a/src/llama_stack_client/types/model_register_params.py
+++ b/src/llama_stack_client/types/model_register_params.py
@@ -3,9 +3,7 @@
 from __future__ import annotations
 
 from typing import Dict, Union, Iterable
-from typing_extensions import Literal, Required, Annotated, TypedDict
-
-from .._utils import PropertyInfo
+from typing_extensions import Literal, Required, TypedDict
 
 __all__ = ["ModelRegisterParams"]
 
@@ -20,7 +18,3 @@ class ModelRegisterParams(TypedDict, total=False):
     provider_id: str
 
     provider_model_id: str
-
-    x_llama_stack_client_version: Annotated[str, PropertyInfo(alias="X-LlamaStack-Client-Version")]
-
-    x_llama_stack_provider_data: Annotated[str, PropertyInfo(alias="X-LlamaStack-Provider-Data")]

--- a/src/llama_stack_client/types/post_training/job_artifacts_params.py
+++ b/src/llama_stack_client/types/post_training/job_artifacts_params.py
@@ -2,16 +2,10 @@
 
 from __future__ import annotations
 
-from typing_extensions import Required, Annotated, TypedDict
-
-from ..._utils import PropertyInfo
+from typing_extensions import Required, TypedDict
 
 __all__ = ["JobArtifactsParams"]
 
 
 class JobArtifactsParams(TypedDict, total=False):
     job_uuid: Required[str]
-
-    x_llama_stack_client_version: Annotated[str, PropertyInfo(alias="X-LlamaStack-Client-Version")]
-
-    x_llama_stack_provider_data: Annotated[str, PropertyInfo(alias="X-LlamaStack-Provider-Data")]

--- a/src/llama_stack_client/types/post_training/job_cancel_params.py
+++ b/src/llama_stack_client/types/post_training/job_cancel_params.py
@@ -2,16 +2,10 @@
 
 from __future__ import annotations
 
-from typing_extensions import Required, Annotated, TypedDict
-
-from ..._utils import PropertyInfo
+from typing_extensions import Required, TypedDict
 
 __all__ = ["JobCancelParams"]
 
 
 class JobCancelParams(TypedDict, total=False):
     job_uuid: Required[str]
-
-    x_llama_stack_client_version: Annotated[str, PropertyInfo(alias="X-LlamaStack-Client-Version")]
-
-    x_llama_stack_provider_data: Annotated[str, PropertyInfo(alias="X-LlamaStack-Provider-Data")]

--- a/src/llama_stack_client/types/post_training/job_status_params.py
+++ b/src/llama_stack_client/types/post_training/job_status_params.py
@@ -2,16 +2,10 @@
 
 from __future__ import annotations
 
-from typing_extensions import Required, Annotated, TypedDict
-
-from ..._utils import PropertyInfo
+from typing_extensions import Required, TypedDict
 
 __all__ = ["JobStatusParams"]
 
 
 class JobStatusParams(TypedDict, total=False):
     job_uuid: Required[str]
-
-    x_llama_stack_client_version: Annotated[str, PropertyInfo(alias="X-LlamaStack-Client-Version")]
-
-    x_llama_stack_provider_data: Annotated[str, PropertyInfo(alias="X-LlamaStack-Provider-Data")]

--- a/src/llama_stack_client/types/post_training_preference_optimize_params.py
+++ b/src/llama_stack_client/types/post_training_preference_optimize_params.py
@@ -3,9 +3,7 @@
 from __future__ import annotations
 
 from typing import Dict, Union, Iterable
-from typing_extensions import Literal, Required, Annotated, TypedDict
-
-from .._utils import PropertyInfo
+from typing_extensions import Literal, Required, TypedDict
 
 __all__ = [
     "PostTrainingPreferenceOptimizeParams",
@@ -29,10 +27,6 @@ class PostTrainingPreferenceOptimizeParams(TypedDict, total=False):
     logger_config: Required[Dict[str, Union[bool, float, str, Iterable[object], object, None]]]
 
     training_config: Required[TrainingConfig]
-
-    x_llama_stack_client_version: Annotated[str, PropertyInfo(alias="X-LlamaStack-Client-Version")]
-
-    x_llama_stack_provider_data: Annotated[str, PropertyInfo(alias="X-LlamaStack-Provider-Data")]
 
 
 class AlgorithmConfig(TypedDict, total=False):

--- a/src/llama_stack_client/types/post_training_supervised_fine_tune_params.py
+++ b/src/llama_stack_client/types/post_training_supervised_fine_tune_params.py
@@ -3,9 +3,8 @@
 from __future__ import annotations
 
 from typing import Dict, Union, Iterable
-from typing_extensions import Literal, Required, Annotated, TypedDict
+from typing_extensions import Literal, Required, TypedDict
 
-from .._utils import PropertyInfo
 from .algorithm_config_param import AlgorithmConfigParam
 
 __all__ = [
@@ -31,10 +30,6 @@ class PostTrainingSupervisedFineTuneParams(TypedDict, total=False):
     algorithm_config: AlgorithmConfigParam
 
     checkpoint_dir: str
-
-    x_llama_stack_client_version: Annotated[str, PropertyInfo(alias="X-LlamaStack-Client-Version")]
-
-    x_llama_stack_provider_data: Annotated[str, PropertyInfo(alias="X-LlamaStack-Provider-Data")]
 
 
 class TrainingConfigDataConfig(TypedDict, total=False):

--- a/src/llama_stack_client/types/safety_run_shield_params.py
+++ b/src/llama_stack_client/types/safety_run_shield_params.py
@@ -3,9 +3,8 @@
 from __future__ import annotations
 
 from typing import Dict, Union, Iterable
-from typing_extensions import Required, Annotated, TypedDict
+from typing_extensions import Required, TypedDict
 
-from .._utils import PropertyInfo
 from .shared_params.message import Message
 
 __all__ = ["SafetyRunShieldParams"]
@@ -17,7 +16,3 @@ class SafetyRunShieldParams(TypedDict, total=False):
     params: Required[Dict[str, Union[bool, float, str, Iterable[object], object, None]]]
 
     shield_id: Required[str]
-
-    x_llama_stack_client_version: Annotated[str, PropertyInfo(alias="X-LlamaStack-Client-Version")]
-
-    x_llama_stack_provider_data: Annotated[str, PropertyInfo(alias="X-LlamaStack-Provider-Data")]

--- a/src/llama_stack_client/types/scoring_function_register_params.py
+++ b/src/llama_stack_client/types/scoring_function_register_params.py
@@ -2,9 +2,8 @@
 
 from __future__ import annotations
 
-from typing_extensions import Required, Annotated, TypedDict
+from typing_extensions import Required, TypedDict
 
-from .._utils import PropertyInfo
 from .scoring_fn_params_param import ScoringFnParamsParam
 from .shared_params.return_type import ReturnType
 
@@ -23,7 +22,3 @@ class ScoringFunctionRegisterParams(TypedDict, total=False):
     provider_id: str
 
     provider_scoring_fn_id: str
-
-    x_llama_stack_client_version: Annotated[str, PropertyInfo(alias="X-LlamaStack-Client-Version")]
-
-    x_llama_stack_provider_data: Annotated[str, PropertyInfo(alias="X-LlamaStack-Provider-Data")]

--- a/src/llama_stack_client/types/scoring_score_batch_params.py
+++ b/src/llama_stack_client/types/scoring_score_batch_params.py
@@ -3,9 +3,8 @@
 from __future__ import annotations
 
 from typing import Dict, Optional
-from typing_extensions import Required, Annotated, TypedDict
+from typing_extensions import Required, TypedDict
 
-from .._utils import PropertyInfo
 from .scoring_fn_params_param import ScoringFnParamsParam
 
 __all__ = ["ScoringScoreBatchParams"]
@@ -17,7 +16,3 @@ class ScoringScoreBatchParams(TypedDict, total=False):
     save_results_dataset: Required[bool]
 
     scoring_functions: Required[Dict[str, Optional[ScoringFnParamsParam]]]
-
-    x_llama_stack_client_version: Annotated[str, PropertyInfo(alias="X-LlamaStack-Client-Version")]
-
-    x_llama_stack_provider_data: Annotated[str, PropertyInfo(alias="X-LlamaStack-Provider-Data")]

--- a/src/llama_stack_client/types/scoring_score_params.py
+++ b/src/llama_stack_client/types/scoring_score_params.py
@@ -3,9 +3,8 @@
 from __future__ import annotations
 
 from typing import Dict, Union, Iterable, Optional
-from typing_extensions import Required, Annotated, TypedDict
+from typing_extensions import Required, TypedDict
 
-from .._utils import PropertyInfo
 from .scoring_fn_params_param import ScoringFnParamsParam
 
 __all__ = ["ScoringScoreParams"]
@@ -15,7 +14,3 @@ class ScoringScoreParams(TypedDict, total=False):
     input_rows: Required[Iterable[Dict[str, Union[bool, float, str, Iterable[object], object, None]]]]
 
     scoring_functions: Required[Dict[str, Optional[ScoringFnParamsParam]]]
-
-    x_llama_stack_client_version: Annotated[str, PropertyInfo(alias="X-LlamaStack-Client-Version")]
-
-    x_llama_stack_provider_data: Annotated[str, PropertyInfo(alias="X-LlamaStack-Provider-Data")]

--- a/src/llama_stack_client/types/shared/agent_config.py
+++ b/src/llama_stack_client/types/shared/agent_config.py
@@ -42,16 +42,5 @@ class AgentConfig(BaseModel):
     tool_choice: Optional[Literal["auto", "required"]] = None
 
     tool_prompt_format: Optional[Literal["json", "function_tag", "python_list"]] = None
-    """
-    `json` -- Refers to the json format for calling tools. The json format takes the
-    form like { "type": "function", "function" : { "name": "function_name",
-    "description": "function_description", "parameters": {...} } }
-
-    `function_tag` -- This is an example of how you could define your own user
-    defined format for making tool calls. The function_tag format looks like this,
-    <function=function_name>(parameters)</function>
-
-    The detailed prompts for each of these formats are added to llama cli
-    """
 
     toolgroups: Optional[List[Toolgroup]] = None

--- a/src/llama_stack_client/types/shared/batch_completion.py
+++ b/src/llama_stack_client/types/shared/batch_completion.py
@@ -3,10 +3,10 @@
 from typing import List
 
 from ..._models import BaseModel
-from .completion_message import CompletionMessage
+from ..completion_response import CompletionResponse
 
 __all__ = ["BatchCompletion"]
 
 
 class BatchCompletion(BaseModel):
-    completion_message_batch: List[CompletionMessage]
+    batch: List[CompletionResponse]

--- a/src/llama_stack_client/types/shared/completion_message.py
+++ b/src/llama_stack_client/types/shared/completion_message.py
@@ -12,9 +12,20 @@ __all__ = ["CompletionMessage"]
 
 class CompletionMessage(BaseModel):
     content: InterleavedContent
+    """The content of the model's response"""
 
     role: Literal["assistant"]
+    """Must be "assistant" to identify this as the model's response"""
 
     stop_reason: Literal["end_of_turn", "end_of_message", "out_of_tokens"]
+    """Reason why the model stopped generating.
+
+    Options are: - `StopReason.end_of_turn`: The model finished generating the
+    entire response. - `StopReason.end_of_message`: The model finished generating
+    but generated a partial response -- usually, a tool call. The user may call the
+    tool and continue the conversation with the tool's response. -
+    `StopReason.out_of_tokens`: The model ran out of token budget.
+    """
 
     tool_calls: List[ToolCall]
+    """List of tool calls. Each tool call is a ToolCall object."""

--- a/src/llama_stack_client/types/shared/response_format.py
+++ b/src/llama_stack_client/types/shared/response_format.py
@@ -11,14 +11,21 @@ __all__ = ["ResponseFormat", "JsonSchemaResponseFormat", "GrammarResponseFormat"
 
 class JsonSchemaResponseFormat(BaseModel):
     json_schema: Dict[str, Union[bool, float, str, List[object], object, None]]
+    """The JSON schema the response should conform to.
+
+    In a Python SDK, this is often a `pydantic` model.
+    """
 
     type: Literal["json_schema"]
+    """Must be "json_schema" to identify this format type"""
 
 
 class GrammarResponseFormat(BaseModel):
     bnf: Dict[str, Union[bool, float, str, List[object], object, None]]
+    """The BNF grammar specification the response should conform to"""
 
     type: Literal["grammar"]
+    """Must be "grammar" to identify this format type"""
 
 
 ResponseFormat: TypeAlias = Annotated[

--- a/src/llama_stack_client/types/shared/system_message.py
+++ b/src/llama_stack_client/types/shared/system_message.py
@@ -10,5 +10,12 @@ __all__ = ["SystemMessage"]
 
 class SystemMessage(BaseModel):
     content: InterleavedContent
+    """The content of the "system prompt".
+
+    If multiple system messages are provided, they are concatenated. The underlying
+    Llama Stack code may also add other system messages (for example, for formatting
+    tool definitions).
+    """
 
     role: Literal["system"]
+    """Must be "system" to identify this as a system message"""

--- a/src/llama_stack_client/types/shared/tool_response_message.py
+++ b/src/llama_stack_client/types/shared/tool_response_message.py
@@ -11,9 +11,13 @@ __all__ = ["ToolResponseMessage"]
 
 class ToolResponseMessage(BaseModel):
     call_id: str
+    """Unique identifier for the tool call this response is for"""
 
     content: InterleavedContent
+    """The response content from the tool"""
 
     role: Literal["tool"]
+    """Must be "tool" to identify this as a tool response"""
 
     tool_name: Union[Literal["brave_search", "wolfram_alpha", "photogen", "code_interpreter"], str]
+    """Name of the tool that was called"""

--- a/src/llama_stack_client/types/shared/user_message.py
+++ b/src/llama_stack_client/types/shared/user_message.py
@@ -11,7 +11,13 @@ __all__ = ["UserMessage"]
 
 class UserMessage(BaseModel):
     content: InterleavedContent
+    """The content of the message, which can include text and other media"""
 
     role: Literal["user"]
+    """Must be "user" to identify this as a user message"""
 
     context: Optional[InterleavedContent] = None
+    """(Optional) This field is used internally by Llama Stack to pass RAG context.
+
+    This field may be removed in the API in the future.
+    """

--- a/src/llama_stack_client/types/shared_params/agent_config.py
+++ b/src/llama_stack_client/types/shared_params/agent_config.py
@@ -43,16 +43,5 @@ class AgentConfig(TypedDict, total=False):
     tool_choice: Literal["auto", "required"]
 
     tool_prompt_format: Literal["json", "function_tag", "python_list"]
-    """
-    `json` -- Refers to the json format for calling tools. The json format takes the
-    form like { "type": "function", "function" : { "name": "function_name",
-    "description": "function_description", "parameters": {...} } }
-
-    `function_tag` -- This is an example of how you could define your own user
-    defined format for making tool calls. The function_tag format looks like this,
-    <function=function_name>(parameters)</function>
-
-    The detailed prompts for each of these formats are added to llama cli
-    """
 
     toolgroups: List[Toolgroup]

--- a/src/llama_stack_client/types/shared_params/completion_message.py
+++ b/src/llama_stack_client/types/shared_params/completion_message.py
@@ -13,9 +13,20 @@ __all__ = ["CompletionMessage"]
 
 class CompletionMessage(TypedDict, total=False):
     content: Required[InterleavedContent]
+    """The content of the model's response"""
 
     role: Required[Literal["assistant"]]
+    """Must be "assistant" to identify this as the model's response"""
 
     stop_reason: Required[Literal["end_of_turn", "end_of_message", "out_of_tokens"]]
+    """Reason why the model stopped generating.
+
+    Options are: - `StopReason.end_of_turn`: The model finished generating the
+    entire response. - `StopReason.end_of_message`: The model finished generating
+    but generated a partial response -- usually, a tool call. The user may call the
+    tool and continue the conversation with the tool's response. -
+    `StopReason.out_of_tokens`: The model ran out of token budget.
+    """
 
     tool_calls: Required[Iterable[ToolCall]]
+    """List of tool calls. Each tool call is a ToolCall object."""

--- a/src/llama_stack_client/types/shared_params/response_format.py
+++ b/src/llama_stack_client/types/shared_params/response_format.py
@@ -10,14 +10,21 @@ __all__ = ["ResponseFormat", "JsonSchemaResponseFormat", "GrammarResponseFormat"
 
 class JsonSchemaResponseFormat(TypedDict, total=False):
     json_schema: Required[Dict[str, Union[bool, float, str, Iterable[object], object, None]]]
+    """The JSON schema the response should conform to.
+
+    In a Python SDK, this is often a `pydantic` model.
+    """
 
     type: Required[Literal["json_schema"]]
+    """Must be "json_schema" to identify this format type"""
 
 
 class GrammarResponseFormat(TypedDict, total=False):
     bnf: Required[Dict[str, Union[bool, float, str, Iterable[object], object, None]]]
+    """The BNF grammar specification the response should conform to"""
 
     type: Required[Literal["grammar"]]
+    """Must be "grammar" to identify this format type"""
 
 
 ResponseFormat: TypeAlias = Union[JsonSchemaResponseFormat, GrammarResponseFormat]

--- a/src/llama_stack_client/types/shared_params/system_message.py
+++ b/src/llama_stack_client/types/shared_params/system_message.py
@@ -11,5 +11,12 @@ __all__ = ["SystemMessage"]
 
 class SystemMessage(TypedDict, total=False):
     content: Required[InterleavedContent]
+    """The content of the "system prompt".
+
+    If multiple system messages are provided, they are concatenated. The underlying
+    Llama Stack code may also add other system messages (for example, for formatting
+    tool definitions).
+    """
 
     role: Required[Literal["system"]]
+    """Must be "system" to identify this as a system message"""

--- a/src/llama_stack_client/types/shared_params/tool_response_message.py
+++ b/src/llama_stack_client/types/shared_params/tool_response_message.py
@@ -12,9 +12,13 @@ __all__ = ["ToolResponseMessage"]
 
 class ToolResponseMessage(TypedDict, total=False):
     call_id: Required[str]
+    """Unique identifier for the tool call this response is for"""
 
     content: Required[InterleavedContent]
+    """The response content from the tool"""
 
     role: Required[Literal["tool"]]
+    """Must be "tool" to identify this as a tool response"""
 
     tool_name: Required[Union[Literal["brave_search", "wolfram_alpha", "photogen", "code_interpreter"], str]]
+    """Name of the tool that was called"""

--- a/src/llama_stack_client/types/shared_params/user_message.py
+++ b/src/llama_stack_client/types/shared_params/user_message.py
@@ -11,7 +11,13 @@ __all__ = ["UserMessage"]
 
 class UserMessage(TypedDict, total=False):
     content: Required[InterleavedContent]
+    """The content of the message, which can include text and other media"""
 
     role: Required[Literal["user"]]
+    """Must be "user" to identify this as a user message"""
 
     context: InterleavedContent
+    """(Optional) This field is used internally by Llama Stack to pass RAG context.
+
+    This field may be removed in the API in the future.
+    """

--- a/src/llama_stack_client/types/shield_register_params.py
+++ b/src/llama_stack_client/types/shield_register_params.py
@@ -3,9 +3,7 @@
 from __future__ import annotations
 
 from typing import Dict, Union, Iterable
-from typing_extensions import Required, Annotated, TypedDict
-
-from .._utils import PropertyInfo
+from typing_extensions import Required, TypedDict
 
 __all__ = ["ShieldRegisterParams"]
 
@@ -18,7 +16,3 @@ class ShieldRegisterParams(TypedDict, total=False):
     provider_id: str
 
     provider_shield_id: str
-
-    x_llama_stack_client_version: Annotated[str, PropertyInfo(alias="X-LlamaStack-Client-Version")]
-
-    x_llama_stack_provider_data: Annotated[str, PropertyInfo(alias="X-LlamaStack-Provider-Data")]

--- a/src/llama_stack_client/types/synthetic_data_generation_generate_params.py
+++ b/src/llama_stack_client/types/synthetic_data_generation_generate_params.py
@@ -3,9 +3,8 @@
 from __future__ import annotations
 
 from typing import Iterable
-from typing_extensions import Literal, Required, Annotated, TypedDict
+from typing_extensions import Literal, Required, TypedDict
 
-from .._utils import PropertyInfo
 from .shared_params.message import Message
 
 __all__ = ["SyntheticDataGenerationGenerateParams"]
@@ -17,7 +16,3 @@ class SyntheticDataGenerationGenerateParams(TypedDict, total=False):
     filtering_function: Required[Literal["none", "random", "top_k", "top_p", "top_k_top_p", "sigmoid"]]
 
     model: str
-
-    x_llama_stack_client_version: Annotated[str, PropertyInfo(alias="X-LlamaStack-Client-Version")]
-
-    x_llama_stack_provider_data: Annotated[str, PropertyInfo(alias="X-LlamaStack-Provider-Data")]

--- a/src/llama_stack_client/types/telemetry_get_span_tree_params.py
+++ b/src/llama_stack_client/types/telemetry_get_span_tree_params.py
@@ -3,9 +3,7 @@
 from __future__ import annotations
 
 from typing import List
-from typing_extensions import Annotated, TypedDict
-
-from .._utils import PropertyInfo
+from typing_extensions import TypedDict
 
 __all__ = ["TelemetryGetSpanTreeParams"]
 
@@ -14,7 +12,3 @@ class TelemetryGetSpanTreeParams(TypedDict, total=False):
     attributes_to_return: List[str]
 
     max_depth: int
-
-    x_llama_stack_client_version: Annotated[str, PropertyInfo(alias="X-LlamaStack-Client-Version")]
-
-    x_llama_stack_provider_data: Annotated[str, PropertyInfo(alias="X-LlamaStack-Provider-Data")]

--- a/src/llama_stack_client/types/telemetry_log_event_params.py
+++ b/src/llama_stack_client/types/telemetry_log_event_params.py
@@ -2,9 +2,8 @@
 
 from __future__ import annotations
 
-from typing_extensions import Required, Annotated, TypedDict
+from typing_extensions import Required, TypedDict
 
-from .._utils import PropertyInfo
 from .event_param import EventParam
 
 __all__ = ["TelemetryLogEventParams"]
@@ -14,7 +13,3 @@ class TelemetryLogEventParams(TypedDict, total=False):
     event: Required[EventParam]
 
     ttl_seconds: Required[int]
-
-    x_llama_stack_client_version: Annotated[str, PropertyInfo(alias="X-LlamaStack-Client-Version")]
-
-    x_llama_stack_provider_data: Annotated[str, PropertyInfo(alias="X-LlamaStack-Provider-Data")]

--- a/src/llama_stack_client/types/telemetry_query_spans_params.py
+++ b/src/llama_stack_client/types/telemetry_query_spans_params.py
@@ -3,9 +3,8 @@
 from __future__ import annotations
 
 from typing import List, Iterable
-from typing_extensions import Required, Annotated, TypedDict
+from typing_extensions import Required, TypedDict
 
-from .._utils import PropertyInfo
 from .query_condition_param import QueryConditionParam
 
 __all__ = ["TelemetryQuerySpansParams"]
@@ -17,7 +16,3 @@ class TelemetryQuerySpansParams(TypedDict, total=False):
     attributes_to_return: Required[List[str]]
 
     max_depth: int
-
-    x_llama_stack_client_version: Annotated[str, PropertyInfo(alias="X-LlamaStack-Client-Version")]
-
-    x_llama_stack_provider_data: Annotated[str, PropertyInfo(alias="X-LlamaStack-Provider-Data")]

--- a/src/llama_stack_client/types/telemetry_query_traces_params.py
+++ b/src/llama_stack_client/types/telemetry_query_traces_params.py
@@ -3,9 +3,8 @@
 from __future__ import annotations
 
 from typing import List, Iterable
-from typing_extensions import Annotated, TypedDict
+from typing_extensions import TypedDict
 
-from .._utils import PropertyInfo
 from .query_condition_param import QueryConditionParam
 
 __all__ = ["TelemetryQueryTracesParams"]
@@ -19,7 +18,3 @@ class TelemetryQueryTracesParams(TypedDict, total=False):
     offset: int
 
     order_by: List[str]
-
-    x_llama_stack_client_version: Annotated[str, PropertyInfo(alias="X-LlamaStack-Client-Version")]
-
-    x_llama_stack_provider_data: Annotated[str, PropertyInfo(alias="X-LlamaStack-Provider-Data")]

--- a/src/llama_stack_client/types/telemetry_save_spans_to_dataset_params.py
+++ b/src/llama_stack_client/types/telemetry_save_spans_to_dataset_params.py
@@ -3,9 +3,8 @@
 from __future__ import annotations
 
 from typing import List, Iterable
-from typing_extensions import Required, Annotated, TypedDict
+from typing_extensions import Required, TypedDict
 
-from .._utils import PropertyInfo
 from .query_condition_param import QueryConditionParam
 
 __all__ = ["TelemetrySaveSpansToDatasetParams"]
@@ -19,7 +18,3 @@ class TelemetrySaveSpansToDatasetParams(TypedDict, total=False):
     dataset_id: Required[str]
 
     max_depth: int
-
-    x_llama_stack_client_version: Annotated[str, PropertyInfo(alias="X-LlamaStack-Client-Version")]
-
-    x_llama_stack_provider_data: Annotated[str, PropertyInfo(alias="X-LlamaStack-Provider-Data")]

--- a/src/llama_stack_client/types/token_log_probs.py
+++ b/src/llama_stack_client/types/token_log_probs.py
@@ -9,3 +9,4 @@ __all__ = ["TokenLogProbs"]
 
 class TokenLogProbs(BaseModel):
     logprobs_by_token: Dict[str, float]
+    """Dictionary mapping tokens to their log probabilities"""

--- a/src/llama_stack_client/types/tool_list_params.py
+++ b/src/llama_stack_client/types/tool_list_params.py
@@ -2,16 +2,10 @@
 
 from __future__ import annotations
 
-from typing_extensions import Annotated, TypedDict
-
-from .._utils import PropertyInfo
+from typing_extensions import TypedDict
 
 __all__ = ["ToolListParams"]
 
 
 class ToolListParams(TypedDict, total=False):
     toolgroup_id: str
-
-    x_llama_stack_client_version: Annotated[str, PropertyInfo(alias="X-LlamaStack-Client-Version")]
-
-    x_llama_stack_provider_data: Annotated[str, PropertyInfo(alias="X-LlamaStack-Provider-Data")]

--- a/src/llama_stack_client/types/tool_runtime/rag_tool_insert_params.py
+++ b/src/llama_stack_client/types/tool_runtime/rag_tool_insert_params.py
@@ -3,9 +3,8 @@
 from __future__ import annotations
 
 from typing import Iterable
-from typing_extensions import Required, Annotated, TypedDict
+from typing_extensions import Required, TypedDict
 
-from ..._utils import PropertyInfo
 from ..shared_params.document import Document
 
 __all__ = ["RagToolInsertParams"]
@@ -17,7 +16,3 @@ class RagToolInsertParams(TypedDict, total=False):
     documents: Required[Iterable[Document]]
 
     vector_db_id: Required[str]
-
-    x_llama_stack_client_version: Annotated[str, PropertyInfo(alias="X-LlamaStack-Client-Version")]
-
-    x_llama_stack_provider_data: Annotated[str, PropertyInfo(alias="X-LlamaStack-Provider-Data")]

--- a/src/llama_stack_client/types/tool_runtime/rag_tool_query_params.py
+++ b/src/llama_stack_client/types/tool_runtime/rag_tool_query_params.py
@@ -3,9 +3,8 @@
 from __future__ import annotations
 
 from typing import List
-from typing_extensions import Required, Annotated, TypedDict
+from typing_extensions import Required, TypedDict
 
-from ..._utils import PropertyInfo
 from ..shared_params.query_config import QueryConfig
 from ..shared_params.interleaved_content import InterleavedContent
 
@@ -18,7 +17,3 @@ class RagToolQueryParams(TypedDict, total=False):
     vector_db_ids: Required[List[str]]
 
     query_config: QueryConfig
-
-    x_llama_stack_client_version: Annotated[str, PropertyInfo(alias="X-LlamaStack-Client-Version")]
-
-    x_llama_stack_provider_data: Annotated[str, PropertyInfo(alias="X-LlamaStack-Provider-Data")]

--- a/src/llama_stack_client/types/tool_runtime_invoke_tool_params.py
+++ b/src/llama_stack_client/types/tool_runtime_invoke_tool_params.py
@@ -3,9 +3,7 @@
 from __future__ import annotations
 
 from typing import Dict, Union, Iterable
-from typing_extensions import Required, Annotated, TypedDict
-
-from .._utils import PropertyInfo
+from typing_extensions import Required, TypedDict
 
 __all__ = ["ToolRuntimeInvokeToolParams"]
 
@@ -14,7 +12,3 @@ class ToolRuntimeInvokeToolParams(TypedDict, total=False):
     kwargs: Required[Dict[str, Union[bool, float, str, Iterable[object], object, None]]]
 
     tool_name: Required[str]
-
-    x_llama_stack_client_version: Annotated[str, PropertyInfo(alias="X-LlamaStack-Client-Version")]
-
-    x_llama_stack_provider_data: Annotated[str, PropertyInfo(alias="X-LlamaStack-Provider-Data")]

--- a/src/llama_stack_client/types/tool_runtime_list_tools_params.py
+++ b/src/llama_stack_client/types/tool_runtime_list_tools_params.py
@@ -2,9 +2,8 @@
 
 from __future__ import annotations
 
-from typing_extensions import Annotated, TypedDict
+from typing_extensions import TypedDict
 
-from .._utils import PropertyInfo
 from .shared_params.url import URL
 
 __all__ = ["ToolRuntimeListToolsParams"]
@@ -14,7 +13,3 @@ class ToolRuntimeListToolsParams(TypedDict, total=False):
     mcp_endpoint: URL
 
     tool_group_id: str
-
-    x_llama_stack_client_version: Annotated[str, PropertyInfo(alias="X-LlamaStack-Client-Version")]
-
-    x_llama_stack_provider_data: Annotated[str, PropertyInfo(alias="X-LlamaStack-Provider-Data")]

--- a/src/llama_stack_client/types/toolgroup_register_params.py
+++ b/src/llama_stack_client/types/toolgroup_register_params.py
@@ -3,9 +3,8 @@
 from __future__ import annotations
 
 from typing import Dict, Union, Iterable
-from typing_extensions import Required, Annotated, TypedDict
+from typing_extensions import Required, TypedDict
 
-from .._utils import PropertyInfo
 from .shared_params.url import URL
 
 __all__ = ["ToolgroupRegisterParams"]
@@ -19,7 +18,3 @@ class ToolgroupRegisterParams(TypedDict, total=False):
     args: Dict[str, Union[bool, float, str, Iterable[object], object, None]]
 
     mcp_endpoint: URL
-
-    x_llama_stack_client_version: Annotated[str, PropertyInfo(alias="X-LlamaStack-Client-Version")]
-
-    x_llama_stack_provider_data: Annotated[str, PropertyInfo(alias="X-LlamaStack-Provider-Data")]

--- a/src/llama_stack_client/types/vector_db_register_params.py
+++ b/src/llama_stack_client/types/vector_db_register_params.py
@@ -2,9 +2,7 @@
 
 from __future__ import annotations
 
-from typing_extensions import Required, Annotated, TypedDict
-
-from .._utils import PropertyInfo
+from typing_extensions import Required, TypedDict
 
 __all__ = ["VectorDBRegisterParams"]
 
@@ -19,7 +17,3 @@ class VectorDBRegisterParams(TypedDict, total=False):
     provider_id: str
 
     provider_vector_db_id: str
-
-    x_llama_stack_client_version: Annotated[str, PropertyInfo(alias="X-LlamaStack-Client-Version")]
-
-    x_llama_stack_provider_data: Annotated[str, PropertyInfo(alias="X-LlamaStack-Provider-Data")]

--- a/src/llama_stack_client/types/vector_io_insert_params.py
+++ b/src/llama_stack_client/types/vector_io_insert_params.py
@@ -3,9 +3,8 @@
 from __future__ import annotations
 
 from typing import Dict, Union, Iterable
-from typing_extensions import Required, Annotated, TypedDict
+from typing_extensions import Required, TypedDict
 
-from .._utils import PropertyInfo
 from .shared_params.interleaved_content import InterleavedContent
 
 __all__ = ["VectorIoInsertParams", "Chunk"]
@@ -17,10 +16,6 @@ class VectorIoInsertParams(TypedDict, total=False):
     vector_db_id: Required[str]
 
     ttl_seconds: int
-
-    x_llama_stack_client_version: Annotated[str, PropertyInfo(alias="X-LlamaStack-Client-Version")]
-
-    x_llama_stack_provider_data: Annotated[str, PropertyInfo(alias="X-LlamaStack-Provider-Data")]
 
 
 class Chunk(TypedDict, total=False):

--- a/src/llama_stack_client/types/vector_io_query_params.py
+++ b/src/llama_stack_client/types/vector_io_query_params.py
@@ -3,9 +3,8 @@
 from __future__ import annotations
 
 from typing import Dict, Union, Iterable
-from typing_extensions import Required, Annotated, TypedDict
+from typing_extensions import Required, TypedDict
 
-from .._utils import PropertyInfo
 from .shared_params.interleaved_content import InterleavedContent
 
 __all__ = ["VectorIoQueryParams"]
@@ -17,7 +16,3 @@ class VectorIoQueryParams(TypedDict, total=False):
     vector_db_id: Required[str]
 
     params: Dict[str, Union[bool, float, str, Iterable[object], object, None]]
-
-    x_llama_stack_client_version: Annotated[str, PropertyInfo(alias="X-LlamaStack-Client-Version")]
-
-    x_llama_stack_provider_data: Annotated[str, PropertyInfo(alias="X-LlamaStack-Provider-Data")]

--- a/tests/api_resources/agents/test_session.py
+++ b/tests/api_resources/agents/test_session.py
@@ -29,16 +29,6 @@ class TestSession:
         assert_matches_type(SessionCreateResponse, session, path=["response"])
 
     @parametrize
-    def test_method_create_with_all_params(self, client: LlamaStackClient) -> None:
-        session = client.agents.session.create(
-            agent_id="agent_id",
-            session_name="session_name",
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
-        )
-        assert_matches_type(SessionCreateResponse, session, path=["response"])
-
-    @parametrize
     def test_raw_response_create(self, client: LlamaStackClient) -> None:
         response = client.agents.session.with_raw_response.create(
             agent_id="agent_id",
@@ -86,8 +76,6 @@ class TestSession:
             session_id="session_id",
             agent_id="agent_id",
             turn_ids=["string"],
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
         )
         assert_matches_type(Session, session, path=["response"])
 
@@ -136,16 +124,6 @@ class TestSession:
         session = client.agents.session.delete(
             session_id="session_id",
             agent_id="agent_id",
-        )
-        assert session is None
-
-    @parametrize
-    def test_method_delete_with_all_params(self, client: LlamaStackClient) -> None:
-        session = client.agents.session.delete(
-            session_id="session_id",
-            agent_id="agent_id",
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
         )
         assert session is None
 
@@ -202,16 +180,6 @@ class TestAsyncSession:
         assert_matches_type(SessionCreateResponse, session, path=["response"])
 
     @parametrize
-    async def test_method_create_with_all_params(self, async_client: AsyncLlamaStackClient) -> None:
-        session = await async_client.agents.session.create(
-            agent_id="agent_id",
-            session_name="session_name",
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
-        )
-        assert_matches_type(SessionCreateResponse, session, path=["response"])
-
-    @parametrize
     async def test_raw_response_create(self, async_client: AsyncLlamaStackClient) -> None:
         response = await async_client.agents.session.with_raw_response.create(
             agent_id="agent_id",
@@ -259,8 +227,6 @@ class TestAsyncSession:
             session_id="session_id",
             agent_id="agent_id",
             turn_ids=["string"],
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
         )
         assert_matches_type(Session, session, path=["response"])
 
@@ -309,16 +275,6 @@ class TestAsyncSession:
         session = await async_client.agents.session.delete(
             session_id="session_id",
             agent_id="agent_id",
-        )
-        assert session is None
-
-    @parametrize
-    async def test_method_delete_with_all_params(self, async_client: AsyncLlamaStackClient) -> None:
-        session = await async_client.agents.session.delete(
-            session_id="session_id",
-            agent_id="agent_id",
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
         )
         assert session is None
 

--- a/tests/api_resources/agents/test_steps.py
+++ b/tests/api_resources/agents/test_steps.py
@@ -28,18 +28,6 @@ class TestSteps:
         assert_matches_type(StepRetrieveResponse, step, path=["response"])
 
     @parametrize
-    def test_method_retrieve_with_all_params(self, client: LlamaStackClient) -> None:
-        step = client.agents.steps.retrieve(
-            step_id="step_id",
-            agent_id="agent_id",
-            session_id="session_id",
-            turn_id="turn_id",
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
-        )
-        assert_matches_type(StepRetrieveResponse, step, path=["response"])
-
-    @parametrize
     def test_raw_response_retrieve(self, client: LlamaStackClient) -> None:
         response = client.agents.steps.with_raw_response.retrieve(
             step_id="step_id",
@@ -114,18 +102,6 @@ class TestAsyncSteps:
             agent_id="agent_id",
             session_id="session_id",
             turn_id="turn_id",
-        )
-        assert_matches_type(StepRetrieveResponse, step, path=["response"])
-
-    @parametrize
-    async def test_method_retrieve_with_all_params(self, async_client: AsyncLlamaStackClient) -> None:
-        step = await async_client.agents.steps.retrieve(
-            step_id="step_id",
-            agent_id="agent_id",
-            session_id="session_id",
-            turn_id="turn_id",
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
         )
         assert_matches_type(StepRetrieveResponse, step, path=["response"])
 

--- a/tests/api_resources/agents/test_turn.py
+++ b/tests/api_resources/agents/test_turn.py
@@ -57,8 +57,6 @@ class TestTurn:
             ],
             stream=False,
             toolgroups=["string"],
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
         )
         assert_matches_type(TurnCreateResponse, turn, path=["response"])
 
@@ -176,8 +174,6 @@ class TestTurn:
                 }
             ],
             toolgroups=["string"],
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
         )
         turn_stream.response.close()
 
@@ -263,17 +259,6 @@ class TestTurn:
             turn_id="turn_id",
             agent_id="agent_id",
             session_id="session_id",
-        )
-        assert_matches_type(Turn, turn, path=["response"])
-
-    @parametrize
-    def test_method_retrieve_with_all_params(self, client: LlamaStackClient) -> None:
-        turn = client.agents.turn.retrieve(
-            turn_id="turn_id",
-            agent_id="agent_id",
-            session_id="session_id",
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
         )
         assert_matches_type(Turn, turn, path=["response"])
 
@@ -372,8 +357,6 @@ class TestAsyncTurn:
             ],
             stream=False,
             toolgroups=["string"],
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
         )
         assert_matches_type(TurnCreateResponse, turn, path=["response"])
 
@@ -491,8 +474,6 @@ class TestAsyncTurn:
                 }
             ],
             toolgroups=["string"],
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
         )
         await turn_stream.response.aclose()
 
@@ -578,17 +559,6 @@ class TestAsyncTurn:
             turn_id="turn_id",
             agent_id="agent_id",
             session_id="session_id",
-        )
-        assert_matches_type(Turn, turn, path=["response"])
-
-    @parametrize
-    async def test_method_retrieve_with_all_params(self, async_client: AsyncLlamaStackClient) -> None:
-        turn = await async_client.agents.turn.retrieve(
-            turn_id="turn_id",
-            agent_id="agent_id",
-            session_id="session_id",
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
         )
         assert_matches_type(Turn, turn, path=["response"])
 

--- a/tests/api_resources/eval/test_jobs.py
+++ b/tests/api_resources/eval/test_jobs.py
@@ -27,16 +27,6 @@ class TestJobs:
         assert_matches_type(EvaluateResponse, job, path=["response"])
 
     @parametrize
-    def test_method_retrieve_with_all_params(self, client: LlamaStackClient) -> None:
-        job = client.eval.jobs.retrieve(
-            job_id="job_id",
-            task_id="task_id",
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
-        )
-        assert_matches_type(EvaluateResponse, job, path=["response"])
-
-    @parametrize
     def test_raw_response_retrieve(self, client: LlamaStackClient) -> None:
         response = client.eval.jobs.with_raw_response.retrieve(
             job_id="job_id",
@@ -85,16 +75,6 @@ class TestJobs:
         assert job is None
 
     @parametrize
-    def test_method_cancel_with_all_params(self, client: LlamaStackClient) -> None:
-        job = client.eval.jobs.cancel(
-            job_id="job_id",
-            task_id="task_id",
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
-        )
-        assert job is None
-
-    @parametrize
     def test_raw_response_cancel(self, client: LlamaStackClient) -> None:
         response = client.eval.jobs.with_raw_response.cancel(
             job_id="job_id",
@@ -139,16 +119,6 @@ class TestJobs:
         job = client.eval.jobs.status(
             job_id="job_id",
             task_id="task_id",
-        )
-        assert_matches_type(Optional[JobStatusResponse], job, path=["response"])
-
-    @parametrize
-    def test_method_status_with_all_params(self, client: LlamaStackClient) -> None:
-        job = client.eval.jobs.status(
-            job_id="job_id",
-            task_id="task_id",
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
         )
         assert_matches_type(Optional[JobStatusResponse], job, path=["response"])
 
@@ -205,16 +175,6 @@ class TestAsyncJobs:
         assert_matches_type(EvaluateResponse, job, path=["response"])
 
     @parametrize
-    async def test_method_retrieve_with_all_params(self, async_client: AsyncLlamaStackClient) -> None:
-        job = await async_client.eval.jobs.retrieve(
-            job_id="job_id",
-            task_id="task_id",
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
-        )
-        assert_matches_type(EvaluateResponse, job, path=["response"])
-
-    @parametrize
     async def test_raw_response_retrieve(self, async_client: AsyncLlamaStackClient) -> None:
         response = await async_client.eval.jobs.with_raw_response.retrieve(
             job_id="job_id",
@@ -263,16 +223,6 @@ class TestAsyncJobs:
         assert job is None
 
     @parametrize
-    async def test_method_cancel_with_all_params(self, async_client: AsyncLlamaStackClient) -> None:
-        job = await async_client.eval.jobs.cancel(
-            job_id="job_id",
-            task_id="task_id",
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
-        )
-        assert job is None
-
-    @parametrize
     async def test_raw_response_cancel(self, async_client: AsyncLlamaStackClient) -> None:
         response = await async_client.eval.jobs.with_raw_response.cancel(
             job_id="job_id",
@@ -317,16 +267,6 @@ class TestAsyncJobs:
         job = await async_client.eval.jobs.status(
             job_id="job_id",
             task_id="task_id",
-        )
-        assert_matches_type(Optional[JobStatusResponse], job, path=["response"])
-
-    @parametrize
-    async def test_method_status_with_all_params(self, async_client: AsyncLlamaStackClient) -> None:
-        job = await async_client.eval.jobs.status(
-            job_id="job_id",
-            task_id="task_id",
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
         )
         assert_matches_type(Optional[JobStatusResponse], job, path=["response"])
 

--- a/tests/api_resources/post_training/test_job.py
+++ b/tests/api_resources/post_training/test_job.py
@@ -27,14 +27,6 @@ class TestJob:
         assert_matches_type(JobListResponse, job, path=["response"])
 
     @parametrize
-    def test_method_list_with_all_params(self, client: LlamaStackClient) -> None:
-        job = client.post_training.job.list(
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
-        )
-        assert_matches_type(JobListResponse, job, path=["response"])
-
-    @parametrize
     def test_raw_response_list(self, client: LlamaStackClient) -> None:
         response = client.post_training.job.with_raw_response.list()
 
@@ -58,15 +50,6 @@ class TestJob:
     def test_method_artifacts(self, client: LlamaStackClient) -> None:
         job = client.post_training.job.artifacts(
             job_uuid="job_uuid",
-        )
-        assert_matches_type(Optional[JobArtifactsResponse], job, path=["response"])
-
-    @parametrize
-    def test_method_artifacts_with_all_params(self, client: LlamaStackClient) -> None:
-        job = client.post_training.job.artifacts(
-            job_uuid="job_uuid",
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
         )
         assert_matches_type(Optional[JobArtifactsResponse], job, path=["response"])
 
@@ -102,15 +85,6 @@ class TestJob:
         assert job is None
 
     @parametrize
-    def test_method_cancel_with_all_params(self, client: LlamaStackClient) -> None:
-        job = client.post_training.job.cancel(
-            job_uuid="job_uuid",
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
-        )
-        assert job is None
-
-    @parametrize
     def test_raw_response_cancel(self, client: LlamaStackClient) -> None:
         response = client.post_training.job.with_raw_response.cancel(
             job_uuid="job_uuid",
@@ -138,15 +112,6 @@ class TestJob:
     def test_method_status(self, client: LlamaStackClient) -> None:
         job = client.post_training.job.status(
             job_uuid="job_uuid",
-        )
-        assert_matches_type(Optional[JobStatusResponse], job, path=["response"])
-
-    @parametrize
-    def test_method_status_with_all_params(self, client: LlamaStackClient) -> None:
-        job = client.post_training.job.status(
-            job_uuid="job_uuid",
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
         )
         assert_matches_type(Optional[JobStatusResponse], job, path=["response"])
 
@@ -184,14 +149,6 @@ class TestAsyncJob:
         assert_matches_type(JobListResponse, job, path=["response"])
 
     @parametrize
-    async def test_method_list_with_all_params(self, async_client: AsyncLlamaStackClient) -> None:
-        job = await async_client.post_training.job.list(
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
-        )
-        assert_matches_type(JobListResponse, job, path=["response"])
-
-    @parametrize
     async def test_raw_response_list(self, async_client: AsyncLlamaStackClient) -> None:
         response = await async_client.post_training.job.with_raw_response.list()
 
@@ -215,15 +172,6 @@ class TestAsyncJob:
     async def test_method_artifacts(self, async_client: AsyncLlamaStackClient) -> None:
         job = await async_client.post_training.job.artifacts(
             job_uuid="job_uuid",
-        )
-        assert_matches_type(Optional[JobArtifactsResponse], job, path=["response"])
-
-    @parametrize
-    async def test_method_artifacts_with_all_params(self, async_client: AsyncLlamaStackClient) -> None:
-        job = await async_client.post_training.job.artifacts(
-            job_uuid="job_uuid",
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
         )
         assert_matches_type(Optional[JobArtifactsResponse], job, path=["response"])
 
@@ -259,15 +207,6 @@ class TestAsyncJob:
         assert job is None
 
     @parametrize
-    async def test_method_cancel_with_all_params(self, async_client: AsyncLlamaStackClient) -> None:
-        job = await async_client.post_training.job.cancel(
-            job_uuid="job_uuid",
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
-        )
-        assert job is None
-
-    @parametrize
     async def test_raw_response_cancel(self, async_client: AsyncLlamaStackClient) -> None:
         response = await async_client.post_training.job.with_raw_response.cancel(
             job_uuid="job_uuid",
@@ -295,15 +234,6 @@ class TestAsyncJob:
     async def test_method_status(self, async_client: AsyncLlamaStackClient) -> None:
         job = await async_client.post_training.job.status(
             job_uuid="job_uuid",
-        )
-        assert_matches_type(Optional[JobStatusResponse], job, path=["response"])
-
-    @parametrize
-    async def test_method_status_with_all_params(self, async_client: AsyncLlamaStackClient) -> None:
-        job = await async_client.post_training.job.status(
-            job_uuid="job_uuid",
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
         )
         assert_matches_type(Optional[JobStatusResponse], job, path=["response"])
 

--- a/tests/api_resources/test_agents.py
+++ b/tests/api_resources/test_agents.py
@@ -68,8 +68,6 @@ class TestAgents:
                 "tool_prompt_format": "json",
                 "toolgroups": ["string"],
             },
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
         )
         assert_matches_type(AgentCreateResponse, agent, path=["response"])
 
@@ -110,23 +108,14 @@ class TestAgents:
     @parametrize
     def test_method_delete(self, client: LlamaStackClient) -> None:
         agent = client.agents.delete(
-            agent_id="agent_id",
-        )
-        assert agent is None
-
-    @parametrize
-    def test_method_delete_with_all_params(self, client: LlamaStackClient) -> None:
-        agent = client.agents.delete(
-            agent_id="agent_id",
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
+            "agent_id",
         )
         assert agent is None
 
     @parametrize
     def test_raw_response_delete(self, client: LlamaStackClient) -> None:
         response = client.agents.with_raw_response.delete(
-            agent_id="agent_id",
+            "agent_id",
         )
 
         assert response.is_closed is True
@@ -137,7 +126,7 @@ class TestAgents:
     @parametrize
     def test_streaming_response_delete(self, client: LlamaStackClient) -> None:
         with client.agents.with_streaming_response.delete(
-            agent_id="agent_id",
+            "agent_id",
         ) as response:
             assert not response.is_closed
             assert response.http_request.headers.get("X-Stainless-Lang") == "python"
@@ -151,7 +140,7 @@ class TestAgents:
     def test_path_params_delete(self, client: LlamaStackClient) -> None:
         with pytest.raises(ValueError, match=r"Expected a non-empty value for `agent_id` but received ''"):
             client.agents.with_raw_response.delete(
-                agent_id="",
+                "",
             )
 
 
@@ -209,8 +198,6 @@ class TestAsyncAgents:
                 "tool_prompt_format": "json",
                 "toolgroups": ["string"],
             },
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
         )
         assert_matches_type(AgentCreateResponse, agent, path=["response"])
 
@@ -251,23 +238,14 @@ class TestAsyncAgents:
     @parametrize
     async def test_method_delete(self, async_client: AsyncLlamaStackClient) -> None:
         agent = await async_client.agents.delete(
-            agent_id="agent_id",
-        )
-        assert agent is None
-
-    @parametrize
-    async def test_method_delete_with_all_params(self, async_client: AsyncLlamaStackClient) -> None:
-        agent = await async_client.agents.delete(
-            agent_id="agent_id",
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
+            "agent_id",
         )
         assert agent is None
 
     @parametrize
     async def test_raw_response_delete(self, async_client: AsyncLlamaStackClient) -> None:
         response = await async_client.agents.with_raw_response.delete(
-            agent_id="agent_id",
+            "agent_id",
         )
 
         assert response.is_closed is True
@@ -278,7 +256,7 @@ class TestAsyncAgents:
     @parametrize
     async def test_streaming_response_delete(self, async_client: AsyncLlamaStackClient) -> None:
         async with async_client.agents.with_streaming_response.delete(
-            agent_id="agent_id",
+            "agent_id",
         ) as response:
             assert not response.is_closed
             assert response.http_request.headers.get("X-Stainless-Lang") == "python"
@@ -292,5 +270,5 @@ class TestAsyncAgents:
     async def test_path_params_delete(self, async_client: AsyncLlamaStackClient) -> None:
         with pytest.raises(ValueError, match=r"Expected a non-empty value for `agent_id` but received ''"):
             await async_client.agents.with_raw_response.delete(
-                agent_id="",
+                "",
             )

--- a/tests/api_resources/test_batch_inference.py
+++ b/tests/api_resources/test_batch_inference.py
@@ -49,6 +49,10 @@ class TestBatchInference:
             ],
             model="model",
             logprobs={"top_k": 0},
+            response_format={
+                "json_schema": {"foo": True},
+                "type": "json_schema",
+            },
             sampling_params={
                 "strategy": {"type": "greedy"},
                 "max_tokens": 0,
@@ -70,8 +74,6 @@ class TestBatchInference:
                     },
                 }
             ],
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
         )
         assert_matches_type(BatchInferenceChatCompletionResponse, batch_inference, path=["response"])
 
@@ -129,13 +131,15 @@ class TestBatchInference:
             content_batch=["string"],
             model="model",
             logprobs={"top_k": 0},
+            response_format={
+                "json_schema": {"foo": True},
+                "type": "json_schema",
+            },
             sampling_params={
                 "strategy": {"type": "greedy"},
                 "max_tokens": 0,
                 "repetition_penalty": 0,
             },
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
         )
         assert_matches_type(BatchCompletion, batch_inference, path=["response"])
 
@@ -198,6 +202,10 @@ class TestAsyncBatchInference:
             ],
             model="model",
             logprobs={"top_k": 0},
+            response_format={
+                "json_schema": {"foo": True},
+                "type": "json_schema",
+            },
             sampling_params={
                 "strategy": {"type": "greedy"},
                 "max_tokens": 0,
@@ -219,8 +227,6 @@ class TestAsyncBatchInference:
                     },
                 }
             ],
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
         )
         assert_matches_type(BatchInferenceChatCompletionResponse, batch_inference, path=["response"])
 
@@ -278,13 +284,15 @@ class TestAsyncBatchInference:
             content_batch=["string"],
             model="model",
             logprobs={"top_k": 0},
+            response_format={
+                "json_schema": {"foo": True},
+                "type": "json_schema",
+            },
             sampling_params={
                 "strategy": {"type": "greedy"},
                 "max_tokens": 0,
                 "repetition_penalty": 0,
             },
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
         )
         assert_matches_type(BatchCompletion, batch_inference, path=["response"])
 

--- a/tests/api_resources/test_datasetio.py
+++ b/tests/api_resources/test_datasetio.py
@@ -28,16 +28,6 @@ class TestDatasetio:
         assert datasetio is None
 
     @parametrize
-    def test_method_append_rows_with_all_params(self, client: LlamaStackClient) -> None:
-        datasetio = client.datasetio.append_rows(
-            dataset_id="dataset_id",
-            rows=[{"foo": True}],
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
-        )
-        assert datasetio is None
-
-    @parametrize
     def test_raw_response_append_rows(self, client: LlamaStackClient) -> None:
         response = client.datasetio.with_raw_response.append_rows(
             dataset_id="dataset_id",
@@ -78,8 +68,6 @@ class TestDatasetio:
             rows_in_page=0,
             filter_condition="filter_condition",
             page_token="page_token",
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
         )
         assert_matches_type(PaginatedRowsResult, datasetio, path=["response"])
 
@@ -118,16 +106,6 @@ class TestAsyncDatasetio:
         datasetio = await async_client.datasetio.append_rows(
             dataset_id="dataset_id",
             rows=[{"foo": True}],
-        )
-        assert datasetio is None
-
-    @parametrize
-    async def test_method_append_rows_with_all_params(self, async_client: AsyncLlamaStackClient) -> None:
-        datasetio = await async_client.datasetio.append_rows(
-            dataset_id="dataset_id",
-            rows=[{"foo": True}],
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
         )
         assert datasetio is None
 
@@ -172,8 +150,6 @@ class TestAsyncDatasetio:
             rows_in_page=0,
             filter_condition="filter_condition",
             page_token="page_token",
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
         )
         assert_matches_type(PaginatedRowsResult, datasetio, path=["response"])
 

--- a/tests/api_resources/test_datasets.py
+++ b/tests/api_resources/test_datasets.py
@@ -20,23 +20,14 @@ class TestDatasets:
     @parametrize
     def test_method_retrieve(self, client: LlamaStackClient) -> None:
         dataset = client.datasets.retrieve(
-            dataset_id="dataset_id",
-        )
-        assert_matches_type(Optional[DatasetRetrieveResponse], dataset, path=["response"])
-
-    @parametrize
-    def test_method_retrieve_with_all_params(self, client: LlamaStackClient) -> None:
-        dataset = client.datasets.retrieve(
-            dataset_id="dataset_id",
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
+            "dataset_id",
         )
         assert_matches_type(Optional[DatasetRetrieveResponse], dataset, path=["response"])
 
     @parametrize
     def test_raw_response_retrieve(self, client: LlamaStackClient) -> None:
         response = client.datasets.with_raw_response.retrieve(
-            dataset_id="dataset_id",
+            "dataset_id",
         )
 
         assert response.is_closed is True
@@ -47,7 +38,7 @@ class TestDatasets:
     @parametrize
     def test_streaming_response_retrieve(self, client: LlamaStackClient) -> None:
         with client.datasets.with_streaming_response.retrieve(
-            dataset_id="dataset_id",
+            "dataset_id",
         ) as response:
             assert not response.is_closed
             assert response.http_request.headers.get("X-Stainless-Lang") == "python"
@@ -61,20 +52,12 @@ class TestDatasets:
     def test_path_params_retrieve(self, client: LlamaStackClient) -> None:
         with pytest.raises(ValueError, match=r"Expected a non-empty value for `dataset_id` but received ''"):
             client.datasets.with_raw_response.retrieve(
-                dataset_id="",
+                "",
             )
 
     @parametrize
     def test_method_list(self, client: LlamaStackClient) -> None:
         dataset = client.datasets.list()
-        assert_matches_type(DatasetListResponse, dataset, path=["response"])
-
-    @parametrize
-    def test_method_list_with_all_params(self, client: LlamaStackClient) -> None:
-        dataset = client.datasets.list(
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
-        )
         assert_matches_type(DatasetListResponse, dataset, path=["response"])
 
     @parametrize
@@ -115,8 +98,6 @@ class TestDatasets:
             metadata={"foo": True},
             provider_dataset_id="provider_dataset_id",
             provider_id="provider_id",
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
         )
         assert dataset is None
 
@@ -151,23 +132,14 @@ class TestDatasets:
     @parametrize
     def test_method_unregister(self, client: LlamaStackClient) -> None:
         dataset = client.datasets.unregister(
-            dataset_id="dataset_id",
-        )
-        assert dataset is None
-
-    @parametrize
-    def test_method_unregister_with_all_params(self, client: LlamaStackClient) -> None:
-        dataset = client.datasets.unregister(
-            dataset_id="dataset_id",
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
+            "dataset_id",
         )
         assert dataset is None
 
     @parametrize
     def test_raw_response_unregister(self, client: LlamaStackClient) -> None:
         response = client.datasets.with_raw_response.unregister(
-            dataset_id="dataset_id",
+            "dataset_id",
         )
 
         assert response.is_closed is True
@@ -178,7 +150,7 @@ class TestDatasets:
     @parametrize
     def test_streaming_response_unregister(self, client: LlamaStackClient) -> None:
         with client.datasets.with_streaming_response.unregister(
-            dataset_id="dataset_id",
+            "dataset_id",
         ) as response:
             assert not response.is_closed
             assert response.http_request.headers.get("X-Stainless-Lang") == "python"
@@ -192,7 +164,7 @@ class TestDatasets:
     def test_path_params_unregister(self, client: LlamaStackClient) -> None:
         with pytest.raises(ValueError, match=r"Expected a non-empty value for `dataset_id` but received ''"):
             client.datasets.with_raw_response.unregister(
-                dataset_id="",
+                "",
             )
 
 
@@ -202,23 +174,14 @@ class TestAsyncDatasets:
     @parametrize
     async def test_method_retrieve(self, async_client: AsyncLlamaStackClient) -> None:
         dataset = await async_client.datasets.retrieve(
-            dataset_id="dataset_id",
-        )
-        assert_matches_type(Optional[DatasetRetrieveResponse], dataset, path=["response"])
-
-    @parametrize
-    async def test_method_retrieve_with_all_params(self, async_client: AsyncLlamaStackClient) -> None:
-        dataset = await async_client.datasets.retrieve(
-            dataset_id="dataset_id",
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
+            "dataset_id",
         )
         assert_matches_type(Optional[DatasetRetrieveResponse], dataset, path=["response"])
 
     @parametrize
     async def test_raw_response_retrieve(self, async_client: AsyncLlamaStackClient) -> None:
         response = await async_client.datasets.with_raw_response.retrieve(
-            dataset_id="dataset_id",
+            "dataset_id",
         )
 
         assert response.is_closed is True
@@ -229,7 +192,7 @@ class TestAsyncDatasets:
     @parametrize
     async def test_streaming_response_retrieve(self, async_client: AsyncLlamaStackClient) -> None:
         async with async_client.datasets.with_streaming_response.retrieve(
-            dataset_id="dataset_id",
+            "dataset_id",
         ) as response:
             assert not response.is_closed
             assert response.http_request.headers.get("X-Stainless-Lang") == "python"
@@ -243,20 +206,12 @@ class TestAsyncDatasets:
     async def test_path_params_retrieve(self, async_client: AsyncLlamaStackClient) -> None:
         with pytest.raises(ValueError, match=r"Expected a non-empty value for `dataset_id` but received ''"):
             await async_client.datasets.with_raw_response.retrieve(
-                dataset_id="",
+                "",
             )
 
     @parametrize
     async def test_method_list(self, async_client: AsyncLlamaStackClient) -> None:
         dataset = await async_client.datasets.list()
-        assert_matches_type(DatasetListResponse, dataset, path=["response"])
-
-    @parametrize
-    async def test_method_list_with_all_params(self, async_client: AsyncLlamaStackClient) -> None:
-        dataset = await async_client.datasets.list(
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
-        )
         assert_matches_type(DatasetListResponse, dataset, path=["response"])
 
     @parametrize
@@ -297,8 +252,6 @@ class TestAsyncDatasets:
             metadata={"foo": True},
             provider_dataset_id="provider_dataset_id",
             provider_id="provider_id",
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
         )
         assert dataset is None
 
@@ -333,23 +286,14 @@ class TestAsyncDatasets:
     @parametrize
     async def test_method_unregister(self, async_client: AsyncLlamaStackClient) -> None:
         dataset = await async_client.datasets.unregister(
-            dataset_id="dataset_id",
-        )
-        assert dataset is None
-
-    @parametrize
-    async def test_method_unregister_with_all_params(self, async_client: AsyncLlamaStackClient) -> None:
-        dataset = await async_client.datasets.unregister(
-            dataset_id="dataset_id",
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
+            "dataset_id",
         )
         assert dataset is None
 
     @parametrize
     async def test_raw_response_unregister(self, async_client: AsyncLlamaStackClient) -> None:
         response = await async_client.datasets.with_raw_response.unregister(
-            dataset_id="dataset_id",
+            "dataset_id",
         )
 
         assert response.is_closed is True
@@ -360,7 +304,7 @@ class TestAsyncDatasets:
     @parametrize
     async def test_streaming_response_unregister(self, async_client: AsyncLlamaStackClient) -> None:
         async with async_client.datasets.with_streaming_response.unregister(
-            dataset_id="dataset_id",
+            "dataset_id",
         ) as response:
             assert not response.is_closed
             assert response.http_request.headers.get("X-Stainless-Lang") == "python"
@@ -374,5 +318,5 @@ class TestAsyncDatasets:
     async def test_path_params_unregister(self, async_client: AsyncLlamaStackClient) -> None:
         with pytest.raises(ValueError, match=r"Expected a non-empty value for `dataset_id` but received ''"):
             await async_client.datasets.with_raw_response.unregister(
-                dataset_id="",
+                "",
             )

--- a/tests/api_resources/test_eval.py
+++ b/tests/api_resources/test_eval.py
@@ -60,8 +60,6 @@ class TestEval:
                 "type": "benchmark",
                 "num_examples": 0,
             },
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
         )
         assert_matches_type(EvaluateResponse, eval, path=["response"])
 
@@ -162,8 +160,6 @@ class TestEval:
                 "type": "benchmark",
                 "num_examples": 0,
             },
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
         )
         assert_matches_type(Job, eval, path=["response"])
 
@@ -266,8 +262,6 @@ class TestAsyncEval:
                 "type": "benchmark",
                 "num_examples": 0,
             },
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
         )
         assert_matches_type(EvaluateResponse, eval, path=["response"])
 
@@ -368,8 +362,6 @@ class TestAsyncEval:
                 "type": "benchmark",
                 "num_examples": 0,
             },
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
         )
         assert_matches_type(Job, eval, path=["response"])
 

--- a/tests/api_resources/test_eval_tasks.py
+++ b/tests/api_resources/test_eval_tasks.py
@@ -20,23 +20,14 @@ class TestEvalTasks:
     @parametrize
     def test_method_retrieve(self, client: LlamaStackClient) -> None:
         eval_task = client.eval_tasks.retrieve(
-            eval_task_id="eval_task_id",
-        )
-        assert_matches_type(Optional[EvalTask], eval_task, path=["response"])
-
-    @parametrize
-    def test_method_retrieve_with_all_params(self, client: LlamaStackClient) -> None:
-        eval_task = client.eval_tasks.retrieve(
-            eval_task_id="eval_task_id",
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
+            "eval_task_id",
         )
         assert_matches_type(Optional[EvalTask], eval_task, path=["response"])
 
     @parametrize
     def test_raw_response_retrieve(self, client: LlamaStackClient) -> None:
         response = client.eval_tasks.with_raw_response.retrieve(
-            eval_task_id="eval_task_id",
+            "eval_task_id",
         )
 
         assert response.is_closed is True
@@ -47,7 +38,7 @@ class TestEvalTasks:
     @parametrize
     def test_streaming_response_retrieve(self, client: LlamaStackClient) -> None:
         with client.eval_tasks.with_streaming_response.retrieve(
-            eval_task_id="eval_task_id",
+            "eval_task_id",
         ) as response:
             assert not response.is_closed
             assert response.http_request.headers.get("X-Stainless-Lang") == "python"
@@ -61,20 +52,12 @@ class TestEvalTasks:
     def test_path_params_retrieve(self, client: LlamaStackClient) -> None:
         with pytest.raises(ValueError, match=r"Expected a non-empty value for `eval_task_id` but received ''"):
             client.eval_tasks.with_raw_response.retrieve(
-                eval_task_id="",
+                "",
             )
 
     @parametrize
     def test_method_list(self, client: LlamaStackClient) -> None:
         eval_task = client.eval_tasks.list()
-        assert_matches_type(EvalTaskListResponse, eval_task, path=["response"])
-
-    @parametrize
-    def test_method_list_with_all_params(self, client: LlamaStackClient) -> None:
-        eval_task = client.eval_tasks.list(
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
-        )
         assert_matches_type(EvalTaskListResponse, eval_task, path=["response"])
 
     @parametrize
@@ -115,8 +98,6 @@ class TestEvalTasks:
             metadata={"foo": True},
             provider_eval_task_id="provider_eval_task_id",
             provider_id="provider_id",
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
         )
         assert eval_task is None
 
@@ -155,23 +136,14 @@ class TestAsyncEvalTasks:
     @parametrize
     async def test_method_retrieve(self, async_client: AsyncLlamaStackClient) -> None:
         eval_task = await async_client.eval_tasks.retrieve(
-            eval_task_id="eval_task_id",
-        )
-        assert_matches_type(Optional[EvalTask], eval_task, path=["response"])
-
-    @parametrize
-    async def test_method_retrieve_with_all_params(self, async_client: AsyncLlamaStackClient) -> None:
-        eval_task = await async_client.eval_tasks.retrieve(
-            eval_task_id="eval_task_id",
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
+            "eval_task_id",
         )
         assert_matches_type(Optional[EvalTask], eval_task, path=["response"])
 
     @parametrize
     async def test_raw_response_retrieve(self, async_client: AsyncLlamaStackClient) -> None:
         response = await async_client.eval_tasks.with_raw_response.retrieve(
-            eval_task_id="eval_task_id",
+            "eval_task_id",
         )
 
         assert response.is_closed is True
@@ -182,7 +154,7 @@ class TestAsyncEvalTasks:
     @parametrize
     async def test_streaming_response_retrieve(self, async_client: AsyncLlamaStackClient) -> None:
         async with async_client.eval_tasks.with_streaming_response.retrieve(
-            eval_task_id="eval_task_id",
+            "eval_task_id",
         ) as response:
             assert not response.is_closed
             assert response.http_request.headers.get("X-Stainless-Lang") == "python"
@@ -196,20 +168,12 @@ class TestAsyncEvalTasks:
     async def test_path_params_retrieve(self, async_client: AsyncLlamaStackClient) -> None:
         with pytest.raises(ValueError, match=r"Expected a non-empty value for `eval_task_id` but received ''"):
             await async_client.eval_tasks.with_raw_response.retrieve(
-                eval_task_id="",
+                "",
             )
 
     @parametrize
     async def test_method_list(self, async_client: AsyncLlamaStackClient) -> None:
         eval_task = await async_client.eval_tasks.list()
-        assert_matches_type(EvalTaskListResponse, eval_task, path=["response"])
-
-    @parametrize
-    async def test_method_list_with_all_params(self, async_client: AsyncLlamaStackClient) -> None:
-        eval_task = await async_client.eval_tasks.list(
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
-        )
         assert_matches_type(EvalTaskListResponse, eval_task, path=["response"])
 
     @parametrize
@@ -250,8 +214,6 @@ class TestAsyncEvalTasks:
             metadata={"foo": True},
             provider_eval_task_id="provider_eval_task_id",
             provider_id="provider_id",
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
         )
         assert eval_task is None
 

--- a/tests/api_resources/test_inference.py
+++ b/tests/api_resources/test_inference.py
@@ -78,8 +78,6 @@ class TestInference:
                     },
                 }
             ],
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
         )
         assert_matches_type(InferenceChatCompletionResponse, inference, path=["response"])
 
@@ -183,8 +181,6 @@ class TestInference:
                     },
                 }
             ],
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
         )
         inference_stream.response.close()
 
@@ -261,8 +257,6 @@ class TestInference:
                 "repetition_penalty": 0,
             },
             stream=False,
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
         )
         assert_matches_type(InferenceCompletionResponse, inference, path=["response"])
 
@@ -329,8 +323,6 @@ class TestInference:
                 "max_tokens": 0,
                 "repetition_penalty": 0,
             },
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
         )
         inference_stream.response.close()
 
@@ -372,16 +364,6 @@ class TestInference:
         inference = client.inference.embeddings(
             contents=["string"],
             model_id="model_id",
-        )
-        assert_matches_type(EmbeddingsResponse, inference, path=["response"])
-
-    @parametrize
-    def test_method_embeddings_with_all_params(self, client: LlamaStackClient) -> None:
-        inference = client.inference.embeddings(
-            contents=["string"],
-            model_id="model_id",
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
         )
         assert_matches_type(EmbeddingsResponse, inference, path=["response"])
 
@@ -472,8 +454,6 @@ class TestAsyncInference:
                     },
                 }
             ],
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
         )
         assert_matches_type(InferenceChatCompletionResponse, inference, path=["response"])
 
@@ -577,8 +557,6 @@ class TestAsyncInference:
                     },
                 }
             ],
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
         )
         await inference_stream.response.aclose()
 
@@ -655,8 +633,6 @@ class TestAsyncInference:
                 "repetition_penalty": 0,
             },
             stream=False,
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
         )
         assert_matches_type(InferenceCompletionResponse, inference, path=["response"])
 
@@ -723,8 +699,6 @@ class TestAsyncInference:
                 "max_tokens": 0,
                 "repetition_penalty": 0,
             },
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
         )
         await inference_stream.response.aclose()
 
@@ -766,16 +740,6 @@ class TestAsyncInference:
         inference = await async_client.inference.embeddings(
             contents=["string"],
             model_id="model_id",
-        )
-        assert_matches_type(EmbeddingsResponse, inference, path=["response"])
-
-    @parametrize
-    async def test_method_embeddings_with_all_params(self, async_client: AsyncLlamaStackClient) -> None:
-        inference = await async_client.inference.embeddings(
-            contents=["string"],
-            model_id="model_id",
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
         )
         assert_matches_type(EmbeddingsResponse, inference, path=["response"])
 

--- a/tests/api_resources/test_inspect.py
+++ b/tests/api_resources/test_inspect.py
@@ -23,14 +23,6 @@ class TestInspect:
         assert_matches_type(HealthInfo, inspect, path=["response"])
 
     @parametrize
-    def test_method_health_with_all_params(self, client: LlamaStackClient) -> None:
-        inspect = client.inspect.health(
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
-        )
-        assert_matches_type(HealthInfo, inspect, path=["response"])
-
-    @parametrize
     def test_raw_response_health(self, client: LlamaStackClient) -> None:
         response = client.inspect.with_raw_response.health()
 
@@ -53,14 +45,6 @@ class TestInspect:
     @parametrize
     def test_method_version(self, client: LlamaStackClient) -> None:
         inspect = client.inspect.version()
-        assert_matches_type(VersionInfo, inspect, path=["response"])
-
-    @parametrize
-    def test_method_version_with_all_params(self, client: LlamaStackClient) -> None:
-        inspect = client.inspect.version(
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
-        )
         assert_matches_type(VersionInfo, inspect, path=["response"])
 
     @parametrize
@@ -93,14 +77,6 @@ class TestAsyncInspect:
         assert_matches_type(HealthInfo, inspect, path=["response"])
 
     @parametrize
-    async def test_method_health_with_all_params(self, async_client: AsyncLlamaStackClient) -> None:
-        inspect = await async_client.inspect.health(
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
-        )
-        assert_matches_type(HealthInfo, inspect, path=["response"])
-
-    @parametrize
     async def test_raw_response_health(self, async_client: AsyncLlamaStackClient) -> None:
         response = await async_client.inspect.with_raw_response.health()
 
@@ -123,14 +99,6 @@ class TestAsyncInspect:
     @parametrize
     async def test_method_version(self, async_client: AsyncLlamaStackClient) -> None:
         inspect = await async_client.inspect.version()
-        assert_matches_type(VersionInfo, inspect, path=["response"])
-
-    @parametrize
-    async def test_method_version_with_all_params(self, async_client: AsyncLlamaStackClient) -> None:
-        inspect = await async_client.inspect.version(
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
-        )
         assert_matches_type(VersionInfo, inspect, path=["response"])
 
     @parametrize

--- a/tests/api_resources/test_models.py
+++ b/tests/api_resources/test_models.py
@@ -20,23 +20,14 @@ class TestModels:
     @parametrize
     def test_method_retrieve(self, client: LlamaStackClient) -> None:
         model = client.models.retrieve(
-            model_id="model_id",
-        )
-        assert_matches_type(Optional[Model], model, path=["response"])
-
-    @parametrize
-    def test_method_retrieve_with_all_params(self, client: LlamaStackClient) -> None:
-        model = client.models.retrieve(
-            model_id="model_id",
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
+            "model_id",
         )
         assert_matches_type(Optional[Model], model, path=["response"])
 
     @parametrize
     def test_raw_response_retrieve(self, client: LlamaStackClient) -> None:
         response = client.models.with_raw_response.retrieve(
-            model_id="model_id",
+            "model_id",
         )
 
         assert response.is_closed is True
@@ -47,7 +38,7 @@ class TestModels:
     @parametrize
     def test_streaming_response_retrieve(self, client: LlamaStackClient) -> None:
         with client.models.with_streaming_response.retrieve(
-            model_id="model_id",
+            "model_id",
         ) as response:
             assert not response.is_closed
             assert response.http_request.headers.get("X-Stainless-Lang") == "python"
@@ -61,20 +52,12 @@ class TestModels:
     def test_path_params_retrieve(self, client: LlamaStackClient) -> None:
         with pytest.raises(ValueError, match=r"Expected a non-empty value for `model_id` but received ''"):
             client.models.with_raw_response.retrieve(
-                model_id="",
+                "",
             )
 
     @parametrize
     def test_method_list(self, client: LlamaStackClient) -> None:
         model = client.models.list()
-        assert_matches_type(ModelListResponse, model, path=["response"])
-
-    @parametrize
-    def test_method_list_with_all_params(self, client: LlamaStackClient) -> None:
-        model = client.models.list(
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
-        )
         assert_matches_type(ModelListResponse, model, path=["response"])
 
     @parametrize
@@ -112,8 +95,6 @@ class TestModels:
             model_type="llm",
             provider_id="provider_id",
             provider_model_id="provider_model_id",
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
         )
         assert_matches_type(Model, model, path=["response"])
 
@@ -144,23 +125,14 @@ class TestModels:
     @parametrize
     def test_method_unregister(self, client: LlamaStackClient) -> None:
         model = client.models.unregister(
-            model_id="model_id",
-        )
-        assert model is None
-
-    @parametrize
-    def test_method_unregister_with_all_params(self, client: LlamaStackClient) -> None:
-        model = client.models.unregister(
-            model_id="model_id",
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
+            "model_id",
         )
         assert model is None
 
     @parametrize
     def test_raw_response_unregister(self, client: LlamaStackClient) -> None:
         response = client.models.with_raw_response.unregister(
-            model_id="model_id",
+            "model_id",
         )
 
         assert response.is_closed is True
@@ -171,7 +143,7 @@ class TestModels:
     @parametrize
     def test_streaming_response_unregister(self, client: LlamaStackClient) -> None:
         with client.models.with_streaming_response.unregister(
-            model_id="model_id",
+            "model_id",
         ) as response:
             assert not response.is_closed
             assert response.http_request.headers.get("X-Stainless-Lang") == "python"
@@ -185,7 +157,7 @@ class TestModels:
     def test_path_params_unregister(self, client: LlamaStackClient) -> None:
         with pytest.raises(ValueError, match=r"Expected a non-empty value for `model_id` but received ''"):
             client.models.with_raw_response.unregister(
-                model_id="",
+                "",
             )
 
 
@@ -195,23 +167,14 @@ class TestAsyncModels:
     @parametrize
     async def test_method_retrieve(self, async_client: AsyncLlamaStackClient) -> None:
         model = await async_client.models.retrieve(
-            model_id="model_id",
-        )
-        assert_matches_type(Optional[Model], model, path=["response"])
-
-    @parametrize
-    async def test_method_retrieve_with_all_params(self, async_client: AsyncLlamaStackClient) -> None:
-        model = await async_client.models.retrieve(
-            model_id="model_id",
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
+            "model_id",
         )
         assert_matches_type(Optional[Model], model, path=["response"])
 
     @parametrize
     async def test_raw_response_retrieve(self, async_client: AsyncLlamaStackClient) -> None:
         response = await async_client.models.with_raw_response.retrieve(
-            model_id="model_id",
+            "model_id",
         )
 
         assert response.is_closed is True
@@ -222,7 +185,7 @@ class TestAsyncModels:
     @parametrize
     async def test_streaming_response_retrieve(self, async_client: AsyncLlamaStackClient) -> None:
         async with async_client.models.with_streaming_response.retrieve(
-            model_id="model_id",
+            "model_id",
         ) as response:
             assert not response.is_closed
             assert response.http_request.headers.get("X-Stainless-Lang") == "python"
@@ -236,20 +199,12 @@ class TestAsyncModels:
     async def test_path_params_retrieve(self, async_client: AsyncLlamaStackClient) -> None:
         with pytest.raises(ValueError, match=r"Expected a non-empty value for `model_id` but received ''"):
             await async_client.models.with_raw_response.retrieve(
-                model_id="",
+                "",
             )
 
     @parametrize
     async def test_method_list(self, async_client: AsyncLlamaStackClient) -> None:
         model = await async_client.models.list()
-        assert_matches_type(ModelListResponse, model, path=["response"])
-
-    @parametrize
-    async def test_method_list_with_all_params(self, async_client: AsyncLlamaStackClient) -> None:
-        model = await async_client.models.list(
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
-        )
         assert_matches_type(ModelListResponse, model, path=["response"])
 
     @parametrize
@@ -287,8 +242,6 @@ class TestAsyncModels:
             model_type="llm",
             provider_id="provider_id",
             provider_model_id="provider_model_id",
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
         )
         assert_matches_type(Model, model, path=["response"])
 
@@ -319,23 +272,14 @@ class TestAsyncModels:
     @parametrize
     async def test_method_unregister(self, async_client: AsyncLlamaStackClient) -> None:
         model = await async_client.models.unregister(
-            model_id="model_id",
-        )
-        assert model is None
-
-    @parametrize
-    async def test_method_unregister_with_all_params(self, async_client: AsyncLlamaStackClient) -> None:
-        model = await async_client.models.unregister(
-            model_id="model_id",
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
+            "model_id",
         )
         assert model is None
 
     @parametrize
     async def test_raw_response_unregister(self, async_client: AsyncLlamaStackClient) -> None:
         response = await async_client.models.with_raw_response.unregister(
-            model_id="model_id",
+            "model_id",
         )
 
         assert response.is_closed is True
@@ -346,7 +290,7 @@ class TestAsyncModels:
     @parametrize
     async def test_streaming_response_unregister(self, async_client: AsyncLlamaStackClient) -> None:
         async with async_client.models.with_streaming_response.unregister(
-            model_id="model_id",
+            "model_id",
         ) as response:
             assert not response.is_closed
             assert response.http_request.headers.get("X-Stainless-Lang") == "python"
@@ -360,5 +304,5 @@ class TestAsyncModels:
     async def test_path_params_unregister(self, async_client: AsyncLlamaStackClient) -> None:
         with pytest.raises(ValueError, match=r"Expected a non-empty value for `model_id` but received ''"):
             await async_client.models.with_raw_response.unregister(
-                model_id="",
+                "",
             )

--- a/tests/api_resources/test_post_training.py
+++ b/tests/api_resources/test_post_training.py
@@ -94,8 +94,6 @@ class TestPostTraining:
                     "memory_efficient_fsdp_wrap": True,
                 },
             },
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
         )
         assert_matches_type(PostTrainingJob, post_training, path=["response"])
 
@@ -251,8 +249,6 @@ class TestPostTraining:
                 "use_dora": True,
             },
             checkpoint_dir="checkpoint_dir",
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
         )
         assert_matches_type(PostTrainingJob, post_training, path=["response"])
 
@@ -401,8 +397,6 @@ class TestAsyncPostTraining:
                     "memory_efficient_fsdp_wrap": True,
                 },
             },
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
         )
         assert_matches_type(PostTrainingJob, post_training, path=["response"])
 
@@ -558,8 +552,6 @@ class TestAsyncPostTraining:
                 "use_dora": True,
             },
             checkpoint_dir="checkpoint_dir",
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
         )
         assert_matches_type(PostTrainingJob, post_training, path=["response"])
 

--- a/tests/api_resources/test_providers.py
+++ b/tests/api_resources/test_providers.py
@@ -23,14 +23,6 @@ class TestProviders:
         assert_matches_type(ProviderListResponse, provider, path=["response"])
 
     @parametrize
-    def test_method_list_with_all_params(self, client: LlamaStackClient) -> None:
-        provider = client.providers.list(
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
-        )
-        assert_matches_type(ProviderListResponse, provider, path=["response"])
-
-    @parametrize
     def test_raw_response_list(self, client: LlamaStackClient) -> None:
         response = client.providers.with_raw_response.list()
 
@@ -57,14 +49,6 @@ class TestAsyncProviders:
     @parametrize
     async def test_method_list(self, async_client: AsyncLlamaStackClient) -> None:
         provider = await async_client.providers.list()
-        assert_matches_type(ProviderListResponse, provider, path=["response"])
-
-    @parametrize
-    async def test_method_list_with_all_params(self, async_client: AsyncLlamaStackClient) -> None:
-        provider = await async_client.providers.list(
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
-        )
         assert_matches_type(ProviderListResponse, provider, path=["response"])
 
     @parametrize

--- a/tests/api_resources/test_routes.py
+++ b/tests/api_resources/test_routes.py
@@ -23,14 +23,6 @@ class TestRoutes:
         assert_matches_type(RouteListResponse, route, path=["response"])
 
     @parametrize
-    def test_method_list_with_all_params(self, client: LlamaStackClient) -> None:
-        route = client.routes.list(
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
-        )
-        assert_matches_type(RouteListResponse, route, path=["response"])
-
-    @parametrize
     def test_raw_response_list(self, client: LlamaStackClient) -> None:
         response = client.routes.with_raw_response.list()
 
@@ -57,14 +49,6 @@ class TestAsyncRoutes:
     @parametrize
     async def test_method_list(self, async_client: AsyncLlamaStackClient) -> None:
         route = await async_client.routes.list()
-        assert_matches_type(RouteListResponse, route, path=["response"])
-
-    @parametrize
-    async def test_method_list_with_all_params(self, async_client: AsyncLlamaStackClient) -> None:
-        route = await async_client.routes.list(
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
-        )
         assert_matches_type(RouteListResponse, route, path=["response"])
 
     @parametrize

--- a/tests/api_resources/test_safety.py
+++ b/tests/api_resources/test_safety.py
@@ -32,23 +32,6 @@ class TestSafety:
         assert_matches_type(RunShieldResponse, safety, path=["response"])
 
     @parametrize
-    def test_method_run_shield_with_all_params(self, client: LlamaStackClient) -> None:
-        safety = client.safety.run_shield(
-            messages=[
-                {
-                    "content": "string",
-                    "role": "user",
-                    "context": "string",
-                }
-            ],
-            params={"foo": True},
-            shield_id="shield_id",
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
-        )
-        assert_matches_type(RunShieldResponse, safety, path=["response"])
-
-    @parametrize
     def test_raw_response_run_shield(self, client: LlamaStackClient) -> None:
         response = client.safety.with_raw_response.run_shield(
             messages=[
@@ -101,23 +84,6 @@ class TestAsyncSafety:
             ],
             params={"foo": True},
             shield_id="shield_id",
-        )
-        assert_matches_type(RunShieldResponse, safety, path=["response"])
-
-    @parametrize
-    async def test_method_run_shield_with_all_params(self, async_client: AsyncLlamaStackClient) -> None:
-        safety = await async_client.safety.run_shield(
-            messages=[
-                {
-                    "content": "string",
-                    "role": "user",
-                    "context": "string",
-                }
-            ],
-            params={"foo": True},
-            shield_id="shield_id",
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
         )
         assert_matches_type(RunShieldResponse, safety, path=["response"])
 

--- a/tests/api_resources/test_scoring.py
+++ b/tests/api_resources/test_scoring.py
@@ -34,24 +34,6 @@ class TestScoring:
         assert_matches_type(ScoringScoreResponse, scoring, path=["response"])
 
     @parametrize
-    def test_method_score_with_all_params(self, client: LlamaStackClient) -> None:
-        scoring = client.scoring.score(
-            input_rows=[{"foo": True}],
-            scoring_functions={
-                "foo": {
-                    "judge_model": "judge_model",
-                    "type": "llm_as_judge",
-                    "aggregation_functions": ["average"],
-                    "judge_score_regexes": ["string"],
-                    "prompt_template": "prompt_template",
-                }
-            },
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
-        )
-        assert_matches_type(ScoringScoreResponse, scoring, path=["response"])
-
-    @parametrize
     def test_raw_response_score(self, client: LlamaStackClient) -> None:
         response = client.scoring.with_raw_response.score(
             input_rows=[{"foo": True}],
@@ -98,25 +80,6 @@ class TestScoring:
                     "type": "llm_as_judge",
                 }
             },
-        )
-        assert_matches_type(ScoringScoreBatchResponse, scoring, path=["response"])
-
-    @parametrize
-    def test_method_score_batch_with_all_params(self, client: LlamaStackClient) -> None:
-        scoring = client.scoring.score_batch(
-            dataset_id="dataset_id",
-            save_results_dataset=True,
-            scoring_functions={
-                "foo": {
-                    "judge_model": "judge_model",
-                    "type": "llm_as_judge",
-                    "aggregation_functions": ["average"],
-                    "judge_score_regexes": ["string"],
-                    "prompt_template": "prompt_template",
-                }
-            },
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
         )
         assert_matches_type(ScoringScoreBatchResponse, scoring, path=["response"])
 
@@ -176,24 +139,6 @@ class TestAsyncScoring:
         assert_matches_type(ScoringScoreResponse, scoring, path=["response"])
 
     @parametrize
-    async def test_method_score_with_all_params(self, async_client: AsyncLlamaStackClient) -> None:
-        scoring = await async_client.scoring.score(
-            input_rows=[{"foo": True}],
-            scoring_functions={
-                "foo": {
-                    "judge_model": "judge_model",
-                    "type": "llm_as_judge",
-                    "aggregation_functions": ["average"],
-                    "judge_score_regexes": ["string"],
-                    "prompt_template": "prompt_template",
-                }
-            },
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
-        )
-        assert_matches_type(ScoringScoreResponse, scoring, path=["response"])
-
-    @parametrize
     async def test_raw_response_score(self, async_client: AsyncLlamaStackClient) -> None:
         response = await async_client.scoring.with_raw_response.score(
             input_rows=[{"foo": True}],
@@ -240,25 +185,6 @@ class TestAsyncScoring:
                     "type": "llm_as_judge",
                 }
             },
-        )
-        assert_matches_type(ScoringScoreBatchResponse, scoring, path=["response"])
-
-    @parametrize
-    async def test_method_score_batch_with_all_params(self, async_client: AsyncLlamaStackClient) -> None:
-        scoring = await async_client.scoring.score_batch(
-            dataset_id="dataset_id",
-            save_results_dataset=True,
-            scoring_functions={
-                "foo": {
-                    "judge_model": "judge_model",
-                    "type": "llm_as_judge",
-                    "aggregation_functions": ["average"],
-                    "judge_score_regexes": ["string"],
-                    "prompt_template": "prompt_template",
-                }
-            },
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
         )
         assert_matches_type(ScoringScoreBatchResponse, scoring, path=["response"])
 

--- a/tests/api_resources/test_scoring_functions.py
+++ b/tests/api_resources/test_scoring_functions.py
@@ -23,23 +23,14 @@ class TestScoringFunctions:
     @parametrize
     def test_method_retrieve(self, client: LlamaStackClient) -> None:
         scoring_function = client.scoring_functions.retrieve(
-            scoring_fn_id="scoring_fn_id",
-        )
-        assert_matches_type(Optional[ScoringFn], scoring_function, path=["response"])
-
-    @parametrize
-    def test_method_retrieve_with_all_params(self, client: LlamaStackClient) -> None:
-        scoring_function = client.scoring_functions.retrieve(
-            scoring_fn_id="scoring_fn_id",
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
+            "scoring_fn_id",
         )
         assert_matches_type(Optional[ScoringFn], scoring_function, path=["response"])
 
     @parametrize
     def test_raw_response_retrieve(self, client: LlamaStackClient) -> None:
         response = client.scoring_functions.with_raw_response.retrieve(
-            scoring_fn_id="scoring_fn_id",
+            "scoring_fn_id",
         )
 
         assert response.is_closed is True
@@ -50,7 +41,7 @@ class TestScoringFunctions:
     @parametrize
     def test_streaming_response_retrieve(self, client: LlamaStackClient) -> None:
         with client.scoring_functions.with_streaming_response.retrieve(
-            scoring_fn_id="scoring_fn_id",
+            "scoring_fn_id",
         ) as response:
             assert not response.is_closed
             assert response.http_request.headers.get("X-Stainless-Lang") == "python"
@@ -64,20 +55,12 @@ class TestScoringFunctions:
     def test_path_params_retrieve(self, client: LlamaStackClient) -> None:
         with pytest.raises(ValueError, match=r"Expected a non-empty value for `scoring_fn_id` but received ''"):
             client.scoring_functions.with_raw_response.retrieve(
-                scoring_fn_id="",
+                "",
             )
 
     @parametrize
     def test_method_list(self, client: LlamaStackClient) -> None:
         scoring_function = client.scoring_functions.list()
-        assert_matches_type(ScoringFunctionListResponse, scoring_function, path=["response"])
-
-    @parametrize
-    def test_method_list_with_all_params(self, client: LlamaStackClient) -> None:
-        scoring_function = client.scoring_functions.list(
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
-        )
         assert_matches_type(ScoringFunctionListResponse, scoring_function, path=["response"])
 
     @parametrize
@@ -124,8 +107,6 @@ class TestScoringFunctions:
             },
             provider_id="provider_id",
             provider_scoring_fn_id="provider_scoring_fn_id",
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
         )
         assert scoring_function is None
 
@@ -164,23 +145,14 @@ class TestAsyncScoringFunctions:
     @parametrize
     async def test_method_retrieve(self, async_client: AsyncLlamaStackClient) -> None:
         scoring_function = await async_client.scoring_functions.retrieve(
-            scoring_fn_id="scoring_fn_id",
-        )
-        assert_matches_type(Optional[ScoringFn], scoring_function, path=["response"])
-
-    @parametrize
-    async def test_method_retrieve_with_all_params(self, async_client: AsyncLlamaStackClient) -> None:
-        scoring_function = await async_client.scoring_functions.retrieve(
-            scoring_fn_id="scoring_fn_id",
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
+            "scoring_fn_id",
         )
         assert_matches_type(Optional[ScoringFn], scoring_function, path=["response"])
 
     @parametrize
     async def test_raw_response_retrieve(self, async_client: AsyncLlamaStackClient) -> None:
         response = await async_client.scoring_functions.with_raw_response.retrieve(
-            scoring_fn_id="scoring_fn_id",
+            "scoring_fn_id",
         )
 
         assert response.is_closed is True
@@ -191,7 +163,7 @@ class TestAsyncScoringFunctions:
     @parametrize
     async def test_streaming_response_retrieve(self, async_client: AsyncLlamaStackClient) -> None:
         async with async_client.scoring_functions.with_streaming_response.retrieve(
-            scoring_fn_id="scoring_fn_id",
+            "scoring_fn_id",
         ) as response:
             assert not response.is_closed
             assert response.http_request.headers.get("X-Stainless-Lang") == "python"
@@ -205,20 +177,12 @@ class TestAsyncScoringFunctions:
     async def test_path_params_retrieve(self, async_client: AsyncLlamaStackClient) -> None:
         with pytest.raises(ValueError, match=r"Expected a non-empty value for `scoring_fn_id` but received ''"):
             await async_client.scoring_functions.with_raw_response.retrieve(
-                scoring_fn_id="",
+                "",
             )
 
     @parametrize
     async def test_method_list(self, async_client: AsyncLlamaStackClient) -> None:
         scoring_function = await async_client.scoring_functions.list()
-        assert_matches_type(ScoringFunctionListResponse, scoring_function, path=["response"])
-
-    @parametrize
-    async def test_method_list_with_all_params(self, async_client: AsyncLlamaStackClient) -> None:
-        scoring_function = await async_client.scoring_functions.list(
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
-        )
         assert_matches_type(ScoringFunctionListResponse, scoring_function, path=["response"])
 
     @parametrize
@@ -265,8 +229,6 @@ class TestAsyncScoringFunctions:
             },
             provider_id="provider_id",
             provider_scoring_fn_id="provider_scoring_fn_id",
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
         )
         assert scoring_function is None
 

--- a/tests/api_resources/test_shields.py
+++ b/tests/api_resources/test_shields.py
@@ -20,23 +20,14 @@ class TestShields:
     @parametrize
     def test_method_retrieve(self, client: LlamaStackClient) -> None:
         shield = client.shields.retrieve(
-            identifier="identifier",
-        )
-        assert_matches_type(Optional[Shield], shield, path=["response"])
-
-    @parametrize
-    def test_method_retrieve_with_all_params(self, client: LlamaStackClient) -> None:
-        shield = client.shields.retrieve(
-            identifier="identifier",
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
+            "identifier",
         )
         assert_matches_type(Optional[Shield], shield, path=["response"])
 
     @parametrize
     def test_raw_response_retrieve(self, client: LlamaStackClient) -> None:
         response = client.shields.with_raw_response.retrieve(
-            identifier="identifier",
+            "identifier",
         )
 
         assert response.is_closed is True
@@ -47,7 +38,7 @@ class TestShields:
     @parametrize
     def test_streaming_response_retrieve(self, client: LlamaStackClient) -> None:
         with client.shields.with_streaming_response.retrieve(
-            identifier="identifier",
+            "identifier",
         ) as response:
             assert not response.is_closed
             assert response.http_request.headers.get("X-Stainless-Lang") == "python"
@@ -61,20 +52,12 @@ class TestShields:
     def test_path_params_retrieve(self, client: LlamaStackClient) -> None:
         with pytest.raises(ValueError, match=r"Expected a non-empty value for `identifier` but received ''"):
             client.shields.with_raw_response.retrieve(
-                identifier="",
+                "",
             )
 
     @parametrize
     def test_method_list(self, client: LlamaStackClient) -> None:
         shield = client.shields.list()
-        assert_matches_type(ShieldListResponse, shield, path=["response"])
-
-    @parametrize
-    def test_method_list_with_all_params(self, client: LlamaStackClient) -> None:
-        shield = client.shields.list(
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
-        )
         assert_matches_type(ShieldListResponse, shield, path=["response"])
 
     @parametrize
@@ -111,8 +94,6 @@ class TestShields:
             params={"foo": True},
             provider_id="provider_id",
             provider_shield_id="provider_shield_id",
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
         )
         assert_matches_type(Shield, shield, path=["response"])
 
@@ -147,23 +128,14 @@ class TestAsyncShields:
     @parametrize
     async def test_method_retrieve(self, async_client: AsyncLlamaStackClient) -> None:
         shield = await async_client.shields.retrieve(
-            identifier="identifier",
-        )
-        assert_matches_type(Optional[Shield], shield, path=["response"])
-
-    @parametrize
-    async def test_method_retrieve_with_all_params(self, async_client: AsyncLlamaStackClient) -> None:
-        shield = await async_client.shields.retrieve(
-            identifier="identifier",
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
+            "identifier",
         )
         assert_matches_type(Optional[Shield], shield, path=["response"])
 
     @parametrize
     async def test_raw_response_retrieve(self, async_client: AsyncLlamaStackClient) -> None:
         response = await async_client.shields.with_raw_response.retrieve(
-            identifier="identifier",
+            "identifier",
         )
 
         assert response.is_closed is True
@@ -174,7 +146,7 @@ class TestAsyncShields:
     @parametrize
     async def test_streaming_response_retrieve(self, async_client: AsyncLlamaStackClient) -> None:
         async with async_client.shields.with_streaming_response.retrieve(
-            identifier="identifier",
+            "identifier",
         ) as response:
             assert not response.is_closed
             assert response.http_request.headers.get("X-Stainless-Lang") == "python"
@@ -188,20 +160,12 @@ class TestAsyncShields:
     async def test_path_params_retrieve(self, async_client: AsyncLlamaStackClient) -> None:
         with pytest.raises(ValueError, match=r"Expected a non-empty value for `identifier` but received ''"):
             await async_client.shields.with_raw_response.retrieve(
-                identifier="",
+                "",
             )
 
     @parametrize
     async def test_method_list(self, async_client: AsyncLlamaStackClient) -> None:
         shield = await async_client.shields.list()
-        assert_matches_type(ShieldListResponse, shield, path=["response"])
-
-    @parametrize
-    async def test_method_list_with_all_params(self, async_client: AsyncLlamaStackClient) -> None:
-        shield = await async_client.shields.list(
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
-        )
         assert_matches_type(ShieldListResponse, shield, path=["response"])
 
     @parametrize
@@ -238,8 +202,6 @@ class TestAsyncShields:
             params={"foo": True},
             provider_id="provider_id",
             provider_shield_id="provider_shield_id",
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
         )
         assert_matches_type(Shield, shield, path=["response"])
 

--- a/tests/api_resources/test_synthetic_data_generation.py
+++ b/tests/api_resources/test_synthetic_data_generation.py
@@ -42,8 +42,6 @@ class TestSyntheticDataGeneration:
             ],
             filtering_function="none",
             model="model",
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
         )
         assert_matches_type(SyntheticDataGenerationResponse, synthetic_data_generation, path=["response"])
 
@@ -112,8 +110,6 @@ class TestAsyncSyntheticDataGeneration:
             ],
             filtering_function="none",
             model="model",
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
         )
         assert_matches_type(SyntheticDataGenerationResponse, synthetic_data_generation, path=["response"])
 

--- a/tests/api_resources/test_telemetry.py
+++ b/tests/api_resources/test_telemetry.py
@@ -33,16 +33,6 @@ class TestTelemetry:
         assert_matches_type(TelemetryGetSpanResponse, telemetry, path=["response"])
 
     @parametrize
-    def test_method_get_span_with_all_params(self, client: LlamaStackClient) -> None:
-        telemetry = client.telemetry.get_span(
-            span_id="span_id",
-            trace_id="trace_id",
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
-        )
-        assert_matches_type(TelemetryGetSpanResponse, telemetry, path=["response"])
-
-    @parametrize
     def test_raw_response_get_span(self, client: LlamaStackClient) -> None:
         response = client.telemetry.with_raw_response.get_span(
             span_id="span_id",
@@ -95,8 +85,6 @@ class TestTelemetry:
             span_id="span_id",
             attributes_to_return=["string"],
             max_depth=0,
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
         )
         assert_matches_type(TelemetryGetSpanTreeResponse, telemetry, path=["response"])
 
@@ -134,23 +122,14 @@ class TestTelemetry:
     @parametrize
     def test_method_get_trace(self, client: LlamaStackClient) -> None:
         telemetry = client.telemetry.get_trace(
-            trace_id="trace_id",
-        )
-        assert_matches_type(Trace, telemetry, path=["response"])
-
-    @parametrize
-    def test_method_get_trace_with_all_params(self, client: LlamaStackClient) -> None:
-        telemetry = client.telemetry.get_trace(
-            trace_id="trace_id",
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
+            "trace_id",
         )
         assert_matches_type(Trace, telemetry, path=["response"])
 
     @parametrize
     def test_raw_response_get_trace(self, client: LlamaStackClient) -> None:
         response = client.telemetry.with_raw_response.get_trace(
-            trace_id="trace_id",
+            "trace_id",
         )
 
         assert response.is_closed is True
@@ -161,7 +140,7 @@ class TestTelemetry:
     @parametrize
     def test_streaming_response_get_trace(self, client: LlamaStackClient) -> None:
         with client.telemetry.with_streaming_response.get_trace(
-            trace_id="trace_id",
+            "trace_id",
         ) as response:
             assert not response.is_closed
             assert response.http_request.headers.get("X-Stainless-Lang") == "python"
@@ -175,7 +154,7 @@ class TestTelemetry:
     def test_path_params_get_trace(self, client: LlamaStackClient) -> None:
         with pytest.raises(ValueError, match=r"Expected a non-empty value for `trace_id` but received ''"):
             client.telemetry.with_raw_response.get_trace(
-                trace_id="",
+                "",
             )
 
     @parametrize
@@ -206,8 +185,6 @@ class TestTelemetry:
                 "attributes": {"foo": True},
             },
             ttl_seconds=0,
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
         )
         assert telemetry is None
 
@@ -279,8 +256,6 @@ class TestTelemetry:
             ],
             attributes_to_return=["string"],
             max_depth=0,
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
         )
         assert_matches_type(TelemetryQuerySpansResponse, telemetry, path=["response"])
 
@@ -344,8 +319,6 @@ class TestTelemetry:
             limit=0,
             offset=0,
             order_by=["string"],
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
         )
         assert_matches_type(TelemetryQueryTracesResponse, telemetry, path=["response"])
 
@@ -399,8 +372,6 @@ class TestTelemetry:
             attributes_to_save=["string"],
             dataset_id="dataset_id",
             max_depth=0,
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
         )
         assert telemetry is None
 
@@ -457,16 +428,6 @@ class TestAsyncTelemetry:
         assert_matches_type(TelemetryGetSpanResponse, telemetry, path=["response"])
 
     @parametrize
-    async def test_method_get_span_with_all_params(self, async_client: AsyncLlamaStackClient) -> None:
-        telemetry = await async_client.telemetry.get_span(
-            span_id="span_id",
-            trace_id="trace_id",
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
-        )
-        assert_matches_type(TelemetryGetSpanResponse, telemetry, path=["response"])
-
-    @parametrize
     async def test_raw_response_get_span(self, async_client: AsyncLlamaStackClient) -> None:
         response = await async_client.telemetry.with_raw_response.get_span(
             span_id="span_id",
@@ -519,8 +480,6 @@ class TestAsyncTelemetry:
             span_id="span_id",
             attributes_to_return=["string"],
             max_depth=0,
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
         )
         assert_matches_type(TelemetryGetSpanTreeResponse, telemetry, path=["response"])
 
@@ -558,23 +517,14 @@ class TestAsyncTelemetry:
     @parametrize
     async def test_method_get_trace(self, async_client: AsyncLlamaStackClient) -> None:
         telemetry = await async_client.telemetry.get_trace(
-            trace_id="trace_id",
-        )
-        assert_matches_type(Trace, telemetry, path=["response"])
-
-    @parametrize
-    async def test_method_get_trace_with_all_params(self, async_client: AsyncLlamaStackClient) -> None:
-        telemetry = await async_client.telemetry.get_trace(
-            trace_id="trace_id",
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
+            "trace_id",
         )
         assert_matches_type(Trace, telemetry, path=["response"])
 
     @parametrize
     async def test_raw_response_get_trace(self, async_client: AsyncLlamaStackClient) -> None:
         response = await async_client.telemetry.with_raw_response.get_trace(
-            trace_id="trace_id",
+            "trace_id",
         )
 
         assert response.is_closed is True
@@ -585,7 +535,7 @@ class TestAsyncTelemetry:
     @parametrize
     async def test_streaming_response_get_trace(self, async_client: AsyncLlamaStackClient) -> None:
         async with async_client.telemetry.with_streaming_response.get_trace(
-            trace_id="trace_id",
+            "trace_id",
         ) as response:
             assert not response.is_closed
             assert response.http_request.headers.get("X-Stainless-Lang") == "python"
@@ -599,7 +549,7 @@ class TestAsyncTelemetry:
     async def test_path_params_get_trace(self, async_client: AsyncLlamaStackClient) -> None:
         with pytest.raises(ValueError, match=r"Expected a non-empty value for `trace_id` but received ''"):
             await async_client.telemetry.with_raw_response.get_trace(
-                trace_id="",
+                "",
             )
 
     @parametrize
@@ -630,8 +580,6 @@ class TestAsyncTelemetry:
                 "attributes": {"foo": True},
             },
             ttl_seconds=0,
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
         )
         assert telemetry is None
 
@@ -703,8 +651,6 @@ class TestAsyncTelemetry:
             ],
             attributes_to_return=["string"],
             max_depth=0,
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
         )
         assert_matches_type(TelemetryQuerySpansResponse, telemetry, path=["response"])
 
@@ -768,8 +714,6 @@ class TestAsyncTelemetry:
             limit=0,
             offset=0,
             order_by=["string"],
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
         )
         assert_matches_type(TelemetryQueryTracesResponse, telemetry, path=["response"])
 
@@ -823,8 +767,6 @@ class TestAsyncTelemetry:
             attributes_to_save=["string"],
             dataset_id="dataset_id",
             max_depth=0,
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
         )
         assert telemetry is None
 

--- a/tests/api_resources/test_tool_runtime.py
+++ b/tests/api_resources/test_tool_runtime.py
@@ -30,16 +30,6 @@ class TestToolRuntime:
         assert_matches_type(ToolInvocationResult, tool_runtime, path=["response"])
 
     @parametrize
-    def test_method_invoke_tool_with_all_params(self, client: LlamaStackClient) -> None:
-        tool_runtime = client.tool_runtime.invoke_tool(
-            kwargs={"foo": True},
-            tool_name="tool_name",
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
-        )
-        assert_matches_type(ToolInvocationResult, tool_runtime, path=["response"])
-
-    @parametrize
     def test_raw_response_invoke_tool(self, client: LlamaStackClient) -> None:
         response = client.tool_runtime.with_raw_response.invoke_tool(
             kwargs={"foo": True},
@@ -77,8 +67,6 @@ class TestToolRuntime:
         tool_runtime = client.tool_runtime.list_tools(
             mcp_endpoint={"uri": "uri"},
             tool_group_id="tool_group_id",
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
         )
         assert_matches_type(JSONLDecoder[ToolDef], tool_runtime, path=["response"])
 
@@ -113,16 +101,6 @@ class TestAsyncToolRuntime:
         tool_runtime = await async_client.tool_runtime.invoke_tool(
             kwargs={"foo": True},
             tool_name="tool_name",
-        )
-        assert_matches_type(ToolInvocationResult, tool_runtime, path=["response"])
-
-    @parametrize
-    async def test_method_invoke_tool_with_all_params(self, async_client: AsyncLlamaStackClient) -> None:
-        tool_runtime = await async_client.tool_runtime.invoke_tool(
-            kwargs={"foo": True},
-            tool_name="tool_name",
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
         )
         assert_matches_type(ToolInvocationResult, tool_runtime, path=["response"])
 
@@ -164,8 +142,6 @@ class TestAsyncToolRuntime:
         tool_runtime = await async_client.tool_runtime.list_tools(
             mcp_endpoint={"uri": "uri"},
             tool_group_id="tool_group_id",
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
         )
         assert_matches_type(AsyncJSONLDecoder[ToolDef], tool_runtime, path=["response"])
 

--- a/tests/api_resources/test_toolgroups.py
+++ b/tests/api_resources/test_toolgroups.py
@@ -23,14 +23,6 @@ class TestToolgroups:
         assert_matches_type(ToolgroupListResponse, toolgroup, path=["response"])
 
     @parametrize
-    def test_method_list_with_all_params(self, client: LlamaStackClient) -> None:
-        toolgroup = client.toolgroups.list(
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
-        )
-        assert_matches_type(ToolgroupListResponse, toolgroup, path=["response"])
-
-    @parametrize
     def test_raw_response_list(self, client: LlamaStackClient) -> None:
         response = client.toolgroups.with_raw_response.list()
 
@@ -53,23 +45,14 @@ class TestToolgroups:
     @parametrize
     def test_method_get(self, client: LlamaStackClient) -> None:
         toolgroup = client.toolgroups.get(
-            toolgroup_id="toolgroup_id",
-        )
-        assert_matches_type(ToolGroup, toolgroup, path=["response"])
-
-    @parametrize
-    def test_method_get_with_all_params(self, client: LlamaStackClient) -> None:
-        toolgroup = client.toolgroups.get(
-            toolgroup_id="toolgroup_id",
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
+            "toolgroup_id",
         )
         assert_matches_type(ToolGroup, toolgroup, path=["response"])
 
     @parametrize
     def test_raw_response_get(self, client: LlamaStackClient) -> None:
         response = client.toolgroups.with_raw_response.get(
-            toolgroup_id="toolgroup_id",
+            "toolgroup_id",
         )
 
         assert response.is_closed is True
@@ -80,7 +63,7 @@ class TestToolgroups:
     @parametrize
     def test_streaming_response_get(self, client: LlamaStackClient) -> None:
         with client.toolgroups.with_streaming_response.get(
-            toolgroup_id="toolgroup_id",
+            "toolgroup_id",
         ) as response:
             assert not response.is_closed
             assert response.http_request.headers.get("X-Stainless-Lang") == "python"
@@ -94,7 +77,7 @@ class TestToolgroups:
     def test_path_params_get(self, client: LlamaStackClient) -> None:
         with pytest.raises(ValueError, match=r"Expected a non-empty value for `toolgroup_id` but received ''"):
             client.toolgroups.with_raw_response.get(
-                toolgroup_id="",
+                "",
             )
 
     @parametrize
@@ -112,8 +95,6 @@ class TestToolgroups:
             toolgroup_id="toolgroup_id",
             args={"foo": True},
             mcp_endpoint={"uri": "uri"},
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
         )
         assert toolgroup is None
 
@@ -146,23 +127,14 @@ class TestToolgroups:
     @parametrize
     def test_method_unregister(self, client: LlamaStackClient) -> None:
         toolgroup = client.toolgroups.unregister(
-            toolgroup_id="toolgroup_id",
-        )
-        assert toolgroup is None
-
-    @parametrize
-    def test_method_unregister_with_all_params(self, client: LlamaStackClient) -> None:
-        toolgroup = client.toolgroups.unregister(
-            toolgroup_id="toolgroup_id",
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
+            "toolgroup_id",
         )
         assert toolgroup is None
 
     @parametrize
     def test_raw_response_unregister(self, client: LlamaStackClient) -> None:
         response = client.toolgroups.with_raw_response.unregister(
-            toolgroup_id="toolgroup_id",
+            "toolgroup_id",
         )
 
         assert response.is_closed is True
@@ -173,7 +145,7 @@ class TestToolgroups:
     @parametrize
     def test_streaming_response_unregister(self, client: LlamaStackClient) -> None:
         with client.toolgroups.with_streaming_response.unregister(
-            toolgroup_id="toolgroup_id",
+            "toolgroup_id",
         ) as response:
             assert not response.is_closed
             assert response.http_request.headers.get("X-Stainless-Lang") == "python"
@@ -187,7 +159,7 @@ class TestToolgroups:
     def test_path_params_unregister(self, client: LlamaStackClient) -> None:
         with pytest.raises(ValueError, match=r"Expected a non-empty value for `toolgroup_id` but received ''"):
             client.toolgroups.with_raw_response.unregister(
-                toolgroup_id="",
+                "",
             )
 
 
@@ -197,14 +169,6 @@ class TestAsyncToolgroups:
     @parametrize
     async def test_method_list(self, async_client: AsyncLlamaStackClient) -> None:
         toolgroup = await async_client.toolgroups.list()
-        assert_matches_type(ToolgroupListResponse, toolgroup, path=["response"])
-
-    @parametrize
-    async def test_method_list_with_all_params(self, async_client: AsyncLlamaStackClient) -> None:
-        toolgroup = await async_client.toolgroups.list(
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
-        )
         assert_matches_type(ToolgroupListResponse, toolgroup, path=["response"])
 
     @parametrize
@@ -230,23 +194,14 @@ class TestAsyncToolgroups:
     @parametrize
     async def test_method_get(self, async_client: AsyncLlamaStackClient) -> None:
         toolgroup = await async_client.toolgroups.get(
-            toolgroup_id="toolgroup_id",
-        )
-        assert_matches_type(ToolGroup, toolgroup, path=["response"])
-
-    @parametrize
-    async def test_method_get_with_all_params(self, async_client: AsyncLlamaStackClient) -> None:
-        toolgroup = await async_client.toolgroups.get(
-            toolgroup_id="toolgroup_id",
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
+            "toolgroup_id",
         )
         assert_matches_type(ToolGroup, toolgroup, path=["response"])
 
     @parametrize
     async def test_raw_response_get(self, async_client: AsyncLlamaStackClient) -> None:
         response = await async_client.toolgroups.with_raw_response.get(
-            toolgroup_id="toolgroup_id",
+            "toolgroup_id",
         )
 
         assert response.is_closed is True
@@ -257,7 +212,7 @@ class TestAsyncToolgroups:
     @parametrize
     async def test_streaming_response_get(self, async_client: AsyncLlamaStackClient) -> None:
         async with async_client.toolgroups.with_streaming_response.get(
-            toolgroup_id="toolgroup_id",
+            "toolgroup_id",
         ) as response:
             assert not response.is_closed
             assert response.http_request.headers.get("X-Stainless-Lang") == "python"
@@ -271,7 +226,7 @@ class TestAsyncToolgroups:
     async def test_path_params_get(self, async_client: AsyncLlamaStackClient) -> None:
         with pytest.raises(ValueError, match=r"Expected a non-empty value for `toolgroup_id` but received ''"):
             await async_client.toolgroups.with_raw_response.get(
-                toolgroup_id="",
+                "",
             )
 
     @parametrize
@@ -289,8 +244,6 @@ class TestAsyncToolgroups:
             toolgroup_id="toolgroup_id",
             args={"foo": True},
             mcp_endpoint={"uri": "uri"},
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
         )
         assert toolgroup is None
 
@@ -323,23 +276,14 @@ class TestAsyncToolgroups:
     @parametrize
     async def test_method_unregister(self, async_client: AsyncLlamaStackClient) -> None:
         toolgroup = await async_client.toolgroups.unregister(
-            toolgroup_id="toolgroup_id",
-        )
-        assert toolgroup is None
-
-    @parametrize
-    async def test_method_unregister_with_all_params(self, async_client: AsyncLlamaStackClient) -> None:
-        toolgroup = await async_client.toolgroups.unregister(
-            toolgroup_id="toolgroup_id",
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
+            "toolgroup_id",
         )
         assert toolgroup is None
 
     @parametrize
     async def test_raw_response_unregister(self, async_client: AsyncLlamaStackClient) -> None:
         response = await async_client.toolgroups.with_raw_response.unregister(
-            toolgroup_id="toolgroup_id",
+            "toolgroup_id",
         )
 
         assert response.is_closed is True
@@ -350,7 +294,7 @@ class TestAsyncToolgroups:
     @parametrize
     async def test_streaming_response_unregister(self, async_client: AsyncLlamaStackClient) -> None:
         async with async_client.toolgroups.with_streaming_response.unregister(
-            toolgroup_id="toolgroup_id",
+            "toolgroup_id",
         ) as response:
             assert not response.is_closed
             assert response.http_request.headers.get("X-Stainless-Lang") == "python"
@@ -364,5 +308,5 @@ class TestAsyncToolgroups:
     async def test_path_params_unregister(self, async_client: AsyncLlamaStackClient) -> None:
         with pytest.raises(ValueError, match=r"Expected a non-empty value for `toolgroup_id` but received ''"):
             await async_client.toolgroups.with_raw_response.unregister(
-                toolgroup_id="",
+                "",
             )

--- a/tests/api_resources/test_tools.py
+++ b/tests/api_resources/test_tools.py
@@ -26,8 +26,6 @@ class TestTools:
     def test_method_list_with_all_params(self, client: LlamaStackClient) -> None:
         tool = client.tools.list(
             toolgroup_id="toolgroup_id",
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
         )
         assert_matches_type(ToolListResponse, tool, path=["response"])
 
@@ -54,23 +52,14 @@ class TestTools:
     @parametrize
     def test_method_get(self, client: LlamaStackClient) -> None:
         tool = client.tools.get(
-            tool_name="tool_name",
-        )
-        assert_matches_type(Tool, tool, path=["response"])
-
-    @parametrize
-    def test_method_get_with_all_params(self, client: LlamaStackClient) -> None:
-        tool = client.tools.get(
-            tool_name="tool_name",
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
+            "tool_name",
         )
         assert_matches_type(Tool, tool, path=["response"])
 
     @parametrize
     def test_raw_response_get(self, client: LlamaStackClient) -> None:
         response = client.tools.with_raw_response.get(
-            tool_name="tool_name",
+            "tool_name",
         )
 
         assert response.is_closed is True
@@ -81,7 +70,7 @@ class TestTools:
     @parametrize
     def test_streaming_response_get(self, client: LlamaStackClient) -> None:
         with client.tools.with_streaming_response.get(
-            tool_name="tool_name",
+            "tool_name",
         ) as response:
             assert not response.is_closed
             assert response.http_request.headers.get("X-Stainless-Lang") == "python"
@@ -95,7 +84,7 @@ class TestTools:
     def test_path_params_get(self, client: LlamaStackClient) -> None:
         with pytest.raises(ValueError, match=r"Expected a non-empty value for `tool_name` but received ''"):
             client.tools.with_raw_response.get(
-                tool_name="",
+                "",
             )
 
 
@@ -111,8 +100,6 @@ class TestAsyncTools:
     async def test_method_list_with_all_params(self, async_client: AsyncLlamaStackClient) -> None:
         tool = await async_client.tools.list(
             toolgroup_id="toolgroup_id",
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
         )
         assert_matches_type(ToolListResponse, tool, path=["response"])
 
@@ -139,23 +126,14 @@ class TestAsyncTools:
     @parametrize
     async def test_method_get(self, async_client: AsyncLlamaStackClient) -> None:
         tool = await async_client.tools.get(
-            tool_name="tool_name",
-        )
-        assert_matches_type(Tool, tool, path=["response"])
-
-    @parametrize
-    async def test_method_get_with_all_params(self, async_client: AsyncLlamaStackClient) -> None:
-        tool = await async_client.tools.get(
-            tool_name="tool_name",
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
+            "tool_name",
         )
         assert_matches_type(Tool, tool, path=["response"])
 
     @parametrize
     async def test_raw_response_get(self, async_client: AsyncLlamaStackClient) -> None:
         response = await async_client.tools.with_raw_response.get(
-            tool_name="tool_name",
+            "tool_name",
         )
 
         assert response.is_closed is True
@@ -166,7 +144,7 @@ class TestAsyncTools:
     @parametrize
     async def test_streaming_response_get(self, async_client: AsyncLlamaStackClient) -> None:
         async with async_client.tools.with_streaming_response.get(
-            tool_name="tool_name",
+            "tool_name",
         ) as response:
             assert not response.is_closed
             assert response.http_request.headers.get("X-Stainless-Lang") == "python"
@@ -180,5 +158,5 @@ class TestAsyncTools:
     async def test_path_params_get(self, async_client: AsyncLlamaStackClient) -> None:
         with pytest.raises(ValueError, match=r"Expected a non-empty value for `tool_name` but received ''"):
             await async_client.tools.with_raw_response.get(
-                tool_name="",
+                "",
             )

--- a/tests/api_resources/test_vector_dbs.py
+++ b/tests/api_resources/test_vector_dbs.py
@@ -24,23 +24,14 @@ class TestVectorDBs:
     @parametrize
     def test_method_retrieve(self, client: LlamaStackClient) -> None:
         vector_db = client.vector_dbs.retrieve(
-            vector_db_id="vector_db_id",
-        )
-        assert_matches_type(Optional[VectorDBRetrieveResponse], vector_db, path=["response"])
-
-    @parametrize
-    def test_method_retrieve_with_all_params(self, client: LlamaStackClient) -> None:
-        vector_db = client.vector_dbs.retrieve(
-            vector_db_id="vector_db_id",
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
+            "vector_db_id",
         )
         assert_matches_type(Optional[VectorDBRetrieveResponse], vector_db, path=["response"])
 
     @parametrize
     def test_raw_response_retrieve(self, client: LlamaStackClient) -> None:
         response = client.vector_dbs.with_raw_response.retrieve(
-            vector_db_id="vector_db_id",
+            "vector_db_id",
         )
 
         assert response.is_closed is True
@@ -51,7 +42,7 @@ class TestVectorDBs:
     @parametrize
     def test_streaming_response_retrieve(self, client: LlamaStackClient) -> None:
         with client.vector_dbs.with_streaming_response.retrieve(
-            vector_db_id="vector_db_id",
+            "vector_db_id",
         ) as response:
             assert not response.is_closed
             assert response.http_request.headers.get("X-Stainless-Lang") == "python"
@@ -65,20 +56,12 @@ class TestVectorDBs:
     def test_path_params_retrieve(self, client: LlamaStackClient) -> None:
         with pytest.raises(ValueError, match=r"Expected a non-empty value for `vector_db_id` but received ''"):
             client.vector_dbs.with_raw_response.retrieve(
-                vector_db_id="",
+                "",
             )
 
     @parametrize
     def test_method_list(self, client: LlamaStackClient) -> None:
         vector_db = client.vector_dbs.list()
-        assert_matches_type(VectorDBListResponse, vector_db, path=["response"])
-
-    @parametrize
-    def test_method_list_with_all_params(self, client: LlamaStackClient) -> None:
-        vector_db = client.vector_dbs.list(
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
-        )
         assert_matches_type(VectorDBListResponse, vector_db, path=["response"])
 
     @parametrize
@@ -117,8 +100,6 @@ class TestVectorDBs:
             embedding_dimension=0,
             provider_id="provider_id",
             provider_vector_db_id="provider_vector_db_id",
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
         )
         assert_matches_type(VectorDBRegisterResponse, vector_db, path=["response"])
 
@@ -151,23 +132,14 @@ class TestVectorDBs:
     @parametrize
     def test_method_unregister(self, client: LlamaStackClient) -> None:
         vector_db = client.vector_dbs.unregister(
-            vector_db_id="vector_db_id",
-        )
-        assert vector_db is None
-
-    @parametrize
-    def test_method_unregister_with_all_params(self, client: LlamaStackClient) -> None:
-        vector_db = client.vector_dbs.unregister(
-            vector_db_id="vector_db_id",
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
+            "vector_db_id",
         )
         assert vector_db is None
 
     @parametrize
     def test_raw_response_unregister(self, client: LlamaStackClient) -> None:
         response = client.vector_dbs.with_raw_response.unregister(
-            vector_db_id="vector_db_id",
+            "vector_db_id",
         )
 
         assert response.is_closed is True
@@ -178,7 +150,7 @@ class TestVectorDBs:
     @parametrize
     def test_streaming_response_unregister(self, client: LlamaStackClient) -> None:
         with client.vector_dbs.with_streaming_response.unregister(
-            vector_db_id="vector_db_id",
+            "vector_db_id",
         ) as response:
             assert not response.is_closed
             assert response.http_request.headers.get("X-Stainless-Lang") == "python"
@@ -192,7 +164,7 @@ class TestVectorDBs:
     def test_path_params_unregister(self, client: LlamaStackClient) -> None:
         with pytest.raises(ValueError, match=r"Expected a non-empty value for `vector_db_id` but received ''"):
             client.vector_dbs.with_raw_response.unregister(
-                vector_db_id="",
+                "",
             )
 
 
@@ -202,23 +174,14 @@ class TestAsyncVectorDBs:
     @parametrize
     async def test_method_retrieve(self, async_client: AsyncLlamaStackClient) -> None:
         vector_db = await async_client.vector_dbs.retrieve(
-            vector_db_id="vector_db_id",
-        )
-        assert_matches_type(Optional[VectorDBRetrieveResponse], vector_db, path=["response"])
-
-    @parametrize
-    async def test_method_retrieve_with_all_params(self, async_client: AsyncLlamaStackClient) -> None:
-        vector_db = await async_client.vector_dbs.retrieve(
-            vector_db_id="vector_db_id",
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
+            "vector_db_id",
         )
         assert_matches_type(Optional[VectorDBRetrieveResponse], vector_db, path=["response"])
 
     @parametrize
     async def test_raw_response_retrieve(self, async_client: AsyncLlamaStackClient) -> None:
         response = await async_client.vector_dbs.with_raw_response.retrieve(
-            vector_db_id="vector_db_id",
+            "vector_db_id",
         )
 
         assert response.is_closed is True
@@ -229,7 +192,7 @@ class TestAsyncVectorDBs:
     @parametrize
     async def test_streaming_response_retrieve(self, async_client: AsyncLlamaStackClient) -> None:
         async with async_client.vector_dbs.with_streaming_response.retrieve(
-            vector_db_id="vector_db_id",
+            "vector_db_id",
         ) as response:
             assert not response.is_closed
             assert response.http_request.headers.get("X-Stainless-Lang") == "python"
@@ -243,20 +206,12 @@ class TestAsyncVectorDBs:
     async def test_path_params_retrieve(self, async_client: AsyncLlamaStackClient) -> None:
         with pytest.raises(ValueError, match=r"Expected a non-empty value for `vector_db_id` but received ''"):
             await async_client.vector_dbs.with_raw_response.retrieve(
-                vector_db_id="",
+                "",
             )
 
     @parametrize
     async def test_method_list(self, async_client: AsyncLlamaStackClient) -> None:
         vector_db = await async_client.vector_dbs.list()
-        assert_matches_type(VectorDBListResponse, vector_db, path=["response"])
-
-    @parametrize
-    async def test_method_list_with_all_params(self, async_client: AsyncLlamaStackClient) -> None:
-        vector_db = await async_client.vector_dbs.list(
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
-        )
         assert_matches_type(VectorDBListResponse, vector_db, path=["response"])
 
     @parametrize
@@ -295,8 +250,6 @@ class TestAsyncVectorDBs:
             embedding_dimension=0,
             provider_id="provider_id",
             provider_vector_db_id="provider_vector_db_id",
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
         )
         assert_matches_type(VectorDBRegisterResponse, vector_db, path=["response"])
 
@@ -329,23 +282,14 @@ class TestAsyncVectorDBs:
     @parametrize
     async def test_method_unregister(self, async_client: AsyncLlamaStackClient) -> None:
         vector_db = await async_client.vector_dbs.unregister(
-            vector_db_id="vector_db_id",
-        )
-        assert vector_db is None
-
-    @parametrize
-    async def test_method_unregister_with_all_params(self, async_client: AsyncLlamaStackClient) -> None:
-        vector_db = await async_client.vector_dbs.unregister(
-            vector_db_id="vector_db_id",
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
+            "vector_db_id",
         )
         assert vector_db is None
 
     @parametrize
     async def test_raw_response_unregister(self, async_client: AsyncLlamaStackClient) -> None:
         response = await async_client.vector_dbs.with_raw_response.unregister(
-            vector_db_id="vector_db_id",
+            "vector_db_id",
         )
 
         assert response.is_closed is True
@@ -356,7 +300,7 @@ class TestAsyncVectorDBs:
     @parametrize
     async def test_streaming_response_unregister(self, async_client: AsyncLlamaStackClient) -> None:
         async with async_client.vector_dbs.with_streaming_response.unregister(
-            vector_db_id="vector_db_id",
+            "vector_db_id",
         ) as response:
             assert not response.is_closed
             assert response.http_request.headers.get("X-Stainless-Lang") == "python"
@@ -370,5 +314,5 @@ class TestAsyncVectorDBs:
     async def test_path_params_unregister(self, async_client: AsyncLlamaStackClient) -> None:
         with pytest.raises(ValueError, match=r"Expected a non-empty value for `vector_db_id` but received ''"):
             await async_client.vector_dbs.with_raw_response.unregister(
-                vector_db_id="",
+                "",
             )

--- a/tests/api_resources/test_vector_io.py
+++ b/tests/api_resources/test_vector_io.py
@@ -41,8 +41,6 @@ class TestVectorIo:
             ],
             vector_db_id="vector_db_id",
             ttl_seconds=0,
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
         )
         assert vector_io is None
 
@@ -96,8 +94,6 @@ class TestVectorIo:
             query="string",
             vector_db_id="vector_db_id",
             params={"foo": True},
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
         )
         assert_matches_type(QueryChunksResponse, vector_io, path=["response"])
 
@@ -155,8 +151,6 @@ class TestAsyncVectorIo:
             ],
             vector_db_id="vector_db_id",
             ttl_seconds=0,
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
         )
         assert vector_io is None
 
@@ -210,8 +204,6 @@ class TestAsyncVectorIo:
             query="string",
             vector_db_id="vector_db_id",
             params={"foo": True},
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
         )
         assert_matches_type(QueryChunksResponse, vector_io, path=["response"])
 

--- a/tests/api_resources/tool_runtime/test_rag_tool.py
+++ b/tests/api_resources/tool_runtime/test_rag_tool.py
@@ -33,24 +33,6 @@ class TestRagTool:
         assert rag_tool is None
 
     @parametrize
-    def test_method_insert_with_all_params(self, client: LlamaStackClient) -> None:
-        rag_tool = client.tool_runtime.rag_tool.insert(
-            chunk_size_in_tokens=0,
-            documents=[
-                {
-                    "content": "string",
-                    "document_id": "document_id",
-                    "metadata": {"foo": True},
-                    "mime_type": "mime_type",
-                }
-            ],
-            vector_db_id="vector_db_id",
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
-        )
-        assert rag_tool is None
-
-    @parametrize
     def test_raw_response_insert(self, client: LlamaStackClient) -> None:
         response = client.tool_runtime.rag_tool.with_raw_response.insert(
             chunk_size_in_tokens=0,
@@ -111,8 +93,6 @@ class TestRagTool:
                     "type": "default",
                 },
             },
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
         )
         assert_matches_type(QueryResult, rag_tool, path=["response"])
 
@@ -158,24 +138,6 @@ class TestAsyncRagTool:
                 }
             ],
             vector_db_id="vector_db_id",
-        )
-        assert rag_tool is None
-
-    @parametrize
-    async def test_method_insert_with_all_params(self, async_client: AsyncLlamaStackClient) -> None:
-        rag_tool = await async_client.tool_runtime.rag_tool.insert(
-            chunk_size_in_tokens=0,
-            documents=[
-                {
-                    "content": "string",
-                    "document_id": "document_id",
-                    "metadata": {"foo": True},
-                    "mime_type": "mime_type",
-                }
-            ],
-            vector_db_id="vector_db_id",
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
         )
         assert rag_tool is None
 
@@ -240,8 +202,6 @@ class TestAsyncRagTool:
                     "type": "default",
                 },
             },
-            x_llama_stack_client_version="X-LlamaStack-Client-Version",
-            x_llama_stack_provider_data="X-LlamaStack-Provider-Data",
         )
         assert_matches_type(QueryResult, rag_tool, path=["response"])
 


### PR DESCRIPTION
Update for client SDK, new docs and simpler OpenAPI spec.

- client-version and provider-data headers are _not_ added to the spec anymore. we don't want these parameters to pollute every single API method doc. 
- we can just work by initializing the client with these headers once
- enums are flattened in the OpenAPI spec (no separate schema type registered for them)
