### PR TITLE
[RFC] Client Agent SDK OutputParser

### DIFF
--- a/src/llama_stack_client/lib/agents/agent.py
+++ b/src/llama_stack_client/lib/agents/agent.py
@@ -25,7 +25,6 @@ class Agent:
         client: LlamaStackClient,
         agent_config: AgentConfig,
         client_tools: Tuple[ClientTool] = (),
-        memory_bank_id: Optional[str] = None,
         output_parser: Optional[OutputParser] = None,
     ):
         self.client = client
@@ -33,9 +32,7 @@ class Agent:
         self.agent_id = self._create_agent(agent_config)
         self.client_tools = {t.get_name(): t for t in client_tools}
         self.sessions = []
-        self.memory_bank_id = memory_bank_id
         self.output_parser = output_parser
-
         self.builtin_tools = {}
         for tg in agent_config["toolgroups"]:
             for tool in self.client.tools.list(toolgroup_id=tg):

--- a/src/llama_stack_client/lib/agents/output_parser.py
+++ b/src/llama_stack_client/lib/agents/output_parser.py
@@ -1,0 +1,22 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+from abc import abstractmethod
+
+from llama_stack_client.types.agents.turn import CompletionMessage
+
+
+class OutputParser:
+    """
+    Developers can define their own response output parser to parse the response from the agent turn.
+
+    Developers need to implement the `parse` method to parse the response from the agent turn.
+    The return value should be a CompletionMessage object with parsed result popoulated in content and tool_calls.
+    """
+
+    @abstractmethod
+    def parse(self, output_message: CompletionMessage) -> CompletionMessage:
+        raise NotImplementedError

--- a/src/llama_stack_client/lib/agents/output_parser.py
+++ b/src/llama_stack_client/lib/agents/output_parser.py
@@ -11,10 +11,36 @@ from llama_stack_client.types.agents.turn import CompletionMessage
 
 class OutputParser:
     """
-    Developers can define their own response output parser to parse the response from the agent turn.
+    Abstract base class for parsing agent responses. Implement this class to customize how
+    agent outputs are processed and transformed.
 
-    Developers need to implement the `parse` method to parse the response from the agent turn.
-    The return value should be a CompletionMessage object with parsed result popoulated in content and tool_calls.
+    This class allows developers to define custom parsing logic for agent responses,
+    which can be useful for:
+    - Extracting specific information from the response
+    - Formatting or structuring the output in a specific way
+    - Validating or sanitizing the agent's response
+
+    To use this class:
+    1. Create a subclass of OutputParser
+    2. Implement the `parse` method
+    3. Pass your parser instance to the Agent's constructor
+
+    Example:
+        class MyCustomParser(OutputParser):
+            def parse(self, output_message: CompletionMessage) -> CompletionMessage:
+                # Add your custom parsing logic here
+                return processed_message
+
+    Methods:
+        parse(output_message: CompletionMessage) -> CompletionMessage:
+            Abstract method that must be implemented by subclasses to process
+            the agent's response.
+
+            Args:
+                output_message (CompletionMessage): The response message from agent turn
+
+            Returns:
+                CompletionMessage: The processed/transformed response message
     """
 
     @abstractmethod

--- a/src/llama_stack_client/lib/agents/react/__init__.py
+++ b/src/llama_stack_client/lib/agents/react/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.

--- a/src/llama_stack_client/lib/agents/react/agent.py
+++ b/src/llama_stack_client/lib/agents/react/agent.py
@@ -1,0 +1,20 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+
+# class ReActAgent(Agent):
+#     """ReAct agent.
+
+#     Simple wrapper around Agent + ReActOutputParser + ReActPromptTemplate to create a ReAct agent.
+#     """
+#     def __init__(self, model: str, output_parser: OutputParser, prompt_template: PromptTemplate):
+#         super().__init__(model, output_parser, prompt_template)
+#         self.output_parser = ReActOutputParser()
+#         self.prompt_template = ReActPromptTemplate()
+
+#     @classmethod
+#     def create(cls, **kwargs) -> "ReActAgent":
+#         return cls(**kwargs)

--- a/src/llama_stack_client/lib/agents/react/agent.py
+++ b/src/llama_stack_client/lib/agents/react/agent.py
@@ -3,18 +3,95 @@
 #
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
+from pydantic import BaseModel
+from typing import Dict, Any
+from ..agent import Agent
+from .output_parser import ReActOutputParser
+from ..output_parser import OutputParser
+from .prompts import DEFAULT_REACT_AGENT_SYSTEM_PROMPT_TEMPLATE
+
+from typing import Tuple, Optional
+from llama_stack_client import LlamaStackClient
+from ..client_tool import ClientTool
+from llama_stack_client.types.agent_create_params import AgentConfig
 
 
-# class ReActAgent(Agent):
-#     """ReAct agent.
+class Action(BaseModel):
+    tool_name: str
+    tool_params: Dict[str, Any]
 
-#     Simple wrapper around Agent + ReActOutputParser + ReActPromptTemplate to create a ReAct agent.
-#     """
-#     def __init__(self, model: str, output_parser: OutputParser, prompt_template: PromptTemplate):
-#         super().__init__(model, output_parser, prompt_template)
-#         self.output_parser = ReActOutputParser()
-#         self.prompt_template = ReActPromptTemplate()
 
-#     @classmethod
-#     def create(cls, **kwargs) -> "ReActAgent":
-#         return cls(**kwargs)
+class ReActOutput(BaseModel):
+    thought: str
+    action: Optional[Action] = None
+    answer: Optional[str] = None
+
+
+class ReActAgent(Agent):
+    """ReAct agent.
+
+    Simple wrapper around Agent to add prepare prompts for creating a ReAct agent from a list of tools.
+    """
+
+    def __init__(
+        self,
+        client: LlamaStackClient,
+        model: str,
+        builtin_toolgroups: Tuple[str] = (),
+        client_tools: Tuple[ClientTool] = (),
+        output_parser: OutputParser = ReActOutputParser(),
+        json_response_format: bool = False,
+        custom_agent_config: Optional[AgentConfig] = None,
+    ):
+        def get_tool_definition(tool):
+            return {
+                "name": tool.identifier,
+                "description": tool.description,
+                "parameters": tool.parameters,
+            }
+
+        if custom_agent_config is None:
+            tool_names = ""
+            tool_descriptions = ""
+            for x in builtin_toolgroups:
+                tool_names += ", ".join([tool.identifier for tool in client.tools.list(toolgroup_id=x)])
+                tool_descriptions += "\n".join(
+                    [f"- {tool.identifier}: {get_tool_definition(tool)}" for tool in client.tools.list(toolgroup_id=x)]
+                )
+
+            tool_names += ", "
+            tool_descriptions += "\n"
+            tool_names += ", ".join([tool.get_name() for tool in client_tools])
+            tool_descriptions += "\n".join(
+                [f"- {tool.get_name()}: {tool.get_tool_definition()}" for tool in client_tools]
+            )
+
+            instruction = DEFAULT_REACT_AGENT_SYSTEM_PROMPT_TEMPLATE.replace("<<tool_names>>", tool_names).replace(
+                "<<tool_descriptions>>", tool_descriptions
+            )
+
+            # user default toolgroups
+            agent_config = AgentConfig(
+                model=model,
+                instructions=instruction,
+                toolgroups=builtin_toolgroups,
+                client_tools=[client_tool.get_tool_definition() for client_tool in client_tools],
+                tool_choice="auto",
+                tool_prompt_format="json",
+                input_shields=[],
+                output_shields=[],
+                enable_session_persistence=False,
+            )
+
+        if json_response_format:
+            agent_config.response_format = {
+                "type": "json_schema",
+                "json_schema": ReActOutput.model_json_schema(),
+            }
+
+        super().__init__(
+            client=client,
+            agent_config=agent_config,
+            client_tools=client_tools,
+            output_parser=output_parser,
+        )

--- a/src/llama_stack_client/lib/agents/react/agent.py
+++ b/src/llama_stack_client/lib/agents/react/agent.py
@@ -77,6 +77,7 @@ class ReActAgent(Agent):
                 toolgroups=builtin_toolgroups,
                 client_tools=[client_tool.get_tool_definition() for client_tool in client_tools],
                 tool_choice="auto",
+                # TODO: refactor this to use SystemMessageBehaviour.replace
                 tool_prompt_format="json",
                 input_shields=[],
                 output_shields=[],

--- a/src/llama_stack_client/lib/agents/react/output_parser.py
+++ b/src/llama_stack_client/lib/agents/react/output_parser.py
@@ -11,15 +11,12 @@ from llama_stack_client.types.shared.tool_call import ToolCall
 import json
 import uuid
 
-from rich.pretty import pprint
-
 
 class ReActOutputParser(OutputParser):
     def parse(self, output_message: CompletionMessage) -> CompletionMessage:
         response_text = str(output_message.content)
         try:
             response_json = json.loads(response_text)
-            pprint(response_json)
         except json.JSONDecodeError as e:
             print(f"Error parsing action: {e}")
             return output_message

--- a/src/llama_stack_client/lib/agents/react/output_parser.py
+++ b/src/llama_stack_client/lib/agents/react/output_parser.py
@@ -11,12 +11,15 @@ from llama_stack_client.types.shared.tool_call import ToolCall
 import json
 import uuid
 
+from rich.pretty import pprint
+
 
 class ReActOutputParser(OutputParser):
     def parse(self, output_message: CompletionMessage) -> CompletionMessage:
         response_text = str(output_message.content)
         try:
             response_json = json.loads(response_text)
+            pprint(response_json)
         except json.JSONDecodeError as e:
             print(f"Error parsing action: {e}")
             return output_message

--- a/src/llama_stack_client/lib/agents/react/output_parser.py
+++ b/src/llama_stack_client/lib/agents/react/output_parser.py
@@ -4,12 +4,25 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
+from pydantic import BaseModel
+from typing import Dict, Any, Optional
 from ..output_parser import OutputParser
 from llama_stack_client.types.shared.completion_message import CompletionMessage
 from llama_stack_client.types.shared.tool_call import ToolCall
 
 import json
 import uuid
+
+
+class Action(BaseModel):
+    tool_name: str
+    tool_params: Dict[str, Any]
+
+
+class ReActOutput(BaseModel):
+    thought: str
+    action: Optional[Action] = None
+    answer: Optional[str] = None
 
 
 class ReActOutputParser(OutputParser):

--- a/src/llama_stack_client/lib/agents/react/output_parser.py
+++ b/src/llama_stack_client/lib/agents/react/output_parser.py
@@ -1,0 +1,34 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+from ..output_parser import OutputParser
+from llama_stack_client.types.shared.completion_message import CompletionMessage
+from llama_stack_client.types.shared.tool_call import ToolCall
+
+import json
+import uuid
+
+
+class ReActOutputParser(OutputParser):
+    def parse(self, output_message: CompletionMessage) -> CompletionMessage:
+        response_text = str(output_message.content)
+        try:
+            response_json = json.loads(response_text)
+        except json.JSONDecodeError as e:
+            print(f"Error parsing action: {e}")
+            return output_message
+
+        if response_json.get("answer", None):
+            return output_message
+
+        if response_json.get("action", None):
+            tool_name = response_json["action"].get("tool_name", None)
+            tool_params = response_json["action"].get("tool_params", None)
+            if tool_name and tool_params:
+                call_id = str(uuid.uuid4())
+                output_message.tool_calls = [ToolCall(call_id=call_id, tool_name=tool_name, arguments=tool_params)]
+
+        return output_message

--- a/src/llama_stack_client/lib/agents/react/prompts.py
+++ b/src/llama_stack_client/lib/agents/react/prompts.py
@@ -149,11 +149,3 @@ Here are the rules you should always follow to solve your task:
 
 Now Begin! If you solve the task correctly, you will receive a reward of $1,000,000.
 """
-
-from pydantic import BaseModel
-
-
-class PromptTemplate(BaseModel):
-    system_prompt_template: str = DEFAULT_REACT_AGENT_SYSTEM_PROMPT_TEMPLATE
-    tool_names: str
-    tool_descriptions: str

--- a/src/llama_stack_client/lib/agents/react/prompts.py
+++ b/src/llama_stack_client/lib/agents/react/prompts.py
@@ -1,0 +1,152 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+DEFAULT_REACT_AGENT_SYSTEM_PROMPT_TEMPLATE = """
+You are an expert assistant who can solve any task using tool calls. You will be given a task to solve as best you can.
+To do so, you have been given access to the following tools: <<tool_names>>
+
+You must always respond in the following JSON format:
+{
+    "thought": $THOUGHT_PROCESS,
+    "action": {
+        "tool_name": $TOOL_NAME,
+        "tool_params": $TOOL_PARAMS
+    },
+    "answer": $ANSWER
+}
+
+Specifically, this json should have a `thought` key, a `action` key and an `answer` key.
+
+The `action` key should specify the $TOOL_NAME the name of the tool to use and the `tool_params` key should specify the parameters key as input to the tool.
+
+Make sure to have the $TOOL_PARAMS as a dictionary in the right format for the tool you are using, and do not put variable names as input if you can find the right values.
+
+You should always think about one action to take, and have the `thought` key contain your thought process about this action.
+If the tool responds, the tool will return an observation containing result of the action. 
+... (this Thought/Action/Observation can repeat N times, you should take several steps when needed. The action key must only use a SINGLE tool at a time.)
+
+You can use the result of the previous action as input for the next action.
+The observation will always be a string: it can represent a file, like "image_1.jpg".
+Then you can use it as input for the next action. You can do it for instance as follows:
+
+Observation: "image_1.jpg"
+{
+    "thought": "I need to transform the image that I received in the previous observation to make it green.",
+    "action": {
+        "tool_name": "image_transformer",
+        "tool_params": {"image": "image_1.jpg"}
+    },
+    "answer": null
+}
+
+
+To provide the final answer to the task, use the `answer` key. It is the only way to complete the task, else you will be stuck on a loop. So your final output should look like this:
+Observation: "your observation"
+
+{
+    "thought": "you thought process",
+    "action": null,
+    "answer": "insert your final answer here"
+}
+
+Here are a few examples using notional tools:
+---
+Task: "Generate an image of the oldest person in this document."
+
+{
+    "thought": "I will proceed step by step and use the following tools: `document_qa` to find the oldest person in the document, then `image_generator` to generate an image according to the answer.",
+    "action": {
+        "tool_name": "document_qa",
+        "tool_params": {"document": "document.pdf", "question": "Who is the oldest person mentioned?"}
+    },
+    "answer": null
+}
+Observation: "The oldest person in the document is John Doe, a 55 year old lumberjack living in Newfoundland."
+
+{
+    "thought": "I will now generate an image showcasing the oldest person.",
+    "action": {
+        "tool_name": "image_generator",
+        "tool_params": {"prompt": "A portrait of John Doe, a 55-year-old man living in Canada."}
+    },
+    "answer": null
+}
+Observation: "image.png"
+
+{
+    "thought": "I will now return the generated image.",
+    "action": null,
+    "answer": "image.png"
+}
+
+---
+Task: "What is the result of the following operation: 5 + 3 + 1294.678?"
+
+{
+    "thought": "I will use python code evaluator to compute the result of the operation and then return the final answer using the `final_answer` tool",
+    "action": {
+        "tool_name": "python_interpreter",
+        "tool_params": {"code": "5 + 3 + 1294.678"}
+    },
+    "answer": null
+}
+Observation: 1302.678
+
+{
+    "thought": "Now that I know the result, I will now return it.",
+    "action": null,
+    "answer": 1302.678
+}
+
+---
+Task: "Which city has the highest population , Guangzhou or Shanghai?"
+
+{
+    "thought": "I need to get the populations for both cities and compare them: I will use the tool `search` to get the population of both cities.",
+    "action": {
+        "tool_name": "search",
+        "tool_params": {"query": "Population Guangzhou"}
+    },
+    "answer": null
+}
+Observation: ['Guangzhou has a population of 15 million inhabitants as of 2021.']
+
+{
+    "thought": "Now let's get the population of Shanghai using the tool 'search'.",
+    "action": {
+        "tool_name": "search",
+        "tool_params": {"query": "Population Shanghai"}
+    },
+    "answer": null
+}
+Observation: "26 million (2019)"
+
+{
+    "thought": "Now I know that Shanghai has a larger population. Let's return the result.",
+    "action": null,
+    "answer": "Shanghai"
+}
+
+Above example were using notional tools that might not exist for you. You only have access to these tools:
+<<tool_descriptions>>
+
+Here are the rules you should always follow to solve your task:
+1. ALWAYS answer in the JSON format with keys "observation", "thought", "action", "answer", else you will fail.
+2. Always use the right arguments for the tools. Never use variable names in the 'tool_params' field, use the value instead.
+3. Call a tool only when needed: do not call the search agent if you do not need information, try to solve the task yourself.
+4. Never re-do a tool call that you previously did with the exact same parameters.
+5. Observations will be provided to you, no need to generate them
+
+Now Begin! If you solve the task correctly, you will receive a reward of $1,000,000.
+"""
+
+from pydantic import BaseModel
+
+
+class PromptTemplate(BaseModel):
+    system_prompt_template: str = DEFAULT_REACT_AGENT_SYSTEM_PROMPT_TEMPLATE
+    tool_names: str
+    tool_descriptions: str

--- a/src/llama_stack_client/lib/agents/react/prompts.py
+++ b/src/llama_stack_client/lib/agents/react/prompts.py
@@ -29,7 +29,7 @@ If the tool responds, the tool will return an observation containing result of t
 ... (this Thought/Action/Observation can repeat N times, you should take several steps when needed. The action key must only use a SINGLE tool at a time.)
 
 You can use the result of the previous action as input for the next action.
-The observation will always be a string: it can represent a file, like "image_1.jpg".
+The observation will always be the response from calling the tool: it can represent a file, like "image_1.jpg". You do not need to generate them, it will be provided to you. 
 Then you can use it as input for the next action. You can do it for instance as follows:
 
 Observation: "image_1.jpg"
@@ -56,6 +56,7 @@ Here are a few examples using notional tools:
 ---
 Task: "Generate an image of the oldest person in this document."
 
+Your Response:
 {
     "thought": "I will proceed step by step and use the following tools: `document_qa` to find the oldest person in the document, then `image_generator` to generate an image according to the answer.",
     "action": {
@@ -64,8 +65,10 @@ Task: "Generate an image of the oldest person in this document."
     },
     "answer": null
 }
-Observation: "The oldest person in the document is John Doe, a 55 year old lumberjack living in Newfoundland."
 
+Your Observation: "The oldest person in the document is John Doe, a 55 year old lumberjack living in Newfoundland."
+
+Your Response:
 {
     "thought": "I will now generate an image showcasing the oldest person.",
     "action": {
@@ -74,7 +77,7 @@ Observation: "The oldest person in the document is John Doe, a 55 year old lumbe
     },
     "answer": null
 }
-Observation: "image.png"
+Your Observation: "image.png"
 
 {
     "thought": "I will now return the generated image.",
@@ -85,6 +88,7 @@ Observation: "image.png"
 ---
 Task: "What is the result of the following operation: 5 + 3 + 1294.678?"
 
+Your Response:
 {
     "thought": "I will use python code evaluator to compute the result of the operation and then return the final answer using the `final_answer` tool",
     "action": {
@@ -93,7 +97,7 @@ Task: "What is the result of the following operation: 5 + 3 + 1294.678?"
     },
     "answer": null
 }
-Observation: 1302.678
+Your Observation: 1302.678
 
 {
     "thought": "Now that I know the result, I will now return it.",
@@ -104,6 +108,7 @@ Observation: 1302.678
 ---
 Task: "Which city has the highest population , Guangzhou or Shanghai?"
 
+Your Response:
 {
     "thought": "I need to get the populations for both cities and compare them: I will use the tool `search` to get the population of both cities.",
     "action": {
@@ -112,8 +117,9 @@ Task: "Which city has the highest population , Guangzhou or Shanghai?"
     },
     "answer": null
 }
-Observation: ['Guangzhou has a population of 15 million inhabitants as of 2021.']
+Your Observation: ['Guangzhou has a population of 15 million inhabitants as of 2021.']
 
+Your Response:
 {
     "thought": "Now let's get the population of Shanghai using the tool 'search'.",
     "action": {
@@ -122,8 +128,9 @@ Observation: ['Guangzhou has a population of 15 million inhabitants as of 2021.'
     },
     "answer": null
 }
-Observation: "26 million (2019)"
+Your Observation: "26 million (2019)"
 
+Your Response:
 {
     "thought": "Now I know that Shanghai has a larger population. Let's return the result.",
     "action": null,
@@ -134,7 +141,7 @@ Above example were using notional tools that might not exist for you. You only h
 <<tool_descriptions>>
 
 Here are the rules you should always follow to solve your task:
-1. ALWAYS answer in the JSON format with keys "observation", "thought", "action", "answer", else you will fail.
+1. ALWAYS answer in the JSON format with keys "thought", "action", "answer", else you will fail. 
 2. Always use the right arguments for the tools. Never use variable names in the 'tool_params' field, use the value instead.
 3. Call a tool only when needed: do not call the search agent if you do not need information, try to solve the task yourself.
 4. Never re-do a tool call that you previously did with the exact same parameters.


### PR DESCRIPTION
# What does this PR do?

- See https://github.com/meta-llama/llama-stack/discussions/975

**Changes**
✅  Bugfix ToolResponseMessage role
✅  Add ReACT default prompt + default output parser
✅  Add ReACTAgent wrapper
🚧  Remove ClientTool and simplify it as a decorator (separate PR, including llama-stack-apps)
✅  Make agent able to return structured outputs
   - Note that some remote provider do not support response_format structured outputs, add it as an optional flag when calling `ReActAgent` wrapper. 

## Test Plan

see test in https://github.com/meta-llama/llama-stack-apps/pull/166

## Sources

Please link relevant resources if necessary.


## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Ran pre-commit to handle lint / formatting issues.
- [ ] Read the [contributor guideline](https://github.com/meta-llama/llama-stack/blob/main/CONTRIBUTING.md),
      Pull Request section?
- [ ] Updated relevant documentation.
- [ ] Wrote necessary unit or integration tests.
