### PR TITLE
Adding util to help developers add message attachment

### DIFF
--- a/src/llama_stack_client/lib/inference/utils.py
+++ b/src/llama_stack_client/lib/inference/utils.py
@@ -1,0 +1,21 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the terms described in the LICENSE file in
+# the root directory of this source tree.
+
+import pathlib
+import base64
+
+
+class MessageAttachment:
+    # https://developer.mozilla.org/en-US/docs/Glossary/Base64
+    @classmethod
+    def base64(cls, file_path: str) -> str:
+        path = pathlib.Path(file_path)
+        return base64.b64encode(path.read_bytes()).decode("utf-8")
+
+    # https://developer.mozilla.org/en-US/docs/Web/URI/Schemes/data
+    @classmethod
+    def data_url(cls, media_type: str, file_path: str) -> str:
+        return f"data:{media_type};base64,{cls.base64(file_path)}"


### PR DESCRIPTION

Summary:
Adding `MessageAttachment.base64(path)` so that sending attachment will look like this:

```
from llama_stack_client.lib.inference.utils import MessageAttachment

response = client.inference.chat_completion(
    model_id="meta-llama/llama3.2-11b-vision-instruct",
    messages=[
        {
            "role": "user",
            "content": {
                "type": "image",
                "image": {
                    "data": MessageAttachment.base64("images/tennis-game.png")
                }
            }
        },
        {
            "role": "user",
            "content": "What's in this image?",
        }
    ]
)
```

Test Plan:
```
pip install .

# start a new notebook and run

from llama_stack_client import LlamaStackClient
from llama_stack_client.lib.inference.utils import MessageAttachment

client = LlamaStackClient(
    base_url='localhost:8321'
)

response = client.inference.chat_completion(
    model_id="meta-llama/llama3.2-11b-vision-instruct",
    messages=[
        {
            "role": "user",
            "content": {
                "type": "image",
                "image": {
                    "data": MessageAttachment.base64("images/tennis-game.png")
                }
            }
        },
        {
            "role": "user",
            "content": "What's in this image?",
        }
    ]
)

print(response)
```
