### PR TITLE
[SDK] add tool decorator helper for custom client tools

### DIFF
--- a/src/llama_stack_client/lib/agents/agent.py
+++ b/src/llama_stack_client/lib/agents/agent.py
@@ -79,9 +79,8 @@ class Agent:
         # custom client tools
         if tool_call.tool_name in self.client_tools:
             tool = self.client_tools[tool_call.tool_name]
-            result_messages = tool.run([message])
-            next_message = result_messages[0]
-            return next_message
+            result_messages = tool.run(message)
+            return result_messages
 
         # builtin tools executed by tool_runtime
         if tool_call.tool_name in self.builtin_tools:

--- a/src/llama_stack_client/lib/agents/agent.py
+++ b/src/llama_stack_client/lib/agents/agent.py
@@ -79,7 +79,9 @@ class Agent:
         # custom client tools
         if tool_call.tool_name in self.client_tools:
             tool = self.client_tools[tool_call.tool_name]
-            result_messages = tool.run(message)
+            # NOTE: tool.run() expects a list of messages, we only pass in last message here
+            # but we could pass in the entire message history
+            result_messages = tool.run([message])
             return result_messages
 
         # builtin tools executed by tool_runtime

--- a/src/llama_stack_client/lib/agents/agent.py
+++ b/src/llama_stack_client/lib/agents/agent.py
@@ -81,8 +81,8 @@ class Agent:
             tool = self.client_tools[tool_call.tool_name]
             # NOTE: tool.run() expects a list of messages, we only pass in last message here
             # but we could pass in the entire message history
-            result_messages = tool.run([message])
-            return result_messages
+            result_message = tool.run([message])
+            return result_message
 
         # builtin tools executed by tool_runtime
         if tool_call.tool_name in self.builtin_tools:

--- a/src/llama_stack_client/lib/agents/client_tool.py
+++ b/src/llama_stack_client/lib/agents/client_tool.py
@@ -116,7 +116,11 @@ def tool(func: T) -> ClientTool:
             :returns: sum of x + y
             '''
             return x + y
+    
+    Note that you must use RST-style docstrings with :param, tags.
+    :returns: tags in the docstring is optional as it would not be used for the tool's description.
     """
+
 
     class WrappedTool(SingleMessageClientTool):
         __name__ = func.__name__
@@ -150,6 +154,9 @@ def tool(func: T) -> ClientTool:
                     if line.strip().startswith(f":param {name}:"):
                         param_doc = line.split(":", 2)[2].strip()
                         break
+                
+                if param_doc == "":
+                    raise ValueError(f"No parameter description found for parameter {name}")
 
                 param = sig.parameters[name]
                 is_optional_type = get_origin(type_hint) is Union and type(None) in get_args(type_hint)

--- a/src/llama_stack_client/lib/agents/client_tool.py
+++ b/src/llama_stack_client/lib/agents/client_tool.py
@@ -64,6 +64,7 @@ class ClientTool:
         self,
         message_history: List[CompletionMessage],
     ) -> ToolResponseMessage:
+        # NOTE: we could override this method to use the entire message history for advanced tools
         last_message = message_history[-1]
     
         assert len(last_message.tool_calls) == 1, "Expected single tool call"

--- a/src/llama_stack_client/lib/agents/client_tool.py
+++ b/src/llama_stack_client/lib/agents/client_tool.py
@@ -9,7 +9,7 @@ from abc import abstractmethod
 from typing import Callable, Dict, TypeVar, get_type_hints, Union, get_origin, get_args, List
 import inspect
 
-from llama_stack_client.types import CompletionMessage, ToolResponseMessage
+from llama_stack_client.types import Message, ToolResponseMessage
 from llama_stack_client.types.tool_def_param import Parameter, ToolDefParam
 
 
@@ -62,7 +62,7 @@ class ClientTool:
 
     def run(
         self,
-        message_history: List[CompletionMessage],
+        message_history: List[Message],
     ) -> ToolResponseMessage:
         # NOTE: we could override this method to use the entire message history for advanced tools
         last_message = message_history[-1]

--- a/src/llama_stack_client/lib/agents/client_tool.py
+++ b/src/llama_stack_client/lib/agents/client_tool.py
@@ -66,7 +66,7 @@ class ClientTool:
     ) -> ToolResponseMessage:
         # NOTE: we could override this method to use the entire message history for advanced tools
         last_message = message_history[-1]
-    
+
         assert len(last_message.tool_calls) == 1, "Expected single tool call"
         tool_call = last_message.tool_calls[0]
 

--- a/src/llama_stack_client/lib/agents/client_tool.py
+++ b/src/llama_stack_client/lib/agents/client_tool.py
@@ -117,7 +117,7 @@ def tool(func: T) -> ClientTool:
             '''
             return x + y
     
-    Note that you must use RST-style docstrings with :param, tags.
+    Note that you must use RST-style docstrings with :param tags for each parameter. These will be used for prompting model to use tools correctly.  
     :returns: tags in the docstring is optional as it would not be used for the tool's description.
     """
 

--- a/src/llama_stack_client/lib/agents/client_tool.py
+++ b/src/llama_stack_client/lib/agents/client_tool.py
@@ -6,7 +6,7 @@
 
 import json
 from abc import abstractmethod
-from typing import Callable, Dict, TypeVar, get_type_hints, List, Union, get_origin, get_args
+from typing import Callable, Dict, TypeVar, get_type_hints, Union, get_origin, get_args
 import inspect
 
 from llama_stack_client.types import CompletionMessage, ToolResponseMessage
@@ -61,7 +61,8 @@ class ClientTool:
         )
 
     def run(
-        self, message: CompletionMessage,
+        self,
+        message: CompletionMessage,
     ) -> ToolResponseMessage:
         assert len(message.tool_calls) == 1, "Expected single tool call"
         tool_call = message.tool_calls[0]
@@ -100,11 +101,10 @@ def client_tool(func: T) -> ClientTool:
             :returns: sum of x + y
             '''
             return x + y
-    
-    Note that you must use RST-style docstrings with :param tags for each parameter. These will be used for prompting model to use tools correctly.  
+
+    Note that you must use RST-style docstrings with :param tags for each parameter. These will be used for prompting model to use tools correctly.
     :returns: tags in the docstring is optional as it would not be used for the tool's description.
     """
-
 
     class _WrappedTool(ClientTool):
         __name__ = func.__name__
@@ -138,7 +138,7 @@ def client_tool(func: T) -> ClientTool:
                     if line.strip().startswith(f":param {name}:"):
                         param_doc = line.split(":", 2)[2].strip()
                         break
-                
+
                 if param_doc == "":
                     raise ValueError(f"No parameter description found for parameter {name}")
 

--- a/src/llama_stack_client/lib/agents/client_tool.py
+++ b/src/llama_stack_client/lib/agents/client_tool.py
@@ -6,8 +6,7 @@
 
 import json
 from abc import abstractmethod
-from functools import wraps
-from typing import Callable, Dict, Type, TypeVar, get_type_hints, List, Union, get_origin, get_args
+from typing import Callable, Dict, TypeVar, get_type_hints, List, Union, get_origin, get_args
 import inspect
 
 from llama_stack_client.types import ToolResponseMessage, UserMessage
@@ -101,7 +100,8 @@ class SingleMessageClientTool(ClientTool):
         raise NotImplementedError()
 
 
-T = TypeVar('T', bound=Callable)
+T = TypeVar("T", bound=Callable)
+
 
 def tool(func: T) -> ClientTool:
     """
@@ -110,13 +110,14 @@ def tool(func: T) -> ClientTool:
         @tool
         def add(x: int, y: int) -> int:
             '''Add 2 integer numbers
-    
+
             :param x: integer 1
             :param y: integer 2
             :returns: sum of x + y
             '''
             return x + y
     """
+
     class WrappedTool(SingleMessageClientTool):
         __name__ = func.__name__
         __doc__ = func.__doc__
@@ -129,14 +130,14 @@ def tool(func: T) -> ClientTool:
             doc = inspect.getdoc(func)
             if doc:
                 # Get everything before the first :param
-                return doc.split(':param')[0].strip()
+                return doc.split(":param")[0].strip()
             return ""
 
         def get_params_definition(self) -> Dict[str, Parameter]:
             hints = get_type_hints(func)
             # Remove return annotation if present
-            hints.pop('return', None)
-            
+            hints.pop("return", None)
+
             # Get parameter descriptions from docstring
             params = {}
             sig = inspect.signature(func)
@@ -145,11 +146,11 @@ def tool(func: T) -> ClientTool:
             for name, type_hint in hints.items():
                 # Look for :param name: in docstring
                 param_doc = ""
-                for line in doc.split('\n'):
-                    if line.strip().startswith(f':param {name}:'):
-                        param_doc = line.split(':', 2)[2].strip()
+                for line in doc.split("\n"):
+                    if line.strip().startswith(f":param {name}:"):
+                        param_doc = line.split(":", 2)[2].strip()
                         break
-                
+
                 param = sig.parameters[name]
                 is_optional_type = get_origin(type_hint) is Union and type(None) in get_args(type_hint)
                 is_required = param.default == inspect.Parameter.empty and not is_optional_type
@@ -158,10 +159,9 @@ def tool(func: T) -> ClientTool:
                     description=param_doc or f"Parameter {name}",
                     parameter_type=type_hint.__name__,
                     default=param.default,
-                    required=is_required
+                    required=is_required,
                 )
             return params
-
 
         def run_impl(self, **kwargs):
             return func(**kwargs)

--- a/src/llama_stack_client/lib/agents/client_tool.py
+++ b/src/llama_stack_client/lib/agents/client_tool.py
@@ -122,7 +122,8 @@ def client_tool(func: T) -> ClientTool:
             if doc:
                 # Get everything before the first :param
                 return doc.split(":param")[0].strip()
-            return ""
+            else:
+                raise ValueError(f"No description found for client tool {__name__}. Please provide a RST-style docstring with description and :param tags for each parameter.")
 
         def get_params_definition(self) -> Dict[str, Parameter]:
             hints = get_type_hints(func)

--- a/src/llama_stack_client/lib/agents/client_tool.py
+++ b/src/llama_stack_client/lib/agents/client_tool.py
@@ -6,7 +6,9 @@
 
 import json
 from abc import abstractmethod
-from typing import Dict, List, Union
+from functools import wraps
+from typing import Callable, Dict, Type, TypeVar, get_type_hints, List, Union, get_origin, get_args
+import inspect
 
 from llama_stack_client.types import ToolResponseMessage, UserMessage
 from llama_stack_client.types.tool_def_param import Parameter, ToolDefParam
@@ -46,7 +48,7 @@ class ClientTool:
             {
                 "name": self.get_name(),
                 "description": self.get_description(),
-                "parameters": {name: definition.__dict__ for name, definition in self.get_params_definition().items()},
+                "parameters": {name: definition for name, definition in self.get_params_definition().items()},
             }
         )
 
@@ -64,3 +66,104 @@ class ClientTool:
         self, messages: List[Union[UserMessage, ToolResponseMessage]]
     ) -> List[Union[UserMessage, ToolResponseMessage]]:
         raise NotImplementedError
+
+
+class SingleMessageClientTool(ClientTool):
+    """
+    Helper class to handle custom tools that take a single message
+    Extending this class and implementing the `run_impl` method will
+    allow for the tool be called by the model and the necessary plumbing.
+    """
+
+    def run(self, messages: List[Union[UserMessage, ToolResponseMessage]]) -> List[ToolResponseMessage]:
+        assert len(messages) == 1, "Expected single message"
+
+        message = messages[0]
+
+        tool_call = message.tool_calls[0]
+
+        try:
+            response = self.run_impl(**tool_call.arguments)
+            response_str = json.dumps(response, ensure_ascii=False)
+        except Exception as e:
+            response_str = f"Error when running tool: {e}"
+
+        message = ToolResponseMessage(
+            call_id=tool_call.call_id,
+            tool_name=tool_call.tool_name,
+            content=response_str,
+            role="tool",
+        )
+        return [message]
+
+    @abstractmethod
+    def run_impl(self, *args, **kwargs):
+        raise NotImplementedError()
+
+
+T = TypeVar('T', bound=Callable)
+
+def tool(func: T) -> ClientTool:
+    """
+    Decorator to convert a function into a ClientTool.
+    Usage:
+        @tool
+        def add(x: int, y: int) -> int:
+            '''Add 2 integer numbers
+    
+            :param x: integer 1
+            :param y: integer 2
+            :returns: sum of x + y
+            '''
+            return x + y
+    """
+    class WrappedTool(SingleMessageClientTool):
+        __name__ = func.__name__
+        __doc__ = func.__doc__
+        __module__ = func.__module__
+
+        def get_name(self) -> str:
+            return func.__name__
+
+        def get_description(self) -> str:
+            doc = inspect.getdoc(func)
+            if doc:
+                # Get everything before the first :param
+                return doc.split(':param')[0].strip()
+            return ""
+
+        def get_params_definition(self) -> Dict[str, Parameter]:
+            hints = get_type_hints(func)
+            # Remove return annotation if present
+            hints.pop('return', None)
+            
+            # Get parameter descriptions from docstring
+            params = {}
+            sig = inspect.signature(func)
+            doc = inspect.getdoc(func) or ""
+
+            for name, type_hint in hints.items():
+                # Look for :param name: in docstring
+                param_doc = ""
+                for line in doc.split('\n'):
+                    if line.strip().startswith(f':param {name}:'):
+                        param_doc = line.split(':', 2)[2].strip()
+                        break
+                
+                param = sig.parameters[name]
+                is_optional_type = get_origin(type_hint) is Union and type(None) in get_args(type_hint)
+                is_required = param.default == inspect.Parameter.empty and not is_optional_type
+                params[name] = Parameter(
+                    name=name,
+                    description=param_doc or f"Parameter {name}",
+                    parameter_type=type_hint.__name__,
+                    default=param.default,
+                    required=is_required
+                )
+            return params
+
+
+        def run_impl(self, **kwargs):
+            return func(**kwargs)
+
+    return WrappedTool()

--- a/src/llama_stack_client/lib/agents/client_tool.py
+++ b/src/llama_stack_client/lib/agents/client_tool.py
@@ -122,7 +122,7 @@ def tool(func: T) -> ClientTool:
     """
 
 
-    class WrappedTool(SingleMessageClientTool):
+    class _WrappedTool(SingleMessageClientTool):
         __name__ = func.__name__
         __doc__ = func.__doc__
         __module__ = func.__module__
@@ -173,4 +173,4 @@ def tool(func: T) -> ClientTool:
         def run_impl(self, **kwargs):
             return func(**kwargs)
 
-    return WrappedTool()
+    return _WrappedTool()

--- a/src/llama_stack_client/lib/agents/client_tool.py
+++ b/src/llama_stack_client/lib/agents/client_tool.py
@@ -123,7 +123,9 @@ def client_tool(func: T) -> ClientTool:
                 # Get everything before the first :param
                 return doc.split(":param")[0].strip()
             else:
-                raise ValueError(f"No description found for client tool {__name__}. Please provide a RST-style docstring with description and :param tags for each parameter.")
+                raise ValueError(
+                    f"No description found for client tool {__name__}. Please provide a RST-style docstring with description and :param tags for each parameter."
+                )
 
         def get_params_definition(self) -> Dict[str, Parameter]:
             hints = get_type_hints(func)

--- a/src/llama_stack_client/lib/agents/client_tool.py
+++ b/src/llama_stack_client/lib/agents/client_tool.py
@@ -6,7 +6,7 @@
 
 import json
 from abc import abstractmethod
-from typing import Callable, Dict, TypeVar, get_type_hints, Union, get_origin, get_args
+from typing import Callable, Dict, TypeVar, get_type_hints, Union, get_origin, get_args, List
 import inspect
 
 from llama_stack_client.types import CompletionMessage, ToolResponseMessage
@@ -62,10 +62,12 @@ class ClientTool:
 
     def run(
         self,
-        message: CompletionMessage,
+        message_history: List[CompletionMessage],
     ) -> ToolResponseMessage:
-        assert len(message.tool_calls) == 1, "Expected single tool call"
-        tool_call = message.tool_calls[0]
+        last_message = message_history[-1]
+    
+        assert len(last_message.tool_calls) == 1, "Expected single tool call"
+        tool_call = last_message.tool_calls[0]
 
         try:
             response = self.run_impl(**tool_call.arguments)

--- a/src/llama_stack_client/lib/agents/react/agent.py
+++ b/src/llama_stack_client/lib/agents/react/agent.py
@@ -82,8 +82,7 @@ class ReActAgent(Agent):
                 model=model,
                 instructions=instruction,
                 toolgroups=builtin_toolgroups,
-                client_tools=[],
-                # client_tools=[client_tool.get_tool_definition() for client_tool in client_tools],
+                client_tools=[client_tool.get_tool_definition() for client_tool in client_tools],
                 tool_choice="auto",
                 # TODO: refactor this to use SystemMessageBehaviour.replace
                 tool_prompt_format="json",

--- a/src/llama_stack_client/lib/agents/react/agent.py
+++ b/src/llama_stack_client/lib/agents/react/agent.py
@@ -67,7 +67,7 @@ class ReActAgent(Agent):
                 ]
             )
             return tool_defs
-    
+
         if custom_agent_config is None:
             tool_names, tool_descriptions = "", ""
             tool_defs = get_tool_defs()

--- a/src/llama_stack_client/lib/agents/react/agent.py
+++ b/src/llama_stack_client/lib/agents/react/agent.py
@@ -67,7 +67,7 @@ class ReActAgent(Agent):
                 ]
             )
             return tool_defs
-
+    
         if custom_agent_config is None:
             tool_names, tool_descriptions = "", ""
             tool_defs = get_tool_defs()
@@ -82,7 +82,8 @@ class ReActAgent(Agent):
                 model=model,
                 instructions=instruction,
                 toolgroups=builtin_toolgroups,
-                client_tools=[client_tool.get_tool_definition() for client_tool in client_tools],
+                client_tools=[],
+                # client_tools=[client_tool.get_tool_definition() for client_tool in client_tools],
                 tool_choice="auto",
                 # TODO: refactor this to use SystemMessageBehaviour.replace
                 tool_prompt_format="json",


### PR DESCRIPTION
# What does this PR do?

- Add decorator for on callables for defining client side custom tools
- Addresses: https://github.com/meta-llama/llama-stack/issues/948

## Test Plan

Usage:
```python
@client_tool
def add(x: int, y: int) -> int:
    '''Add 2 integer numbers
    
            :param x: integer 1
            :param y: integer 2
            :returns: sum of x + y
    '''
    return x + y
```

`add` will be a ClientTool that can be passed

- Working example in: https://github.com/meta-llama/llama-stack-apps/pull/166


## Sources

Please link relevant resources if necessary.


## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Ran pre-commit to handle lint / formatting issues.
- [ ] Read the [contributor guideline](https://github.com/meta-llama/llama-stack/blob/main/CONTRIBUTING.md),
      Pull Request section?
- [ ] Updated relevant documentation.
- [ ] Wrote necessary unit or integration tests.
