### PR TITLE
fix: llama-stack-client providers list

### DIFF
--- a/src/llama_stack_client/lib/cli/providers/list.py
+++ b/src/llama_stack_client/lib/cli/providers/list.py
@@ -19,8 +19,7 @@ def list_providers(ctx):
     for header in headers:
         table.add_column(header)
 
-    for k, v in providers_response.items():
-        for provider_info in v:
-            table.add_row(k, provider_info.provider_id, provider_info.provider_type)
+    for response in providers_response:
+        table.add_row(response.api, response.provider_id, response.provider_type)
 
     console.print(table)


### PR DESCRIPTION
# What does this PR do?

currently this command always errors out due to using .items() on a list.

```
╭─────────────────────────────────────────────────╮
│ Failed to list providers                        │
│                                                 │
│ Error Type: AttributeError                      │
│ Details: 'list' object has no attribute 'items' │
```
Fix the loop that looks at the list response


## Test Plan

after fixing: output on Ollama distribution is the following:

```
┏━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃ API          ┃ Provider ID           ┃ Provider Type                 ┃
┡━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
│ inference    │ ollama                │ remote::ollama                │
│ inference    │ sentence-transformers │ inline::sentence-transformers │
│ vector_io    │ faiss                 │ inline::faiss                 │
│ safety       │ llama-guard           │ inline::llama-guard           │
│ agents       │ meta-reference        │ inline::meta-reference        │
│ telemetry    │ meta-reference        │ inline::meta-reference        │
│ eval         │ meta-reference        │ inline::meta-reference        │
│ datasetio    │ huggingface           │ remote::huggingface           │
│ datasetio    │ localfs               │ inline::localfs               │
│ scoring      │ basic                 │ inline::basic                 │
│ scoring      │ llm-as-judge          │ inline::llm-as-judge          │
│ scoring      │ braintrust            │ inline::braintrust            │
│ tool_runtime │ brave-search          │ remote::brave-search          │
│ tool_runtime │ tavily-search         │ remote::tavily-search         │
│ tool_runtime │ code-interpreter      │ inline::code-interpreter      │
│ tool_runtime │ rag-runtime           │ inline::rag-runtime           │
└──────────────┴───────────────────────┴───────────────────────────────┘
```

