### PR TITLE
fix: broken .retrieve call using `identifier=`

### DIFF
--- a/src/llama_stack_client/lib/cli/models/models.py
+++ b/src/llama_stack_client/lib/cli/models/models.py
@@ -72,7 +72,7 @@ def get_model(ctx, model_id: str):
     client = ctx.obj["client"]
     console = Console()
 
-    models_get_response = client.models.retrieve(identifier=model_id)
+    models_get_response = client.models.retrieve(model_id=model_id)
 
     if not models_get_response:
         console.print(


### PR DESCRIPTION
# What does this PR do?

identifier is not a valid argument for `retrieve` but model_id is.

```
╰─ llama-stack-client models get meta-llama/Llama-3.2-3B-Instruct
╭────────────────────────────────────────────────────────────────────────────────────╮
│ Failed to get model details                                                        │
│                                                                                    │
│ Error Type: TypeError                                                              │
│ Details: ModelsResource.retrieve() got an unexpected keyword argument 'identifier' │
╰────────────────────────────────────────────────────────────────────────────────────╯
```

[//]: # (If resolving an issue, uncomment and update the line below)
[//]: # (Closes #[issue-number])

## Test Plan

the error now is: 

```
╰─ llama-stack-client models get meta-llama/Llama-3.2-3B-Instruct
╭────────────────────────────────────────────────────╮
│ Failed to get model details                        │
│                                                    │
│ Error Type: NotFoundError                          │
│ Details: Error code: 404 - {'detail': 'Not Found'} │
╰────────────────────────────────────────────────────╯
```

