### PR TITLE
refactor: update react_agent to use tool_config

### DIFF
--- a/src/llama_stack_client/lib/agents/react/agent.py
+++ b/src/llama_stack_client/lib/agents/react/agent.py
@@ -83,9 +83,11 @@ class ReActAgent(Agent):
                 instructions=instruction,
                 toolgroups=builtin_toolgroups,
                 client_tools=[client_tool.get_tool_definition() for client_tool in client_tools],
-                tool_choice="auto",
-                # TODO: refactor this to use SystemMessageBehaviour.replace
-                tool_prompt_format="json",
+                tool_config={
+                    "tool_choice": "auto",
+                    "tool_prompt_format": "json" if "3.1" in model else "python_list",
+                    "system_message_behavior": "replace",
+                },
                 input_shields=[],
                 output_shields=[],
                 enable_session_persistence=False,


### PR DESCRIPTION
# What does this PR do?
- update react agent to use tool_config + system prompt override

[//]: # (If resolving an issue, uncomment and update the line below)
[//]: # (Closes #[issue-number])

## Test Plan
```
python -m examples.agents.react_agent
```

<img width="842" alt="image" src="https://github.com/user-attachments/assets/2bc2d2e8-a820-460b-b680-27e4b0e1f88b" />


[//]: # (## Documentation)
[//]: # (- [ ] Added a Changelog entry if the change is significant)
