### PR TITLE
feat: async agent wrapper

### DIFF
--- a/src/llama_stack_client/lib/agents/agent.py
+++ b/src/llama_stack_client/lib/agents/agent.py
@@ -3,7 +3,6 @@
 #
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
-import asyncio
 from typing import AsyncIterator, Iterator, List, Optional, Tuple, Union
 
 from llama_stack_client import AsyncLlamaStackClient, LlamaStackClient
@@ -21,24 +20,104 @@ from .tool_parser import ToolParser
 DEFAULT_MAX_ITER = 10
 
 
-class Agent:
+class AgentMixin:
+    def _get_tool_calls(self, chunk: AgentTurnResponseStreamChunk) -> List[ToolCall]:
+        if chunk.event.payload.event_type not in {"turn_complete", "turn_awaiting_input"}:
+            return []
+
+        message = chunk.event.payload.turn.output_message
+        if message.stop_reason == "out_of_tokens":
+            return []
+
+        if self.tool_parser:
+            return self.tool_parser.get_tool_calls(message)
+
+        return message.tool_calls
+
+    def _get_turn_id(self, chunk: AgentTurnResponseStreamChunk) -> Optional[str]:
+        if chunk.event.payload.event_type not in ["turn_complete", "turn_awaiting_input"]:
+            return None
+
+        return chunk.event.payload.turn.turn_id
+
+
+class Agent(AgentMixin):
     def __init__(
         self,
-        client: Union[AsyncLlamaStackClient, LlamaStackClient],
+        client: LlamaStackClient,
         agent_config: AgentConfig,
         client_tools: Tuple[ClientTool] = (),
         tool_parser: Optional[ToolParser] = None,
     ):
-        self.async_agent = AsyncAgent(client, agent_config, client_tools, tool_parser)
-        asyncio.run(self.async_agent.initialize())
-        self.sessions = self.async_agent.sessions
-        self.client_tools = self.async_agent.client_tools
-        self.tool_parser = self.async_agent.tool_parser
-        self.builtin_tools = self.async_agent.builtin_tools
-        self.agent_id = self.async_agent.agent_id
+        self.client = client
+        self.agent_config = agent_config
+        self.agent_id = self._create_agent(agent_config)
+        self.client_tools = {t.get_name(): t for t in client_tools}
+        self.sessions = []
+        self.tool_parser = tool_parser
+        self.builtin_tools = {}
+        for tg in agent_config["toolgroups"]:
+            for tool in self.client.tools.list(toolgroup_id=tg):
+                self.builtin_tools[tool.identifier] = tool
+
+    def _create_agent(self, agent_config: AgentConfig) -> int:
+        agentic_system_create_response = self.client.agents.create(
+            agent_config=agent_config,
+        )
+        self.agent_id = agentic_system_create_response.agent_id
+        return self.agent_id
 
     def create_session(self, session_name: str) -> str:
-        return asyncio.run(self.async_agent.create_session(session_name))
+        agentic_system_create_session_response = self.client.agents.session.create(
+            agent_id=self.agent_id,
+            session_name=session_name,
+        )
+        self.session_id = agentic_system_create_session_response.session_id
+        self.sessions.append(self.session_id)
+        return self.session_id
+
+    def _run_tool(self, tool_calls: List[ToolCall]) -> ToolResponseMessage:
+        assert len(tool_calls) == 1, "Only one tool call is supported"
+        tool_call = tool_calls[0]
+
+        # custom client tools
+        if tool_call.tool_name in self.client_tools:
+            tool = self.client_tools[tool_call.tool_name]
+            # NOTE: tool.run() expects a list of messages, we only pass in last message here
+            # but we could pass in the entire message history
+            result_message = tool.run(
+                [
+                    CompletionMessage(
+                        role="assistant",
+                        content=tool_call.tool_name,
+                        tool_calls=[tool_call],
+                        stop_reason="end_of_turn",
+                    )
+                ]
+            )
+            return result_message
+
+        # builtin tools executed by tool_runtime
+        if tool_call.tool_name in self.builtin_tools:
+            tool_result = self.client.tool_runtime.invoke_tool(
+                tool_name=tool_call.tool_name,
+                kwargs=tool_call.arguments,
+            )
+            tool_response_message = ToolResponseMessage(
+                call_id=tool_call.call_id,
+                tool_name=tool_call.tool_name,
+                content=tool_result.content,
+                role="tool",
+            )
+            return tool_response_message
+
+        # cannot find tools
+        return ToolResponseMessage(
+            call_id=tool_call.call_id,
+            tool_name=tool_call.tool_name,
+            content=f"Unknown tool `{tool_call.tool_name}` was called.",
+            role="tool",
+        )
 
     def create_turn(
         self,
@@ -49,31 +128,73 @@ class Agent:
         stream: bool = True,
     ) -> Iterator[AgentTurnResponseStreamChunk] | Turn:
         if stream:
-            loop = asyncio.new_event_loop()
-            asyncio.set_event_loop(loop)
-
-            def sync_generator():
-                try:
-                    async_stream = loop.run_until_complete(
-                        self.async_agent.create_turn(messages, session_id, toolgroups, documents, stream)
-                    )
-                    while True:
-                        chunk = loop.run_until_complete(async_stream.__anext__())
-                        yield chunk
-                except StopAsyncIteration:
-                    pass
-                finally:
-                    loop.close()
-
-            return sync_generator()
+            return self._create_turn_streaming(messages, session_id, toolgroups, documents)
         else:
-            return asyncio.run(self.async_agent.create_turn(messages, session_id, toolgroups, documents, stream))
+            chunks = [x for x in self._create_turn_streaming(messages, session_id, toolgroups, documents)]
+            if not chunks:
+                raise Exception("Turn did not complete")
+            return chunks[-1].event.payload.turn
+
+    def _create_turn_streaming(
+        self,
+        messages: List[Union[UserMessage, ToolResponseMessage]],
+        session_id: Optional[str] = None,
+        toolgroups: Optional[List[Toolgroup]] = None,
+        documents: Optional[List[Document]] = None,
+    ) -> Iterator[AgentTurnResponseStreamChunk]:
+        n_iter = 0
+        max_iter = self.agent_config.get("max_infer_iters", DEFAULT_MAX_ITER)
+
+        # 1. create an agent turn
+        turn_response = self.client.agents.turn.create(
+            agent_id=self.agent_id,
+            # use specified session_id or last session created
+            session_id=session_id or self.session_id[-1],
+            messages=messages,
+            stream=True,
+            documents=documents,
+            toolgroups=toolgroups,
+            allow_turn_resume=True,
+        )
+
+        # 2. process turn and resume if there's a tool call
+        is_turn_complete = False
+        while not is_turn_complete:
+            is_turn_complete = True
+            for chunk in turn_response:
+                tool_calls = self._get_tool_calls(chunk)
+                if hasattr(chunk, "error"):
+                    yield chunk
+                    return
+                elif not tool_calls:
+                    yield chunk
+                else:
+                    is_turn_complete = False
+                    turn_id = self._get_turn_id(chunk)
+                    if n_iter == 0:
+                        yield chunk
+
+                    # run the tools
+                    tool_response_message = self._run_tool(tool_calls)
+                    # pass it to next iteration
+                    turn_response = self.client.agents.turn.resume(
+                        agent_id=self.agent_id,
+                        session_id=session_id or self.session_id[-1],
+                        turn_id=turn_id,
+                        tool_responses=[tool_response_message],
+                        stream=True,
+                    )
+                    n_iter += 1
+                    break
+
+            if n_iter >= max_iter:
+                raise Exception(f"Turn did not complete in {max_iter} iterations")
 
 
-class AsyncAgent:
+class AsyncAgent(AgentMixin):
     def __init__(
         self,
-        client: Union[AsyncLlamaStackClient, LlamaStackClient],
+        client: AsyncLlamaStackClient,
         agent_config: AgentConfig,
         client_tools: Tuple[ClientTool] = (),
         tool_parser: Optional[ToolParser] = None,
@@ -85,42 +206,23 @@ class AsyncAgent:
         self.tool_parser = tool_parser
         self.builtin_tools = {}
 
-        self.is_async = True
-
         if isinstance(client, LlamaStackClient):
-            self.is_async = False
+            raise ValueError("AsyncAgent must be initialized with an AsyncLlamaStackClient")
 
     async def initialize(self) -> None:
-        if self.is_async:
-            agentic_system_create_response = await self.client.agents.create(
-                agent_config=self.agent_config,
-            )
-        else:
-            agentic_system_create_response = self.client.agents.create(
-                agent_config=self.agent_config,
-            )
-
+        agentic_system_create_response = await self.client.agents.create(
+            agent_config=self.agent_config,
+        )
         self.agent_id = agentic_system_create_response.agent_id
         for tg in self.agent_config["toolgroups"]:
-            if self.is_async:
-                for tool in await self.client.tools.list(toolgroup_id=tg):
-                    self.builtin_tools[tool.identifier] = tool
-            else:
-                for tool in self.client.tools.list(toolgroup_id=tg):
-                    self.builtin_tools[tool.identifier] = tool
+            for tool in await self.client.tools.list(toolgroup_id=tg):
+                self.builtin_tools[tool.identifier] = tool
 
     async def create_session(self, session_name: str) -> str:
-        if self.is_async:
-            agentic_system_create_session_response = await self.client.agents.session.create(
-                agent_id=self.agent_id,
-                session_name=session_name,
-            )
-        else:
-            agentic_system_create_session_response = self.client.agents.session.create(
-                agent_id=self.agent_id,
-                session_name=session_name,
-            )
-
+        agentic_system_create_session_response = await self.client.agents.session.create(
+            agent_id=self.agent_id,
+            session_name=session_name,
+        )
         self.session_id = agentic_system_create_session_response.session_id
         self.sessions.append(self.session_id)
         return self.session_id
@@ -148,35 +250,24 @@ class AsyncAgent:
         # custom client tools
         if tool_call.tool_name in self.client_tools:
             tool = self.client_tools[tool_call.tool_name]
-            # NOTE: tool.run() expects a list of messages, we only pass in last message here
-            # but we could pass in the entire message history
-            messages = [
-                CompletionMessage(
-                    role="assistant",
-                    content=tool_call.tool_name,
-                    tool_calls=[tool_call],
-                    stop_reason="end_of_turn",
-                )
-            ]
-            if self.is_async:
-                result_message = await tool.async_run(messages)
-            else:
-                result_message = tool.run(messages)
-
+            result_message = await tool.async_run(
+                [
+                    CompletionMessage(
+                        role="assistant",
+                        content=tool_call.tool_name,
+                        tool_calls=[tool_call],
+                        stop_reason="end_of_turn",
+                    )
+                ]
+            )
             return result_message
 
         # builtin tools executed by tool_runtime
         if tool_call.tool_name in self.builtin_tools:
-            if self.is_async:
-                tool_result = await self.client.tool_runtime.invoke_tool(
-                    tool_name=tool_call.tool_name,
-                    kwargs=tool_call.arguments,
-                )
-            else:
-                tool_result = self.client.tool_runtime.invoke_tool(
-                    tool_name=tool_call.tool_name,
-                    kwargs=tool_call.arguments,
-                )
+            tool_result = await self.client.tool_runtime.invoke_tool(
+                tool_name=tool_call.tool_name,
+                kwargs=tool_call.arguments,
+            )
             tool_response_message = ToolResponseMessage(
                 call_id=tool_call.call_id,
                 tool_name=tool_call.tool_name,
@@ -204,107 +295,44 @@ class AsyncAgent:
         max_iter = self.agent_config.get("max_infer_iters", DEFAULT_MAX_ITER)
 
         # 1. create an agent turn
-        if self.is_async:
-            turn_response = await self.client.agents.turn.create(
-                agent_id=self.agent_id,
-                # use specified session_id or last session created
-                session_id=session_id or self.session_id[-1],
-                messages=messages,
-                stream=True,
-                documents=documents,
-                toolgroups=toolgroups,
-                allow_turn_resume=True,
-            )
-        else:
-            turn_response = self.client.agents.turn.create(
-                agent_id=self.agent_id,
-                # use specified session_id or last session created
-                session_id=session_id or self.session_id[-1],
-                messages=messages,
-                stream=True,
-                documents=documents,
-                toolgroups=toolgroups,
-                allow_turn_resume=True,
-            )
+        turn_response = await self.client.agents.turn.create(
+            agent_id=self.agent_id,
+            session_id=session_id or self.session_id[-1],
+            messages=messages,
+            stream=True,
+            documents=documents,
+        )
 
         # 2. process turn and resume if there's a tool call
         is_turn_complete = False
         while not is_turn_complete:
             is_turn_complete = True
-
-            if self.is_async:
-                async for chunk in turn_response:
-                    tool_calls = self._get_tool_calls(chunk)
-                    if hasattr(chunk, "error"):
+            async for chunk in turn_response:
+                tool_calls = self._get_tool_calls(chunk)
+                if hasattr(chunk, "error"):
+                    yield chunk
+                    return
+                elif not tool_calls:
+                    yield chunk
+                else:
+                    is_turn_complete = False
+                    turn_id = self._get_turn_id(chunk)
+                    if n_iter == 0:
                         yield chunk
-                        return
-                    elif not tool_calls:
-                        yield chunk
-                    else:
-                        is_turn_complete = False
-                        turn_id = self._get_turn_id(chunk)
-                        if n_iter == 0:
-                            yield chunk
 
-                        # run the tools
-                        tool_response_message = await self._run_tool(tool_calls)
+                    # run the tools
+                    tool_response_message = await self._run_tool(tool_calls)
+                    # pass it to next iteration
+                    turn_response = await self.client.agents.turn.resume(
+                        agent_id=self.agent_id,
+                        session_id=session_id or self.session_id[-1],
+                        turn_id=turn_id,
+                        tool_responses=[tool_response_message],
+                        stream=True,
+                    )
 
-                        # pass it to next iteration
-                        turn_response = await self.client.agents.turn.resume(
-                            agent_id=self.agent_id,
-                            session_id=session_id or self.session_id[-1],
-                            turn_id=turn_id,
-                            tool_responses=[tool_response_message],
-                            stream=True,
-                        )
-
-                        n_iter += 1
-            else:
-                for chunk in turn_response:
-                    tool_calls = self._get_tool_calls(chunk)
-                    if hasattr(chunk, "error"):
-                        yield chunk
-                        return
-                    elif not tool_calls:
-                        yield chunk
-                    else:
-                        is_turn_complete = False
-                        turn_id = self._get_turn_id(chunk)
-                        if n_iter == 0:
-                            yield chunk
-
-                        # run the tools
-                        tool_response_message = await self._run_tool(tool_calls)
-
-                        # pass it to next iteration
-                        turn_response = self.client.agents.turn.resume(
-                            agent_id=self.agent_id,
-                            session_id=session_id or self.session_id[-1],
-                            turn_id=turn_id,
-                            tool_responses=[tool_response_message],
-                            stream=True,
-                        )
-
-                        n_iter += 1
+                    n_iter += 1
+                    break
 
             if n_iter >= max_iter:
                 raise Exception(f"Turn did not complete in {max_iter} iterations")
-
-    def _get_tool_calls(self, chunk: AgentTurnResponseStreamChunk) -> List[ToolCall]:
-        if chunk.event.payload.event_type not in {"turn_complete", "turn_awaiting_input"}:
-            return []
-
-        message = chunk.event.payload.turn.output_message
-        if message.stop_reason == "out_of_tokens":
-            return []
-
-        if self.tool_parser:
-            return self.tool_parser.get_tool_calls(message)
-
-        return message.tool_calls
-
-    def _get_turn_id(self, chunk: AgentTurnResponseStreamChunk) -> Optional[str]:
-        if chunk.event.payload.event_type not in ["turn_complete", "turn_awaiting_input"]:
-            return None
-
-        return chunk.event.payload.turn.turn_id

--- a/src/llama_stack_client/lib/agents/agent.py
+++ b/src/llama_stack_client/lib/agents/agent.py
@@ -293,15 +293,17 @@ class AsyncAgent(AgentMixin):
         documents: Optional[List[Document]] = None,
     ) -> AsyncIterator[AgentTurnResponseStreamChunk]:
         n_iter = 0
-        max_iter = self.agent_config.get("max_infer_iters", DEFAULT_MAX_ITER)
 
         # 1. create an agent turn
         turn_response = await self.client.agents.turn.create(
             agent_id=self.agent_id,
+            # use specified session_id or last session created
             session_id=session_id or self.session_id[-1],
             messages=messages,
             stream=True,
             documents=documents,
+            toolgroups=toolgroups,
+            allow_turn_resume=True,
         )
 
         # 2. process turn and resume if there's a tool call
@@ -309,20 +311,27 @@ class AsyncAgent(AgentMixin):
         while not is_turn_complete:
             is_turn_complete = True
             async for chunk in turn_response:
-                tool_calls = self._get_tool_calls(chunk)
                 if hasattr(chunk, "error"):
                     yield chunk
                     return
-                elif not tool_calls:
+
+                tool_calls = self._get_tool_calls(chunk)
+                if not tool_calls:
                     yield chunk
                 else:
                     is_turn_complete = False
+                    # End of turn is reached, do not resume even if there's a tool call
+                    if chunk.event.payload.turn.output_message.stop_reason in {"end_of_turn"}:
+                        yield chunk
+                        break
+
                     turn_id = self._get_turn_id(chunk)
                     if n_iter == 0:
                         yield chunk
 
                     # run the tools
                     tool_response_message = await self._run_tool(tool_calls)
+
                     # pass it to next iteration
                     turn_response = await self.client.agents.turn.resume(
                         agent_id=self.agent_id,
@@ -331,9 +340,4 @@ class AsyncAgent(AgentMixin):
                         tool_responses=[tool_response_message],
                         stream=True,
                     )
-
                     n_iter += 1
-                    break
-
-            if n_iter >= max_iter:
-                raise Exception(f"Turn did not complete in {max_iter} iterations")

--- a/src/llama_stack_client/lib/agents/agent.py
+++ b/src/llama_stack_client/lib/agents/agent.py
@@ -3,17 +3,15 @@
 #
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
-from typing import Iterator, List, Optional, Tuple, Union
+from typing import AsyncIterator, Iterator, List, Optional, Tuple, Union
 
-from llama_stack_client import LlamaStackClient
+from llama_stack_client import AsyncLlamaStackClient, LlamaStackClient
 
 from llama_stack_client.types import ToolResponseMessage, UserMessage
 from llama_stack_client.types.agent_create_params import AgentConfig
 from llama_stack_client.types.agents.turn import CompletionMessage, Turn
 from llama_stack_client.types.agents.turn_create_params import Document, Toolgroup
-from llama_stack_client.types.agents.turn_create_response import (
-    AgentTurnResponseStreamChunk,
-)
+from llama_stack_client.types.agents.turn_create_response import AgentTurnResponseStreamChunk
 from llama_stack_client.types.shared.tool_call import ToolCall
 
 from .client_tool import ClientTool
@@ -22,7 +20,28 @@ from .tool_parser import ToolParser
 DEFAULT_MAX_ITER = 10
 
 
-class Agent:
+class AgentMixin:
+    def _get_tool_calls(self, chunk: AgentTurnResponseStreamChunk) -> List[ToolCall]:
+        if chunk.event.payload.event_type not in {"turn_complete", "turn_awaiting_input"}:
+            return []
+
+        message = chunk.event.payload.turn.output_message
+        if message.stop_reason == "out_of_tokens":
+            return []
+
+        if self.tool_parser:
+            return self.tool_parser.get_tool_calls(message)
+
+        return message.tool_calls
+
+    def _get_turn_id(self, chunk: AgentTurnResponseStreamChunk) -> Optional[str]:
+        if chunk.event.payload.event_type not in ["turn_complete", "turn_awaiting_input"]:
+            return None
+
+        return chunk.event.payload.turn.turn_id
+
+
+class Agent(AgentMixin):
     def __init__(
         self,
         client: LlamaStackClient,
@@ -56,25 +75,6 @@ class Agent:
         self.session_id = agentic_system_create_session_response.session_id
         self.sessions.append(self.session_id)
         return self.session_id
-
-    def _get_tool_calls(self, chunk: AgentTurnResponseStreamChunk) -> List[ToolCall]:
-        if chunk.event.payload.event_type not in {"turn_complete", "turn_awaiting_input"}:
-            return []
-
-        message = chunk.event.payload.turn.output_message
-        if message.stop_reason == "out_of_tokens":
-            return []
-
-        if self.tool_parser:
-            return self.tool_parser.get_tool_calls(message)
-
-        return message.tool_calls
-
-    def _get_turn_id(self, chunk: AgentTurnResponseStreamChunk) -> Optional[str]:
-        if chunk.event.payload.event_type not in ["turn_complete", "turn_awaiting_input"]:
-            return None
-
-        return chunk.event.payload.turn.turn_id
 
     def _run_tool(self, tool_calls: List[ToolCall]) -> ToolResponseMessage:
         assert len(tool_calls) == 1, "Only one tool call is supported"
@@ -189,3 +189,71 @@ class Agent:
 
             if n_iter >= max_iter:
                 raise Exception(f"Turn did not complete in {max_iter} iterations")
+
+
+class AsyncAgent:
+    def __init__(
+        self,
+        client: AsyncLlamaStackClient,
+        agent_config: AgentConfig,
+        client_tools: Tuple[ClientTool] = (),
+        tool_parser: Optional[ToolParser] = None,
+    ):
+        self.client = client
+        self.agent_config = agent_config
+        self.client_tools = {t.get_name(): t for t in client_tools}
+        self.sessions = []
+        self.tool_parser = tool_parser
+        self.builtin_tools = {}
+
+    async def initialize(self) -> None:
+        agentic_system_create_response = await self.client.agents.create(
+            agent_config=self.agent_config,
+        )
+        self.agent_id = agentic_system_create_response.agent_id
+        for tg in self.agent_config["toolgroups"]:
+            for tool in await self.client.tools.list(toolgroup_id=tg):
+                self.builtin_tools[tool.identifier] = tool
+
+    async def create_session(self, session_name: str) -> str:
+        agentic_system_create_session_response = await self.client.agents.session.create(
+            agent_id=self.agent_id,
+            session_name=session_name,
+        )
+        self.session_id = agentic_system_create_session_response.session_id
+        self.sessions.append(self.session_id)
+        return self.session_id
+
+    async def create_turn(
+        self,
+        messages: List[Union[UserMessage, ToolResponseMessage]],
+        session_id: Optional[str] = None,
+        toolgroups: Optional[List[Toolgroup]] = None,
+        documents: Optional[List[Document]] = None,
+        stream: bool = True,
+    ) -> AsyncIterator[AgentTurnResponseStreamChunk] | Turn:
+        if stream:
+            return self._create_turn_streaming(messages, session_id, toolgroups, documents)
+        else:
+            chunks = [x async for x in self._create_turn_streaming(messages, session_id, toolgroups, documents)]
+            if not chunks:
+                raise Exception("Turn did not complete")
+            return chunks[-1].event.payload.turn
+
+    async def _create_turn_streaming(
+        self,
+        messages: List[Union[UserMessage, ToolResponseMessage]],
+        session_id: Optional[str] = None,
+        toolgroups: Optional[List[Toolgroup]] = None,
+        documents: Optional[List[Document]] = None,
+    ) -> AsyncIterator[AgentTurnResponseStreamChunk]:
+        turn_response = await self.client.agents.turn.create(
+            agent_id=self.agent_id,
+            session_id=session_id or self.session_id[-1],
+            messages=messages,
+            stream=True,
+            documents=documents,
+        )
+
+        async for chunk in turn_response:
+            yield chunk

--- a/src/llama_stack_client/lib/agents/agent.py
+++ b/src/llama_stack_client/lib/agents/agent.py
@@ -316,12 +316,69 @@ class Agent:
 class AsyncAgent:
     def __init__(
         self,
-        client: AsyncLlamaStackClient,
-        agent_config: AgentConfig,
-        client_tools: Tuple[ClientTool] = (),
+        client: LlamaStackClient,
+        # begin deprecated
+        agent_config: Optional[AgentConfig] = None,
+        client_tools: Tuple[ClientTool, ...] = (),
+        # end deprecated
         tool_parser: Optional[ToolParser] = None,
+        model: Optional[str] = None,
+        instructions: Optional[str] = None,
+        tools: Optional[List[Union[Toolgroup, ClientTool]]] = None,
+        tool_config: Optional[ToolConfig] = None,
+        sampling_params: Optional[SamplingParams] = None,
+        max_infer_iters: Optional[int] = None,
+        input_shields: Optional[List[str]] = None,
+        output_shields: Optional[List[str]] = None,
+        response_format: Optional[ResponseFormat] = None,
+        enable_session_persistence: Optional[bool] = None,
     ):
+        """Construct an Agent with the given parameters.
+
+        :param client: The LlamaStackClient instance.
+        :param agent_config: The AgentConfig instance.
+            ::deprecated: use other parameters instead
+        :param client_tools: A tuple of ClientTool instances.
+            ::deprecated: use tools instead
+        :param tool_parser: Custom logic that parses tool calls from a message.
+        :param model: The model to use for the agent.
+        :param instructions: The instructions for the agent.
+        :param tools: A list of tools for the agent. Values can be one of the following:
+            - dict representing a toolgroup/tool with arguments: e.g. {"name": "builtin::rag/knowledge_search", "args": {"vector_db_ids": [123]}}
+            - a python function decorated with @client_tool
+            - str representing a tool within a toolgroup: e.g. "builtin::rag/knowledge_search"
+            - str representing a toolgroup_id: e.g. "builtin::rag", "builtin::code_interpreter", where all tools in the toolgroup will be added to the agent
+            - an instance of ClientTool: A client tool object.
+        :param tool_config: The tool configuration for the agent.
+        :param sampling_params: The sampling parameters for the agent.
+        :param max_infer_iters: The maximum number of inference iterations.
+        :param input_shields: The input shields for the agent.
+        :param output_shields: The output shields for the agent.
+        :param response_format: The response format for the agent.
+        :param enable_session_persistence: Whether to enable session persistence.
+        """
         self.client = client
+
+        if agent_config is not None:
+            logger.warning("`agent_config` is deprecated. Use inlined parameters instead.")
+        if client_tools != ():
+            logger.warning("`client_tools` is deprecated. Use `tools` instead.")
+
+        # Construct agent_config from parameters if not provided
+        if agent_config is None:
+            agent_config = AgentUtils.get_agent_config(
+                model=model,
+                instructions=instructions,
+                tools=tools,
+                tool_config=tool_config,
+                sampling_params=sampling_params,
+                max_infer_iters=max_infer_iters,
+                input_shields=input_shields,
+                output_shields=output_shields,
+                response_format=response_format,
+                enable_session_persistence=enable_session_persistence,
+            )
+
         self.agent_config = agent_config
         self.client_tools = {t.get_name(): t for t in client_tools}
         self.sessions = []
@@ -341,6 +398,7 @@ class AsyncAgent:
                 self.builtin_tools[tool.identifier] = tool
 
     async def create_session(self, session_name: str) -> str:
+        await self.initialize()
         agentic_system_create_session_response = await self.client.agents.session.create(
             agent_id=self.agent_id,
             session_name=session_name,

--- a/src/llama_stack_client/lib/agents/agent.py
+++ b/src/llama_stack_client/lib/agents/agent.py
@@ -6,7 +6,7 @@
 import logging
 from typing import AsyncIterator, Iterator, List, Optional, Tuple, Union
 
-from llama_stack_client import AsyncLlamaStackClient, LlamaStackClient
+from llama_stack_client import LlamaStackClient
 
 from llama_stack_client.types import ToolResponseMessage, ToolResponseParam, UserMessage
 from llama_stack_client.types.agent_create_params import AgentConfig

--- a/src/llama_stack_client/lib/agents/agent.py
+++ b/src/llama_stack_client/lib/agents/agent.py
@@ -386,6 +386,7 @@ class AsyncAgent:
                 response_format=response_format,
                 enable_session_persistence=enable_session_persistence,
             )
+            client_tools = AgentUtils.get_client_tools(tools)
 
         self.agent_config = agent_config
         self.client_tools = {t.get_name(): t for t in client_tools}

--- a/src/llama_stack_client/lib/agents/agent.py
+++ b/src/llama_stack_client/lib/agents/agent.py
@@ -314,7 +314,7 @@ class Agent:
                 raise Exception("Max inference iterations reached")
 
 
-class AsyncAgent(AgentMixin):
+class AsyncAgent:
     def __init__(
         self,
         client: AsyncLlamaStackClient,

--- a/src/llama_stack_client/lib/agents/agent.py
+++ b/src/llama_stack_client/lib/agents/agent.py
@@ -3,6 +3,7 @@
 #
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
+import asyncio
 from typing import AsyncIterator, Iterator, List, Optional, Tuple, Union
 
 from llama_stack_client import AsyncLlamaStackClient, LlamaStackClient
@@ -41,83 +42,24 @@ class AgentMixin:
         return chunk.event.payload.turn.turn_id
 
 
-class Agent(AgentMixin):
+class Agent:
     def __init__(
         self,
-        client: LlamaStackClient,
+        client: Union[AsyncLlamaStackClient, LlamaStackClient],
         agent_config: AgentConfig,
         client_tools: Tuple[ClientTool] = (),
         tool_parser: Optional[ToolParser] = None,
     ):
-        self.client = client
-        self.agent_config = agent_config
-        self.agent_id = self._create_agent(agent_config)
-        self.client_tools = {t.get_name(): t for t in client_tools}
-        self.sessions = []
-        self.tool_parser = tool_parser
-        self.builtin_tools = {}
-        for tg in agent_config["toolgroups"]:
-            for tool in self.client.tools.list(toolgroup_id=tg):
-                self.builtin_tools[tool.identifier] = tool
-
-    def _create_agent(self, agent_config: AgentConfig) -> int:
-        agentic_system_create_response = self.client.agents.create(
-            agent_config=agent_config,
-        )
-        self.agent_id = agentic_system_create_response.agent_id
-        return self.agent_id
+        self.async_agent = AsyncAgent(client, agent_config, client_tools, tool_parser)
+        asyncio.run(self.async_agent.initialize())
+        self.sessions = self.async_agent.sessions
+        self.client_tools = self.async_agent.client_tools
+        self.tool_parser = self.async_agent.tool_parser
+        self.builtin_tools = self.async_agent.builtin_tools
+        self.agent_id = self.async_agent.agent_id
 
     def create_session(self, session_name: str) -> str:
-        agentic_system_create_session_response = self.client.agents.session.create(
-            agent_id=self.agent_id,
-            session_name=session_name,
-        )
-        self.session_id = agentic_system_create_session_response.session_id
-        self.sessions.append(self.session_id)
-        return self.session_id
-
-    def _run_tool(self, tool_calls: List[ToolCall]) -> ToolResponseMessage:
-        assert len(tool_calls) == 1, "Only one tool call is supported"
-        tool_call = tool_calls[0]
-
-        # custom client tools
-        if tool_call.tool_name in self.client_tools:
-            tool = self.client_tools[tool_call.tool_name]
-            # NOTE: tool.run() expects a list of messages, we only pass in last message here
-            # but we could pass in the entire message history
-            result_message = tool.run(
-                [
-                    CompletionMessage(
-                        role="assistant",
-                        content=tool_call.tool_name,
-                        tool_calls=[tool_call],
-                        stop_reason="end_of_turn",
-                    )
-                ]
-            )
-            return result_message
-
-        # builtin tools executed by tool_runtime
-        if tool_call.tool_name in self.builtin_tools:
-            tool_result = self.client.tool_runtime.invoke_tool(
-                tool_name=tool_call.tool_name,
-                kwargs=tool_call.arguments,
-            )
-            tool_response_message = ToolResponseMessage(
-                call_id=tool_call.call_id,
-                tool_name=tool_call.tool_name,
-                content=tool_result.content,
-                role="tool",
-            )
-            return tool_response_message
-
-        # cannot find tools
-        return ToolResponseMessage(
-            call_id=tool_call.call_id,
-            tool_name=tool_call.tool_name,
-            content=f"Unknown tool `{tool_call.tool_name}` was called.",
-            role="tool",
-        )
+        return asyncio.run(self.async_agent.create_session(session_name))
 
     def create_turn(
         self,
@@ -127,74 +69,33 @@ class Agent(AgentMixin):
         documents: Optional[List[Document]] = None,
         stream: bool = True,
     ) -> Iterator[AgentTurnResponseStreamChunk] | Turn:
+
         if stream:
-            return self._create_turn_streaming(messages, session_id, toolgroups, documents)
-        else:
-            chunks = [x for x in self._create_turn_streaming(messages, session_id, toolgroups, documents)]
-            if not chunks:
-                raise Exception("Turn did not complete")
-            return chunks[-1].event.payload.turn
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
 
-    def _create_turn_streaming(
-        self,
-        messages: List[Union[UserMessage, ToolResponseMessage]],
-        session_id: Optional[str] = None,
-        toolgroups: Optional[List[Toolgroup]] = None,
-        documents: Optional[List[Document]] = None,
-    ) -> Iterator[AgentTurnResponseStreamChunk]:
-        n_iter = 0
-        max_iter = self.agent_config.get("max_infer_iters", DEFAULT_MAX_ITER)
-
-        # 1. create an agent turn
-        turn_response = self.client.agents.turn.create(
-            agent_id=self.agent_id,
-            # use specified session_id or last session created
-            session_id=session_id or self.session_id[-1],
-            messages=messages,
-            stream=True,
-            documents=documents,
-            toolgroups=toolgroups,
-            allow_turn_resume=True,
-        )
-
-        # 2. process turn and resume if there's a tool call
-        is_turn_complete = False
-        while not is_turn_complete:
-            is_turn_complete = True
-            for chunk in turn_response:
-                tool_calls = self._get_tool_calls(chunk)
-                if hasattr(chunk, "error"):
-                    yield chunk
-                    return
-                elif not tool_calls:
-                    yield chunk
-                else:
-                    is_turn_complete = False
-                    turn_id = self._get_turn_id(chunk)
-                    if n_iter == 0:
-                        yield chunk
-
-                    # run the tools
-                    tool_response_message = self._run_tool(tool_calls)
-                    # pass it to next iteration
-                    turn_response = self.client.agents.turn.resume(
-                        agent_id=self.agent_id,
-                        session_id=session_id or self.session_id[-1],
-                        turn_id=turn_id,
-                        tool_responses=[tool_response_message],
-                        stream=True,
+            def sync_generator():
+                try:
+                    async_stream = loop.run_until_complete(
+                        self.async_agent.create_turn(messages, session_id, toolgroups, documents, stream)
                     )
-                    n_iter += 1
-                    break
+                    while True:
+                        chunk = loop.run_until_complete(async_stream.__anext__())
+                        yield chunk
+                except StopAsyncIteration:
+                    pass
+                finally:
+                    loop.close()
 
-            if n_iter >= max_iter:
-                raise Exception(f"Turn did not complete in {max_iter} iterations")
+            return sync_generator()
+        else:
+            return asyncio.run(self.async_agent.create_turn(messages, session_id, toolgroups, documents, stream))
 
 
 class AsyncAgent(AgentMixin):
     def __init__(
         self,
-        client: AsyncLlamaStackClient,
+        client: Union[AsyncLlamaStackClient, LlamaStackClient],
         agent_config: AgentConfig,
         client_tools: Tuple[ClientTool] = (),
         tool_parser: Optional[ToolParser] = None,
@@ -206,20 +107,41 @@ class AsyncAgent(AgentMixin):
         self.tool_parser = tool_parser
         self.builtin_tools = {}
 
+        self.is_async = True
+        if isinstance(client, LlamaStackClient):
+            self.is_async = False
+
     async def initialize(self) -> None:
-        agentic_system_create_response = await self.client.agents.create(
-            agent_config=self.agent_config,
-        )
+        if self.is_async:
+            agentic_system_create_response = await self.client.agents.create(
+                agent_config=self.agent_config,
+            )
+        else:
+            agentic_system_create_response = self.client.agents.create(
+                agent_config=self.agent_config,
+            )
+
         self.agent_id = agentic_system_create_response.agent_id
         for tg in self.agent_config["toolgroups"]:
-            for tool in await self.client.tools.list(toolgroup_id=tg):
-                self.builtin_tools[tool.identifier] = tool
+            if self.is_async:
+                for tool in await self.client.tools.list(toolgroup_id=tg):
+                    self.builtin_tools[tool.identifier] = tool
+            else:
+                for tool in self.client.tools.list(toolgroup_id=tg):
+                    self.builtin_tools[tool.identifier] = tool
 
     async def create_session(self, session_name: str) -> str:
-        agentic_system_create_session_response = await self.client.agents.session.create(
-            agent_id=self.agent_id,
-            session_name=session_name,
-        )
+        if self.is_async:
+            agentic_system_create_session_response = await self.client.agents.session.create(
+                agent_id=self.agent_id,
+                session_name=session_name,
+            )
+        else:
+            agentic_system_create_session_response = self.client.agents.session.create(
+                agent_id=self.agent_id,
+                session_name=session_name,
+            )
+
         self.session_id = agentic_system_create_session_response.session_id
         self.sessions.append(self.session_id)
         return self.session_id
@@ -247,24 +169,35 @@ class AsyncAgent(AgentMixin):
         # custom client tools
         if tool_call.tool_name in self.client_tools:
             tool = self.client_tools[tool_call.tool_name]
-            result_message = await tool.async_run(
-                [
-                    CompletionMessage(
-                        role="assistant",
-                        content=tool_call.tool_name,
-                        tool_calls=[tool_call],
-                        stop_reason="end_of_turn",
-                    )
-                ]
-            )
+            # NOTE: tool.run() expects a list of messages, we only pass in last message here
+            # but we could pass in the entire message history
+            messages = [
+                CompletionMessage(
+                    role="assistant",
+                    content=tool_call.tool_name,
+                    tool_calls=[tool_call],
+                    stop_reason="end_of_turn",
+                )
+            ]
+            if self.is_async:
+                result_message = await tool.async_run(messages)
+            else:
+                result_message = tool.run(messages)
+
             return result_message
 
         # builtin tools executed by tool_runtime
         if tool_call.tool_name in self.builtin_tools:
-            tool_result = await self.client.tool_runtime.invoke_tool(
-                tool_name=tool_call.tool_name,
-                kwargs=tool_call.arguments,
-            )
+            if self.is_async:
+                tool_result = await self.client.tool_runtime.invoke_tool(
+                    tool_name=tool_call.tool_name,
+                    kwargs=tool_call.arguments,
+                )
+            else:
+                tool_result = self.client.tool_runtime.invoke_tool(
+                    tool_name=tool_call.tool_name,
+                    kwargs=tool_call.arguments,
+                )
             tool_response_message = ToolResponseMessage(
                 call_id=tool_call.call_id,
                 tool_name=tool_call.tool_name,
@@ -288,47 +221,92 @@ class AsyncAgent(AgentMixin):
         toolgroups: Optional[List[Toolgroup]] = None,
         documents: Optional[List[Document]] = None,
     ) -> AsyncIterator[AgentTurnResponseStreamChunk]:
-        # 1. create an agent turn
-        turn_response = await self.client.agents.turn.create(
-            agent_id=self.agent_id,
-            session_id=session_id or self.session_id[-1],
-            messages=messages,
-            stream=True,
-            documents=documents,
-        )
-
-        # 2. process turn and resume if there's a tool call
         n_iter = 0
         max_iter = self.agent_config.get("max_infer_iters", DEFAULT_MAX_ITER)
+
+        # 1. create an agent turn
+        if self.is_async:
+            turn_response = await self.client.agents.turn.create(
+                agent_id=self.agent_id,
+                # use specified session_id or last session created
+                session_id=session_id or self.session_id[-1],
+                messages=messages,
+                stream=True,
+                documents=documents,
+                toolgroups=toolgroups,
+                allow_turn_resume=True,
+            )
+        else:
+            turn_response = self.client.agents.turn.create(
+                agent_id=self.agent_id,
+                # use specified session_id or last session created
+                session_id=session_id or self.session_id[-1],
+                messages=messages,
+                stream=True,
+                documents=documents,
+                toolgroups=toolgroups,
+                allow_turn_resume=True,
+            )
+
+        # 2. process turn and resume if there's a tool call
         is_turn_complete = False
         while not is_turn_complete:
             is_turn_complete = True
-            async for chunk in turn_response:
-                tool_calls = self._get_tool_calls(chunk)
-                if hasattr(chunk, "error"):
-                    yield chunk
-                    return
-                elif not tool_calls:
-                    yield chunk
-                else:
-                    is_turn_complete = False
-                    turn_id = self._get_turn_id(chunk)
-                    if n_iter == 0:
+
+            if self.is_async:
+                async for chunk in turn_response:
+                    tool_calls = self._get_tool_calls(chunk)
+                    if hasattr(chunk, "error"):
                         yield chunk
+                        return
+                    elif not tool_calls:
+                        yield chunk
+                    else:
+                        is_turn_complete = False
+                        turn_id = self._get_turn_id(chunk)
+                        if n_iter == 0:
+                            yield chunk
 
-                    # run the tools
-                    tool_response_message = await self._run_tool(tool_calls)
-                    # pass it to next iteration
-                    turn_response = await self.client.agents.turn.resume(
-                        agent_id=self.agent_id,
-                        session_id=session_id or self.session_id[-1],
-                        turn_id=turn_id,
-                        tool_responses=[tool_response_message],
-                        stream=True,
-                    )
+                        # run the tools
+                        tool_response_message = await self._run_tool(tool_calls)
 
-                    n_iter += 1
-                    break
+                        # pass it to next iteration
+                        turn_response = await self.client.agents.turn.resume(
+                            agent_id=self.agent_id,
+                            session_id=session_id or self.session_id[-1],
+                            turn_id=turn_id,
+                            tool_responses=[tool_response_message],
+                            stream=True,
+                        )
+
+                        n_iter += 1
+            else:
+                for chunk in turn_response:
+                    tool_calls = self._get_tool_calls(chunk)
+                    if hasattr(chunk, "error"):
+                        yield chunk
+                        return
+                    elif not tool_calls:
+                        yield chunk
+                    else:
+                        is_turn_complete = False
+                        turn_id = self._get_turn_id(chunk)
+                        if n_iter == 0:
+                            yield chunk
+
+                        # run the tools
+                        tool_response_message = await self._run_tool(tool_calls)
+
+                        # pass it to next iteration
+                        turn_response = self.client.agents.turn.resume(
+                            agent_id=self.agent_id,
+                            session_id=session_id or self.session_id[-1],
+                            turn_id=turn_id,
+                            tool_responses=[tool_response_message],
+                            stream=True,
+                        )
+
+                        n_iter += 1
 
             if n_iter >= max_iter:
                 raise Exception(f"Turn did not complete in {max_iter} iterations")

--- a/src/llama_stack_client/lib/agents/agent.py
+++ b/src/llama_stack_client/lib/agents/agent.py
@@ -278,7 +278,7 @@ class Agent(AgentMixin):
                         stream=True,
                     )
                     n_iter += 1
-                   
+
             if self.tool_parser and n_iter > self.agent_config.get("max_infer_iters", DEFAULT_MAX_ITER):
                 raise Exception("Max inference iterations reached")
 

--- a/src/llama_stack_client/lib/agents/agent.py
+++ b/src/llama_stack_client/lib/agents/agent.py
@@ -247,8 +247,7 @@ class AsyncAgent(AgentMixin):
         # custom client tools
         if tool_call.tool_name in self.client_tools:
             tool = self.client_tools[tool_call.tool_name]
-            # TODO: make the client tool async
-            result_message = tool.run(
+            result_message = await tool.async_run(
                 [
                     CompletionMessage(
                         role="assistant",
@@ -303,6 +302,7 @@ class AsyncAgent(AgentMixin):
         max_iter = self.agent_config.get("max_infer_iters", DEFAULT_MAX_ITER)
         is_turn_complete = False
         while not is_turn_complete:
+            is_turn_complete = True
             async for chunk in turn_response:
                 tool_calls = self._get_tool_calls(chunk)
                 if hasattr(chunk, "error"):

--- a/src/llama_stack_client/lib/agents/agent.py
+++ b/src/llama_stack_client/lib/agents/agent.py
@@ -28,6 +28,13 @@ logger = logging.getLogger(__name__)
 
 class AgentUtils:
     @staticmethod
+    def get_client_tools(tools: Optional[List[Union[Toolgroup, ClientTool]]]) -> List[ClientTool]:
+        if not tools:
+            return []
+
+        return [tool for tool in tools if isinstance(tool, ClientTool)]
+
+    @staticmethod
     def get_tool_calls(chunk: AgentTurnResponseStreamChunk, tool_parser: Optional[ToolParser] = None) -> List[ToolCall]:
         if chunk.event.payload.event_type not in {"turn_complete", "turn_awaiting_input"}:
             return []
@@ -169,6 +176,7 @@ class Agent:
                 response_format=response_format,
                 enable_session_persistence=enable_session_persistence,
             )
+            client_tools = AgentUtils.get_client_tools(tools)
 
         self.agent_config = agent_config
         self.client_tools = {t.get_name(): t for t in client_tools}

--- a/src/llama_stack_client/lib/agents/agent.py
+++ b/src/llama_stack_client/lib/agents/agent.py
@@ -48,7 +48,6 @@ class Agent:
         documents: Optional[List[Document]] = None,
         stream: bool = True,
     ) -> Iterator[AgentTurnResponseStreamChunk] | Turn:
-
         if stream:
             loop = asyncio.new_event_loop()
             asyncio.set_event_loop(loop)

--- a/src/llama_stack_client/lib/agents/agent.py
+++ b/src/llama_stack_client/lib/agents/agent.py
@@ -191,7 +191,7 @@ class Agent(AgentMixin):
                 raise Exception(f"Turn did not complete in {max_iter} iterations")
 
 
-class AsyncAgent:
+class AsyncAgent(AgentMixin):
     def __init__(
         self,
         client: AsyncLlamaStackClient,

--- a/src/llama_stack_client/lib/agents/agent.py
+++ b/src/llama_stack_client/lib/agents/agent.py
@@ -171,21 +171,20 @@ class Agent:
             )
 
         self.agent_config = agent_config
-        self.agent_id = self._create_agent(agent_config)
         self.client_tools = {t.get_name(): t for t in client_tools}
         self.sessions = []
         self.tool_parser = tool_parser
         self.builtin_tools = {}
-        for tg in agent_config["toolgroups"]:
-            for tool in self.client.tools.list(toolgroup_id=tg):
-                self.builtin_tools[tool.identifier] = tool
+        self.initialize()
 
-    def _create_agent(self, agent_config: AgentConfig) -> int:
+    def initialize(self) -> None:
         agentic_system_create_response = self.client.agents.create(
-            agent_config=agent_config,
+            agent_config=self.agent_config,
         )
         self.agent_id = agentic_system_create_response.agent_id
-        return self.agent_id
+        for tg in self.agent_config["toolgroups"]:
+            for tool in self.client.tools.list(toolgroup_id=tg):
+                self.builtin_tools[tool.identifier] = tool
 
     def create_session(self, session_name: str) -> str:
         agentic_system_create_session_response = self.client.agents.session.create(


### PR DESCRIPTION
# What does this PR do?
- Introduce `AsyncAgent` -- an async version of Agent wrapper using AsyncLlamaStackClient
- Enable async def with client_tool decorator
- Closes https://github.com/meta-llama/llama-stack/issues/1391

```python
class Agent:
    def create_session(...): ...
    def create_turn(...): ...

class AsyncAgent
    async def create_session(...): ...
    async def create_turn(...): ...
```

> NOTE, there's some code duplication to keep the distinction and avoid too many if/else 

[//]: # (If resolving an issue, uncomment and update the line below)
[//]: # (Closes #[issue-number])

## Test Plan
- test with script in: https://github.com/meta-llama/llama-stack-apps/blob/async_agent/examples/agents/async_agent.py
- test with ReAct agent

```
pytest -v tests/client-sdk/agents/test_agents.py --inference-model meta-llama/Llama-3.1-8B-Instruct
```

<img width="843" alt="image" src="https://github.com/user-attachments/assets/29c08ff6-4e8e-4ca3-a017-e1445b1648d2" />

- TODO (follow up): add a test case in client-sdk agents test in llama-stack

- sync agent test passing in: https://github.com/meta-llama/llama-stack/pull/1462


[//]: # (## Documentation)
[//]: # (- [ ] Added a Changelog entry if the change is significant)
