### PR TITLE
fix: React Agent for non-llama models 

### DIFF
--- a/src/llama_stack_client/lib/agents/agent.py
+++ b/src/llama_stack_client/lib/agents/agent.py
@@ -162,11 +162,11 @@ class Agent:
         while not is_turn_complete:
             is_turn_complete = True
             for chunk in turn_response:
-                tool_calls = self._get_tool_calls(chunk)
                 if hasattr(chunk, "error"):
                     yield chunk
                     return
-                elif not tool_calls:
+                tool_calls = self._get_tool_calls(chunk)
+                if not tool_calls:
                     yield chunk
                 else:
                     is_turn_complete = False

--- a/src/llama_stack_client/lib/agents/client_tool.py
+++ b/src/llama_stack_client/lib/agents/client_tool.py
@@ -163,7 +163,8 @@ def client_tool(func: T) -> ClientTool:
                 params[name] = Parameter(
                     name=name,
                     description=param_doc or f"Parameter {name}",
-                    parameter_type=type_hint.__name__,
+                    # Hack: litellm/openai expects "string" for str type
+                    parameter_type=type_hint.__name__ if type_hint.__name__ != "str" else "string",
                     default=(param.default if param.default != inspect.Parameter.empty else None),
                     required=is_required,
                 )

--- a/src/llama_stack_client/lib/agents/event_logger.py
+++ b/src/llama_stack_client/lib/agents/event_logger.py
@@ -63,7 +63,8 @@ class TurnStreamEventPrinter:
         for printable_event in self._yield_printable_events(chunk, self.previous_event_type, self.previous_step_type):
             yield printable_event
 
-        self.previous_event_type, self.previous_step_type = self._get_event_type_step_type(chunk)
+        if not hasattr(chunk, "error"):
+            self.previous_event_type, self.previous_step_type = self._get_event_type_step_type(chunk)
 
     def _yield_printable_events(
         self, chunk: Any, previous_event_type: Optional[str] = None, previous_step_type: Optional[str] = None

--- a/src/llama_stack_client/lib/agents/react/agent.py
+++ b/src/llama_stack_client/lib/agents/react/agent.py
@@ -97,7 +97,7 @@ class ReActAgent(Agent):
             agent_config = custom_agent_config
 
         if json_response_format:
-            agent_config.response_format = {
+            agent_config["response_format"] = {
                 "type": "json_schema",
                 "json_schema": ReActOutput.model_json_schema(),
             }

--- a/src/llama_stack_client/lib/agents/react/agent.py
+++ b/src/llama_stack_client/lib/agents/react/agent.py
@@ -3,29 +3,18 @@
 #
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
-from typing import Any, Dict, Optional, Tuple
+from typing import Optional, Tuple
 
 from llama_stack_client import LlamaStackClient
 from llama_stack_client.types.agent_create_params import AgentConfig
-from pydantic import BaseModel
+
 
 from ..agent import Agent
 from ..client_tool import ClientTool
 from ..tool_parser import ToolParser
 from .prompts import DEFAULT_REACT_AGENT_SYSTEM_PROMPT_TEMPLATE
 
-from .tool_parser import ReActToolParser
-
-
-class Action(BaseModel):
-    tool_name: str
-    tool_params: Dict[str, Any]
-
-
-class ReActOutput(BaseModel):
-    thought: str
-    action: Optional[Action] = None
-    answer: Optional[str] = None
+from .tool_parser import ReActToolParser, ReActOutput
 
 
 class ReActAgent(Agent):


### PR DESCRIPTION
- Cannot take `Any` in structured outputs for ReActOutput ( updated the structure ) 
- open-ai takes "string" instead of "str" in tool param 
- better error handling in event logger 