### PR TITLE
fix: remove the alpha suffix in run_benchmark.py

### DIFF
--- a/src/llama_stack_client/lib/cli/eval/run_benchmark.py
+++ b/src/llama_stack_client/lib/cli/eval/run_benchmark.py
@@ -101,7 +101,7 @@ def run_benchmark(
         output_res = {}
 
         for i, r in enumerate(tqdm(rows.rows)):
-            eval_res = client.eval.evaluate_rows_alpha(
+            eval_res = client.eval.evaluate_rows(
                 benchmark_id=benchmark_id,
                 input_rows=[r],
                 scoring_functions=scoring_functions,


### PR DESCRIPTION
## What does this PR do?
Remove the alpha suffix of evaluate_rows after the new pkg release


## Test Plan
test with `llama-stack-client --endpoint xxx eval run-benchmark "meta-reference-mmlu-cot" --model-id "meta-llama/Llama-3.1-8B-Instruct" --output-dir "/home/markchen1015/" --num-examples 5` and the eval finished successfully


![Screenshot 2025-03-04 at 11 35 03 PM](https://github.com/user-attachments/assets/3cfb6e99-c9b1-409b-b880-98ae3d14b9eb)
