### PR TITLE
feat: `llama-stack-client providers inspect PROVIDER_ID`

### DIFF
--- a/src/llama_stack_client/lib/cli/providers/inspect.py
+++ b/src/llama_stack_client/lib/cli/providers/inspect.py
@@ -1,0 +1,27 @@
+import click
+import yaml
+from rich.console import Console
+
+from ..common.utils import handle_client_errors
+
+
+@click.command(name="inspect")
+@click.argument("provider_id")
+@click.pass_context
+@handle_client_errors("inspect providers")
+def inspect_provider(ctx, provider_id):
+    """Show available providers on distribution endpoint"""
+    client = ctx.obj["client"]
+    console = Console()
+
+    providers_response = client.providers.inspect(provider_id=provider_id)
+
+    if providers_response is None:
+        click.secho("Provider not found", fg="red")
+        raise click.exceptions.Exit(1)
+
+    console.print(f"provider_id={providers_response.provider_id}")
+    console.print(f"provider_type={providers_response.provider_type}")
+    console.print("config:")
+    for line in yaml.dump(providers_response.config, indent=2).split("\n"):
+        console.print(line)

--- a/src/llama_stack_client/lib/cli/providers/providers.py
+++ b/src/llama_stack_client/lib/cli/providers/providers.py
@@ -1,6 +1,7 @@
 import click
 
 from .list import list_providers
+from .inspect import inspect_provider
 
 
 @click.group()
@@ -11,3 +12,4 @@ def providers():
 
 # Register subcommands
 providers.add_command(list_providers)
+providers.add_command(inspect_provider)

--- a/src/llama_stack_client/resources/providers.py
+++ b/src/llama_stack_client/resources/providers.py
@@ -18,6 +18,7 @@ from .._response import (
 from .._wrappers import DataWrapper
 from .._base_client import make_request_options
 from ..types.provider_list_response import ProviderListResponse
+from ..types.provider_get_response import GetProviderResponse
 
 __all__ = ["ProvidersResource", "AsyncProvidersResource"]
 
@@ -53,7 +54,7 @@ class ProvidersResource(SyncAPIResource):
         timeout: float | httpx.Timeout | None | NotGiven = NOT_GIVEN,
     ) -> ProviderListResponse:
         return self._get(
-            "/v1/inspect/providers",
+            "/v1/providers",
             options=make_request_options(
                 extra_headers=extra_headers,
                 extra_query=extra_query,
@@ -62,6 +63,29 @@ class ProvidersResource(SyncAPIResource):
                 post_parser=DataWrapper[ProviderListResponse]._unwrapper,
             ),
             cast_to=cast(Type[ProviderListResponse], DataWrapper[ProviderListResponse]),
+        )
+
+    def inspect(
+        self,
+        provider_id,
+        *,
+        # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
+        # The extra values given here take precedence over values defined on the client or passed to this method.
+        extra_headers: Headers | None = None,
+        extra_query: Query | None = None,
+        extra_body: Body | None = None,
+        timeout: float | httpx.Timeout | None | NotGiven = NOT_GIVEN,
+    ) -> GetProviderResponse:
+        return self._get(
+            f"/v1/providers/{provider_id}",
+            options=make_request_options(
+                extra_headers=extra_headers,
+                extra_query=extra_query,
+                extra_body=extra_body,
+                timeout=timeout,
+                post_parser=DataWrapper[GetProviderResponse]._unwrapper,
+            ),
+            cast_to=cast(Type[GetProviderResponse], DataWrapper[GetProviderResponse]),
         )
 
 
@@ -96,7 +120,7 @@ class AsyncProvidersResource(AsyncAPIResource):
         timeout: float | httpx.Timeout | None | NotGiven = NOT_GIVEN,
     ) -> ProviderListResponse:
         return await self._get(
-            "/v1/inspect/providers",
+            "/v1/providers",
             options=make_request_options(
                 extra_headers=extra_headers,
                 extra_query=extra_query,
@@ -105,6 +129,29 @@ class AsyncProvidersResource(AsyncAPIResource):
                 post_parser=DataWrapper[ProviderListResponse]._unwrapper,
             ),
             cast_to=cast(Type[ProviderListResponse], DataWrapper[ProviderListResponse]),
+        )
+    
+    async def inspect(
+        self,
+        provider_id,
+        *,
+        # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
+        # The extra values given here take precedence over values defined on the client or passed to this method.
+        extra_headers: Headers | None = None,
+        extra_query: Query | None = None,
+        extra_body: Body | None = None,
+        timeout: float | httpx.Timeout | None | NotGiven = NOT_GIVEN,
+    ) -> GetProviderResponse:
+        return await self._get(
+            f"/v1/providers/{provider_id}",
+            options=make_request_options(
+                extra_headers=extra_headers,
+                extra_query=extra_query,
+                extra_body=extra_body,
+                timeout=timeout,
+                post_parser=DataWrapper[GetProviderResponse]._unwrapper,
+            ),
+            cast_to=cast(Type[GetProviderResponse], DataWrapper[GetProviderResponse]),
         )
 
 
@@ -116,6 +163,9 @@ class ProvidersResourceWithRawResponse:
             providers.list,
         )
 
+        self.inspect = to_raw_response_wrapper(
+            providers.inspect,
+        )
 
 class AsyncProvidersResourceWithRawResponse:
     def __init__(self, providers: AsyncProvidersResource) -> None:
@@ -124,6 +174,11 @@ class AsyncProvidersResourceWithRawResponse:
         self.list = async_to_raw_response_wrapper(
             providers.list,
         )
+
+        self.inspect = async_to_raw_response_wrapper(
+            providers.inspect,
+        )
+
 
 
 class ProvidersResourceWithStreamingResponse:
@@ -134,6 +189,10 @@ class ProvidersResourceWithStreamingResponse:
             providers.list,
         )
 
+        self.inspect = to_streamed_response_wrapper(
+            providers.inspect,
+        )
+
 
 class AsyncProvidersResourceWithStreamingResponse:
     def __init__(self, providers: AsyncProvidersResource) -> None:
@@ -141,4 +200,7 @@ class AsyncProvidersResourceWithStreamingResponse:
 
         self.list = async_to_streamed_response_wrapper(
             providers.list,
+        )
+        self.inspect = async_to_streamed_response_wrapper(
+            providers.inspect,
         )

--- a/src/llama_stack_client/types/provider_get_response.py
+++ b/src/llama_stack_client/types/provider_get_response.py
@@ -1,0 +1,9 @@
+# File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
+
+from typing_extensions import TypeAlias
+
+from .provider_info import ProviderInfoWithConfig
+
+__all__ = ["GetProviderResponse"]
+
+GetProviderResponse: TypeAlias = ProviderInfoWithConfig

--- a/src/llama_stack_client/types/provider_info.py
+++ b/src/llama_stack_client/types/provider_info.py
@@ -2,6 +2,7 @@
 
 
 from .._models import BaseModel
+from typing import Dict, Any
 
 __all__ = ["ProviderInfo"]
 
@@ -12,3 +13,12 @@ class ProviderInfo(BaseModel):
     provider_id: str
 
     provider_type: str
+
+class ProviderInfoWithConfig(BaseModel):
+    api: str
+
+    provider_id: str
+
+    provider_type: str
+
+    config: Dict[str, Any]


### PR DESCRIPTION
# What does this PR do?

allow a user to see certain parts of the provider configuration for a specified provider. This is the cli code corresponding to https://github.com/meta-llama/llama-stack/pull/1429


This PR introduces:
-  `llama-stack-client providers inspect`
- amends `llama-stack-client providers list` to use `/v1/providers`
- `GetProviderResponse` to handle the response from these new API calls