### PR TITLE
fix: react agent with custom tool parser n_iters

### DIFF
--- a/src/llama_stack_client/lib/agents/agent.py
+++ b/src/llama_stack_client/lib/agents/agent.py
@@ -277,5 +277,5 @@ class Agent:
                     )
                     n_iter += 1
 
-            if n_iter > self.agent_config.get("max_infer_iters", DEFAULT_MAX_ITER):
+            if self.tool_parser and n_iter > self.agent_config.get("max_infer_iters", DEFAULT_MAX_ITER):
                 raise Exception("Max inference iterations reached")

--- a/src/llama_stack_client/lib/agents/agent.py
+++ b/src/llama_stack_client/lib/agents/agent.py
@@ -119,10 +119,6 @@ class Agent:
             agent_config = AgentConfig(**agent_config)
 
         self.agent_config = agent_config
-
-        if "max_infer_iters" not in self.agent_config:
-            self.agent_config["max_infer_iters"] = DEFAULT_MAX_ITER
-
         self.agent_id = self._create_agent(agent_config)
         self.client_tools = {t.get_name(): t for t in client_tools}
         self.sessions = []
@@ -281,5 +277,5 @@ class Agent:
                     )
                     n_iter += 1
 
-            if n_iter > self.agent_config["max_infer_iters"]:
+            if n_iter > self.agent_config.get("max_infer_iters", DEFAULT_MAX_ITER):
                 raise Exception("Max inference iterations reached")

--- a/src/llama_stack_client/lib/agents/agent.py
+++ b/src/llama_stack_client/lib/agents/agent.py
@@ -40,7 +40,7 @@ class Agent:
         tools: Optional[List[Union[Toolgroup, ClientTool]]] = None,
         tool_config: Optional[ToolConfig] = None,
         sampling_params: Optional[SamplingParams] = None,
-        max_infer_iters: int = DEFAULT_MAX_ITER,
+        max_infer_iters: Optional[int] = None,
         input_shields: Optional[List[str]] = None,
         output_shields: Optional[List[str]] = None,
         response_format: Optional[ResponseFormat] = None,
@@ -91,10 +91,10 @@ class Agent:
             # Add optional parameters if provided
             if enable_session_persistence is not None:
                 agent_config["enable_session_persistence"] = enable_session_persistence
-            if input_shields is not None:
-                agent_config["input_shields"] = input_shields
             if max_infer_iters is not None:
                 agent_config["max_infer_iters"] = max_infer_iters
+            if input_shields is not None:
+                agent_config["input_shields"] = input_shields
             if output_shields is not None:
                 agent_config["output_shields"] = output_shields
             if response_format is not None:
@@ -119,10 +119,10 @@ class Agent:
             agent_config = AgentConfig(**agent_config)
 
         self.agent_config = agent_config
-        self.agent_config["max_infer_iters"] = max_infer_iters
-        from rich.pretty import pprint
 
-        pprint(agent_config)
+        if "max_infer_iters" not in self.agent_config:
+            self.agent_config["max_infer_iters"] = DEFAULT_MAX_ITER
+
         self.agent_id = self._create_agent(agent_config)
         self.client_tools = {t.get_name(): t for t in client_tools}
         self.sessions = []

--- a/src/llama_stack_client/lib/agents/react/tool_parser.py
+++ b/src/llama_stack_client/lib/agents/react/tool_parser.py
@@ -5,7 +5,7 @@
 # the root directory of this source tree.
 
 import uuid
-from typing import Dict, List, Optional, Union
+from typing import List, Optional, Union
 
 from pydantic import BaseModel, ValidationError
 

--- a/src/llama_stack_client/lib/agents/react/tool_parser.py
+++ b/src/llama_stack_client/lib/agents/react/tool_parser.py
@@ -4,18 +4,27 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
+import uuid
+from typing import Dict, List, Optional, Union
+
 from pydantic import BaseModel, ValidationError
-from typing import Optional, List, Union
-from ..tool_parser import ToolParser
+
 from llama_stack_client.types.shared.completion_message import CompletionMessage
 from llama_stack_client.types.shared.tool_call import ToolCall
-
-import uuid
+from ..tool_parser import ToolParser
 
 
 class Param(BaseModel):
     name: str
-    value: Union[str, int, float, bool]
+    value: Union[
+        str,
+        int,
+        float,
+        bool,
+        List[Union[str, int, float, bool, None]],
+        Dict[str, Union[str, int, float, bool, None]],
+        None,
+    ]
 
 
 class Action(BaseModel):
@@ -37,6 +46,13 @@ class ReActToolParser(ToolParser):
             react_output = ReActOutput.model_validate_json(response_text)
         except ValidationError as e:
             print(f"Error parsing action: {e}")
+            print(f"Response text: {response_text}")
+            import json
+
+            from rich.pretty import pprint
+
+            try_json = json.loads(response_text)
+            pprint(try_json)
             return tool_calls
 
         if react_output.answer:

--- a/src/llama_stack_client/lib/agents/react/tool_parser.py
+++ b/src/llama_stack_client/lib/agents/react/tool_parser.py
@@ -16,15 +16,7 @@ from ..tool_parser import ToolParser
 
 class Param(BaseModel):
     name: str
-    value: Union[
-        str,
-        int,
-        float,
-        bool,
-        List[Union[str, int, float, bool, None]],
-        Dict[str, Union[str, int, float, bool, None]],
-        None,
-    ]
+    value: Union[str, int, float, bool]
 
 
 class Action(BaseModel):
@@ -46,13 +38,6 @@ class ReActToolParser(ToolParser):
             react_output = ReActOutput.model_validate_json(response_text)
         except ValidationError as e:
             print(f"Error parsing action: {e}")
-            print(f"Response text: {response_text}")
-            import json
-
-            from rich.pretty import pprint
-
-            try_json = json.loads(response_text)
-            pprint(try_json)
             return tool_calls
 
         if react_output.answer:


### PR DESCRIPTION
# What does this PR do?

- Custom tool_parser on client side is not working correctly with latest change unifying max_infer_iters. 
- This is b/c we output an `end_of_message`
- Temporary is to still keep track of n_iters when we have custom tool_parser on client, this will not be needed when we move ReAct to server side. 

[//]: # (If resolving an issue, uncomment and update the line below)
[//]: # (Closes #[issue-number])

## Test Plan
```
python -m examples.agents.react_agent localhost 8321
```

[//]: # (## Documentation)
[//]: # (- [ ] Added a Changelog entry if the change is significant)
