### PR TITLE
Add `-h` help flag support to all CLI commands

### DIFF
--- a/src/llama_stack_client/lib/cli/configure.py
+++ b/src/llama_stack_client/lib/cli/configure.py
@@ -23,6 +23,7 @@ def get_config():
 
 
 @click.command()
+@click.help_option("-h", "--help")
 @click.option("--endpoint", type=str, help="Llama Stack distribution endpoint", default="")
 @click.option("--api-key", type=str, help="Llama Stack distribution API key", default="")
 def configure(endpoint: str | None, api_key: str | None):

--- a/src/llama_stack_client/lib/cli/datasets/datasets.py
+++ b/src/llama_stack_client/lib/cli/datasets/datasets.py
@@ -10,6 +10,7 @@ from .register import register
 
 
 @click.group()
+@click.help_option("-h", "--help")
 def datasets():
     """Manage datasets."""
 

--- a/src/llama_stack_client/lib/cli/datasets/list.py
+++ b/src/llama_stack_client/lib/cli/datasets/list.py
@@ -12,6 +12,7 @@ from ..common.utils import handle_client_errors
 
 
 @click.command("list")
+@click.help_option("-h", "--help")
 @click.pass_context
 @handle_client_errors("list datasets")
 def list_datasets(ctx):

--- a/src/llama_stack_client/lib/cli/datasets/register.py
+++ b/src/llama_stack_client/lib/cli/datasets/register.py
@@ -30,6 +30,7 @@ def data_url_from_file(file_path: str) -> str:
 
 
 @click.command("register")
+@click.help_option("-h", "--help")
 @click.option("--dataset-id", required=True, help="Id of the dataset")
 @click.option("--provider-id", help="Provider ID for the dataset", default=None)
 @click.option("--provider-dataset-id", help="Provider's dataset ID", default=None)

--- a/src/llama_stack_client/lib/cli/eval/eval.py
+++ b/src/llama_stack_client/lib/cli/eval/eval.py
@@ -12,6 +12,7 @@ from .run_scoring import run_scoring
 
 
 @click.group()
+@click.help_option("-h", "--help")
 def eval():
     """Run evaluation tasks."""
 

--- a/src/llama_stack_client/lib/cli/eval/run_benchmark.py
+++ b/src/llama_stack_client/lib/cli/eval/run_benchmark.py
@@ -17,6 +17,7 @@ from .utils import aggregate_accuracy, aggregate_average, aggregate_categorical_
 
 
 @click.command("run-benchmark")
+@click.help_option("-h", "--help")
 @click.argument("benchmark-ids", nargs=-1, required=True)
 @click.option(
     "--model-id",

--- a/src/llama_stack_client/lib/cli/eval/run_scoring.py
+++ b/src/llama_stack_client/lib/cli/eval/run_scoring.py
@@ -15,6 +15,7 @@ from tqdm.rich import tqdm
 
 
 @click.command("run-scoring")
+@click.help_option("-h", "--help")
 @click.argument("scoring-function-ids", nargs=-1, required=True)
 @click.option(
     "--dataset-id",

--- a/src/llama_stack_client/lib/cli/eval_tasks/eval_tasks.py
+++ b/src/llama_stack_client/lib/cli/eval_tasks/eval_tasks.py
@@ -16,11 +16,13 @@ from .list import list_eval_tasks
 
 
 @click.group()
+@click.help_option("-h", "--help")
 def eval_tasks():
     """Manage evaluation tasks."""
 
 
 @eval_tasks.command()
+@click.help_option("-h", "--help")
 @click.option("--eval-task-id", required=True, help="ID of the eval task")
 @click.option("--dataset-id", required=True, help="ID of the dataset to evaluate")
 @click.option("--scoring-functions", required=True, multiple=True, help="Scoring functions to use for evaluation")

--- a/src/llama_stack_client/lib/cli/eval_tasks/list.py
+++ b/src/llama_stack_client/lib/cli/eval_tasks/list.py
@@ -12,6 +12,7 @@ from ..common.utils import handle_client_errors
 
 
 @click.command("list")
+@click.help_option("-h", "--help")
 @click.pass_context
 @handle_client_errors("list eval tasks")
 def list_eval_tasks(ctx):

--- a/src/llama_stack_client/lib/cli/inference/inference.py
+++ b/src/llama_stack_client/lib/cli/inference/inference.py
@@ -15,11 +15,13 @@ from ..common.utils import handle_client_errors
 
 
 @click.group()
+@click.help_option("-h", "--help")
 def inference():
     """Inference (chat)."""
 
 
 @click.command("chat-completion")
+@click.help_option("-h", "--help")
 @click.option("--message", help="Message")
 @click.option("--stream", is_flag=True, help="Streaming", default=False)
 @click.option("--session", is_flag=True, help="Start a Chat Session", default=False)

--- a/src/llama_stack_client/lib/cli/inspect/inspect.py
+++ b/src/llama_stack_client/lib/cli/inspect/inspect.py
@@ -4,6 +4,7 @@ from .version import inspect_version
 
 
 @click.group()
+@click.help_option("-h", "--help")
 def inspect():
     """Inspect server configuration."""
 

--- a/src/llama_stack_client/lib/cli/inspect/version.py
+++ b/src/llama_stack_client/lib/cli/inspect/version.py
@@ -5,6 +5,7 @@ from ..common.utils import handle_client_errors
 
 
 @click.command("version")
+@click.help_option("-h", "--help")
 @click.pass_context
 @handle_client_errors("inspect version")
 def inspect_version(ctx):

--- a/src/llama_stack_client/lib/cli/llama_stack_client.py
+++ b/src/llama_stack_client/lib/cli/llama_stack_client.py
@@ -29,6 +29,7 @@ from .vector_dbs import vector_dbs
 
 
 @click.group()
+@click.help_option("-h", "--help")
 @click.version_option(version=version("llama-stack-client"), prog_name="llama-stack-client")
 @click.option("--endpoint", type=str, help="Llama Stack distribution endpoint", default="")
 @click.option("--api-key", type=str, help="Llama Stack distribution API key", default="")

--- a/src/llama_stack_client/lib/cli/models/models.py
+++ b/src/llama_stack_client/lib/cli/models/models.py
@@ -14,11 +14,13 @@ from ..common.utils import handle_client_errors
 
 
 @click.group()
+@click.help_option("-h", "--help")
 def models():
     """Manage GenAI models."""
 
 
 @click.command(name="list", help="Show available llama models at distribution endpoint")
+@click.help_option("-h", "--help")
 @click.pass_context
 @handle_client_errors("list models")
 def list_models(ctx):
@@ -63,6 +65,7 @@ def list_models(ctx):
 
 
 @click.command(name="get")
+@click.help_option("-h", "--help")
 @click.argument("model_id")
 @click.pass_context
 @handle_client_errors("get model details")
@@ -91,6 +94,7 @@ def get_model(ctx, model_id: str):
 
 
 @click.command(name="register", help="Register a new model at distribution endpoint")
+@click.help_option("-h", "--help")
 @click.argument("model_id")
 @click.option("--provider-id", help="Provider ID for the model", default=None)
 @click.option("--provider-model-id", help="Provider's model ID", default=None)
@@ -119,6 +123,7 @@ def register_model(
 
 
 @click.command(name="unregister", help="Unregister a model from distribution endpoint")
+@click.help_option("-h", "--help")
 @click.argument("model_id")
 @click.pass_context
 @handle_client_errors("unregister model")

--- a/src/llama_stack_client/lib/cli/post_training/post_training.py
+++ b/src/llama_stack_client/lib/cli/post_training/post_training.py
@@ -15,11 +15,13 @@ from ..common.utils import handle_client_errors
 
 
 @click.group()
+@click.help_option("-h", "--help")
 def post_training():
     """Post-training."""
 
 
 @click.command("supervised_fine_tune")
+@click.help_option("-h", "--help")
 @click.option("--job-uuid", required=True, help="Job UUID")
 @click.option("--model", required=True, help="Model ID")
 @click.option("--algorithm-config", required=True, help="Algorithm Config")
@@ -53,6 +55,7 @@ def supervised_fine_tune(
 
 
 @click.command("list")
+@click.help_option("-h", "--help")
 @click.pass_context
 @handle_client_errors("post_training get_training_jobs")
 def get_training_jobs(ctx):
@@ -65,6 +68,7 @@ def get_training_jobs(ctx):
 
 
 @click.command("status")
+@click.help_option("-h", "--help")
 @click.option("--job-uuid", required=True, help="Job UUID")
 @click.pass_context
 @handle_client_errors("post_training get_training_job_status")
@@ -78,6 +82,7 @@ def get_training_job_status(ctx, job_uuid: str):
 
 
 @click.command("artifacts")
+@click.help_option("-h", "--help")
 @click.option("--job-uuid", required=True, help="Job UUID")
 @click.pass_context
 @handle_client_errors("post_training get_training_job_artifacts")
@@ -91,6 +96,7 @@ def get_training_job_artifacts(ctx, job_uuid: str):
 
 
 @click.command("cancel")
+@click.help_option("-h", "--help")
 @click.option("--job-uuid", required=True, help="Job UUID")
 @click.pass_context
 @handle_client_errors("post_training cancel_training_job")

--- a/src/llama_stack_client/lib/cli/providers/list.py
+++ b/src/llama_stack_client/lib/cli/providers/list.py
@@ -6,6 +6,7 @@ from ..common.utils import handle_client_errors
 
 
 @click.command("list")
+@click.help_option("-h", "--help")
 @click.pass_context
 @handle_client_errors("list providers")
 def list_providers(ctx):

--- a/src/llama_stack_client/lib/cli/providers/providers.py
+++ b/src/llama_stack_client/lib/cli/providers/providers.py
@@ -4,6 +4,7 @@ from .list import list_providers
 
 
 @click.group()
+@click.help_option("-h", "--help")
 def providers():
     """Manage API providers."""
 

--- a/src/llama_stack_client/lib/cli/scoring_functions/list.py
+++ b/src/llama_stack_client/lib/cli/scoring_functions/list.py
@@ -12,6 +12,7 @@ from ..common.utils import handle_client_errors
 
 
 @click.command("list")
+@click.help_option("-h", "--help")
 @click.pass_context
 @handle_client_errors("list scoring functions")
 def list_scoring_functions(ctx):

--- a/src/llama_stack_client/lib/cli/scoring_functions/scoring_functions.py
+++ b/src/llama_stack_client/lib/cli/scoring_functions/scoring_functions.py
@@ -14,11 +14,13 @@ from .list import list_scoring_functions
 
 
 @click.group()
+@click.help_option("-h", "--help")
 def scoring_functions():
     """Manage scoring functions."""
 
 
 @scoring_functions.command()
+@click.help_option("-h", "--help")
 @click.option("--scoring-fn-id", required=True, help="Id of the scoring function")
 @click.option("--description", required=True, help="Description of the scoring function")
 @click.option("--return-type", type=str, required=True, help="Return type of the scoring function")

--- a/src/llama_stack_client/lib/cli/shields/shields.py
+++ b/src/llama_stack_client/lib/cli/shields/shields.py
@@ -15,11 +15,13 @@ from ..common.utils import handle_client_errors
 
 
 @click.group()
+@click.help_option("-h", "--help")
 def shields():
     """Manage safety shield services."""
 
 
 @click.command("list")
+@click.help_option("-h", "--help")
 @click.pass_context
 @handle_client_errors("list shields")
 def list(ctx):
@@ -59,6 +61,7 @@ def list(ctx):
 
 
 @shields.command()
+@click.help_option("-h", "--help")
 @click.option("--shield-id", required=True, help="Id of the shield")
 @click.option("--provider-id", help="Provider ID for the shield", default=None)
 @click.option("--provider-shield-id", help="Provider's shield ID", default=None)

--- a/src/llama_stack_client/lib/cli/toolgroups/toolgroups.py
+++ b/src/llama_stack_client/lib/cli/toolgroups/toolgroups.py
@@ -14,11 +14,13 @@ from ..common.utils import handle_client_errors
 
 
 @click.group()
+@click.help_option("-h", "--help")
 def toolgroups():
     """Manage available tool groups."""
 
 
 @click.command(name="list", help="Show available llama toolgroups at distribution endpoint")
+@click.help_option("-h", "--help")
 @click.pass_context
 @handle_client_errors("list toolgroups")
 def list_toolgroups(ctx):
@@ -39,6 +41,7 @@ def list_toolgroups(ctx):
 
 
 @click.command(name="get")
+@click.help_option("-h", "--help")
 @click.argument("toolgroup_id")
 @click.pass_context
 @handle_client_errors("get toolgroup details")
@@ -72,6 +75,7 @@ def get_toolgroup(ctx, toolgroup_id: str):
 
 
 @click.command(name="register", help="Register a new toolgroup at distribution endpoint")
+@click.help_option("-h", "--help")
 @click.argument("toolgroup_id")
 @click.option("--provider-id", help="Provider ID for the toolgroup", default=None)
 @click.option("--provider-toolgroup-id", help="Provider's toolgroup ID", default=None)
@@ -102,6 +106,7 @@ def register_toolgroup(
 
 
 @click.command(name="unregister", help="Unregister a toolgroup from distribution endpoint")
+@click.help_option("-h", "--help")
 @click.argument("toolgroup_id")
 @click.pass_context
 @handle_client_errors("unregister toolgroup")

--- a/src/llama_stack_client/lib/cli/vector_dbs/vector_dbs.py
+++ b/src/llama_stack_client/lib/cli/vector_dbs/vector_dbs.py
@@ -15,11 +15,13 @@ from ..common.utils import handle_client_errors
 
 
 @click.group()
+@click.help_option("-h", "--help")
 def vector_dbs():
     """Manage vector databases."""
 
 
 @click.command("list")
+@click.help_option("-h", "--help")
 @click.pass_context
 @handle_client_errors("list vector dbs")
 def list(ctx):
@@ -56,6 +58,7 @@ def list(ctx):
 
 
 @vector_dbs.command()
+@click.help_option("-h", "--help")
 @click.argument("vector-db-id")
 @click.option("--provider-id", help="Provider ID for the vector db", default=None)
 @click.option("--provider-vector-db-id", help="Provider's vector db ID", default=None)
@@ -96,6 +99,7 @@ def register(
 
 
 @vector_dbs.command()
+@click.help_option("-h", "--help")
 @click.argument("vector-db-id")
 @click.pass_context
 @handle_client_errors("delete vector db")


### PR DESCRIPTION
Updated each command in the CLI to support the `-h` flag for displaying usage instructions.

# What does this PR do?
This PR adds support for the -h help flag to all CLI commands. It enables users to view usage instructions and command options by appending -h or --help to any command in the CLI. This enhancement improves the usability of the CLI by providing a consistent and easy way for users to access command-specific help information. The help flag functionality is implemented across all commands, ensuring that every CLI command supports this feature.

## Test Plan
Manual Testing:

Run each CLI command with the -h or --help flag.
Verify that the correct help message is displayed for each command, including the command options, arguments, and usage instructions.