### PR TITLE
fix(agent): initialize toolgroups/client_tools

### DIFF
--- a/src/llama_stack_client/lib/agents/agent.py
+++ b/src/llama_stack_client/lib/agents/agent.py
@@ -86,6 +86,8 @@ class Agent:
             agent_config = {
                 "model": model,
                 "instructions": instructions,
+                "toolgroups": [],
+                "client_tools": [],
             }
 
             # Add optional parameters if provided


### PR DESCRIPTION

Summary:
otherwise errors on L127

Test Plan:
py.test -v -s --nbval-lax ./docs/getting_started.ipynb with https://github.com/meta-llama/llama-stack/pull/1402