### PR TITLE
chore: remove litellm type conversion

### DIFF
--- a/src/llama_stack_client/lib/agents/client_tool.py
+++ b/src/llama_stack_client/lib/agents/client_tool.py
@@ -197,8 +197,7 @@ def client_tool(func: T) -> ClientTool:
                 params[name] = Parameter(
                     name=name,
                     description=param_doc or f"Parameter {name}",
-                    # Hack: litellm/openai expects "string" for str type
-                    parameter_type=type_hint.__name__ if type_hint.__name__ != "str" else "string",
+                    parameter_type=type_hint.__name__,
                     default=(param.default if param.default != inspect.Parameter.empty else None),
                     required=is_required,
                 )


### PR DESCRIPTION

Summary:
Moving this to litellm inference instead https://github.com/meta-llama/llama-stack/pull/1565

Test Plan:
LLAMA_STACK_CONFIG=fireworks pytest -s -v tests/integration/agents/test_agents.py --safety-shield meta-llama/Llama-Guard-3-8B --text-model meta-llama/Llama-3.1-8B-Instruct