### PR TITLE
fix: validate endpoint url

### DIFF
--- a/src/llama_stack_client/lib/cli/configure.py
+++ b/src/llama_stack_client/lib/cli/configure.py
@@ -10,6 +10,7 @@ import click
 import yaml
 from prompt_toolkit import prompt
 from prompt_toolkit.validation import Validator
+from urllib.parse import urlparse
 
 from llama_stack_client.lib.cli.constants import LLAMA_STACK_CLIENT_CONFIG_DIR, get_config_file_path
 
@@ -36,8 +37,8 @@ def configure(endpoint: str | None, api_key: str | None):
         final_endpoint = prompt(
             "> Enter the endpoint of the Llama Stack distribution server: ",
             validator=Validator.from_callable(
-                lambda x: len(x) > 0,
-                error_message="Endpoint cannot be empty, please enter a valid endpoint",
+                lambda x: len(x) > 0 and (parsed := urlparse(x)).scheme and parsed.netloc,
+                error_message="Endpoint cannot be empty and must be a valid URL, please enter a valid endpoint",
             ),
         )
 


### PR DESCRIPTION
# What does this PR do?

currently `llama-stack-client configure` allows a user to set up with a invalid URL such as ` ['::', '0.0.0.0']:8321` and then any subsequent command fails due to improperly reading the bad URL from the config.yaml

## Test Plan

after: 

<img width="775" alt="Screenshot 2025-03-12 at 2 03 14 PM" src="https://github.com/user-attachments/assets/746d1e13-b8e7-4ad9-99dd-6e50069c2641" />