### PR TITLE
fix: `llama-stack-client provider inspect` should use retrieve

### DIFF
--- a/src/llama_stack_client/lib/cli/providers/inspect.py
+++ b/src/llama_stack_client/lib/cli/providers/inspect.py
@@ -14,9 +14,9 @@ def inspect_provider(ctx, provider_id):
     client = ctx.obj["client"]
     console = Console()
 
-    providers_response = client.providers.inspect(provider_id=provider_id)
+    providers_response = client.providers.retrieve(provider_id=provider_id)
 
-    if providers_response is None:
+    if not providers_response:
         click.secho("Provider not found", fg="red")
         raise click.exceptions.Exit(1)
 


### PR DESCRIPTION

# What does this PR do?

after regenerating the client with stainless and updating the openAPI spec, `inspect` is now `retreive`. fix `llama-stack-client provider inspect`

## Test Plan

<img width="450" alt="Screenshot 2025-03-14 at 7 55 32 AM" src="https://github.com/user-attachments/assets/f37db091-9da5-4908-a6af-85a17b4aeb01" />

