### PR TITLE
remove override in react agent 

### DIFF
--- a/src/llama_stack_client/lib/agents/react/tool_parser.py
+++ b/src/llama_stack_client/lib/agents/react/tool_parser.py
@@ -33,7 +33,6 @@ class ReActOutput(BaseModel):
 
 
 class ReActToolParser(ToolParser):
-    @override
     def get_tool_calls(self, output_message: CompletionMessage) -> List[ToolCall]:
         tool_calls = []
         response_text = str(output_message.content)


### PR DESCRIPTION
# What does this PR do?
Running into this error: 
```
python test_vision.py
Traceback (most recent call last):
  File "/Users/kaiwu/work/internal-llama-stack-apps/examples/computer_use/test_vision.py", line 5, in <module>
    from llama_stack_client.lib.agents.react.agent import ReActAgent
  File "/opt/homebrew/anaconda3/envs/dmg/lib/python3.10/site-packages/llama_stack_client/lib/agents/react/agent.py", line 20, in <module>
    from .tool_parser import ReActOutput, ReActToolParser
  File "/opt/homebrew/anaconda3/envs/dmg/lib/python3.10/site-packages/llama_stack_client/lib/agents/react/tool_parser.py", line 35, in <module>
    class ReActToolParser(ToolParser):
  File "/opt/homebrew/anaconda3/envs/dmg/lib/python3.10/site-packages/llama_stack_client/lib/agents/react/tool_parser.py", line 36, in ReActToolParser
    @override
NameError: name 'override' is not defined
```
Removing [this line](https://github.com/meta-llama/llama-stack-client-python/blame/main/src/llama_stack_client/lib/agents/react/tool_parser.py#L36) fixed this error.
Now I can run  react agent:
```
python test_vision.py
ChatCompletionResponse(
│   completion_message=CompletionMessage(
│   │   content="The image features a close-up of a Golden Retriever puppy, with the dog's head and upper body prominently displayed. The puppy is centered in the frame, facing forward, and its mouth is open, revealing its tongue. The background of the image is blurred, but it appears to be a natural setting, possibly outdoors or in a park.\n\n**Key Features:**\n\n* **Dog Breed:** The dog in the image is a Golden Retriever puppy.\n* **Facial Expression:** The puppy's mouth is open, showing its tongue.\n* **Background:** The background is blurred, suggesting a natural setting.\n* **Overall Impression:** The image conveys a sense of joy and playfulness, capturing the energetic and friendly nature of the Golden Retriever breed.",
│   │   role='assistant',
│   │   stop_reason='end_of_turn',
│   │   tool_calls=[]
│   ),
│   logprobs=None,
│   metrics=[
│   │   Metric(metric='prompt_tokens', value=22.0, unit=None),
│   │   Metric(metric='completion_tokens', value=166.0, unit=None),
│   │   Metric(metric='total_tokens', value=188.0, unit=None)
│   ]
)
```

## Test Plan
[Describe the tests you ran to verify your changes with result summaries. *Provide clear instructions so the plan can be easily re-executed.*]

[//]: # (## Documentation)
[//]: # (- [ ] Added a Changelog entry if the change is significant)
