### PR TITLE
CLI fix: Fix CLI for datasets register

### DIFF
--- a/src/llama_stack_client/lib/cli/datasets/list.py
+++ b/src/llama_stack_client/lib/cli/datasets/list.py
@@ -19,7 +19,7 @@ def list_datasets(ctx):
     """Show available datasets on distribution endpoint"""
     client = ctx.obj["client"]
     console = Console()
-    headers = ["identifier", "provider_id", "metadata", "type"]
+    headers = ["identifier", "provider_id", "metadata", "type", "purpose"]
 
     datasets_list_response = client.datasets.list()
     if datasets_list_response:


### PR DESCRIPTION
# What does this PR do?
Fixed the `llama-stack-cli datasets register` to match the modified API (some mandatory parameters
were removed and a new one was added).
Added the dataset purpose to the output of the `llama-stack-cli datasets list` command.

[//]: # (If resolving an issue, uncomment and update the line below)
Closes #211

## Test Plan
[Describe the tests you ran to verify your changes with result summaries. *Provide clear instructions so the plan can be easily re-executed.*]

[//]: # (## Documentation)
[//]: # (- [ ] Added a Changelog entry if the change is significant)
