### PR TITLE
mcp: Remove CLI functionality with missing deps (fire, mcp)

### DIFF
--- a/src/llama_stack_client/lib/tools/mcp_oauth.py
+++ b/src/llama_stack_client/lib/tools/mcp_oauth.py
@@ -1,4 +1,3 @@
-import asyncio
 import base64
 import hashlib
 import logging

--- a/src/llama_stack_client/lib/tools/mcp_oauth.py
+++ b/src/llama_stack_client/lib/tools/mcp_oauth.py
@@ -10,7 +10,6 @@ import urllib.parse
 import uuid
 from http.server import BaseHTTPRequestHandler, HTTPServer
 
-import fire
 import requests
 
 logging.basicConfig(level=logging.INFO)
@@ -265,33 +264,3 @@ class CallbackServer(HTTPServer):
 def get_oauth_token_for_mcp_server(url: str) -> str | None:
     helper = McpOAuthHelper(url)
     return helper.initiate_auth_flow()
-
-
-async def run_main(url: str):
-    from mcp import ClientSession
-    from mcp.client.sse import sse_client
-
-    token = get_oauth_token_for_mcp_server(url)
-    if not token:
-        return
-
-    headers = {
-        "Authorization": f"Bearer {token}",
-    }
-
-    async with sse_client(url, headers=headers) as streams:
-        async with ClientSession(*streams) as session:
-            await session.initialize()
-            result = await session.list_tools()
-
-            logger.info(f"Tools: {len(result.tools)}, showing first 5:")
-            for t in result.tools[:5]:
-                logger.info(f"{t.name}: {t.description}")
-
-
-def main(url: str):
-    asyncio.run(run_main(url))
-
-
-if __name__ == "__main__":
-    fire.Fire(main)


### PR DESCRIPTION
# What does this PR do?
Removes what I believe was test code. Alternative fix is to add `fire` and `mcp` as project dependencies. 

```
  File "/home/rbost/code/ifd-backend-api/ifd/core/agents/llama_stack.py", line 8, in <module>
    from llama_stack_client import AsyncLlamaStackClient
  File "/home/rbost/code/ifd-backend-api/.venv/lib/python3.13/site-packages/llama_stack_client/__init__.py", line 42, in <module>
    from .lib.agents.agent import Agent
  File "/home/rbost/code/ifd-backend-api/.venv/lib/python3.13/site-packages/llama_stack_client/lib/__init__.py", line 7, in <module>
    from .tools.mcp_oauth import get_oauth_token_for_mcp_server
  File "/home/rbost/code/ifd-backend-api/.venv/lib/python3.13/site-packages/llama_stack_client/lib/tools/mcp_oauth.py", line 13, in <module>
    import fire
ModuleNotFoundError: No module named 'fire'
```

## Test Plan
I have an application using llama-stack-client-python that was failing to launch due to above stack trace. This PR resolves that stack trace by simply removing the code.

