### PR TITLE
fix: correct toolgroups_id parameter name on unregister call

### DIFF
--- a/src/llama_stack_client/lib/cli/toolgroups/toolgroups.py
+++ b/src/llama_stack_client/lib/cli/toolgroups/toolgroups.py
@@ -118,7 +118,7 @@ def unregister_toolgroup(ctx, toolgroup_id: str):
     client = ctx.obj["client"]
     console = Console()
 
-    response = client.toolgroups.unregister(tool_group_id=toolgroup_id)
+    response = client.toolgroups.unregister(toolgroup_id=toolgroup_id)
     if response:
         console.print(f"[green]Successfully deleted toolgroup {toolgroup_id}[/green]")
 


### PR DESCRIPTION
# What does this PR do?

Fixes this error with `toolgroups unregister` :+1: 

```
$ llama-stack-client toolgroups unregister mcp::gabes-proto
╭─────────────────────────────────────────────────────────────────────────────────────────────╮
│ Failed to unregister toolgroup                                                              │
│                                                                                             │
│ Error Type: TypeError                                                                       │
│ Details: ToolgroupsResource.unregister() got an unexpected keyword argument 'tool_group_id' │
╰─────────────────────────────────────────────────────────────────────────────────────────────╯
```

with this fix, you get 

```
$ llama-stack-client toolgroups unregister "mcp::gabes-proto"
INFO:httpx:HTTP Request: DELETE http://localhost:8321/v1/toolgroups/mcp::gabes-proto "HTTP/1.1 200 OK"
```

did not find an open issue ... if having one is critical, please advise and I'll create one - thanks

## Test Plan

Register a tool and then try to unregister it

