### PR TITLE
Sync updates from stainless: a3a4573f7eee99d69b26e5e8d48beeb61f82fe7e

### DIFF
--- a/src/llama_stack_client/__init__.py
+++ b/src/llama_stack_client/__init__.py
@@ -36,7 +36,7 @@ from ._exceptions import (
     UnprocessableEntityError,
     APIResponseValidationError,
 )
-from ._base_client import DefaultHttpxClient, DefaultAsyncHttpxClient
+from ._base_client import DefaultHttpxClient, DefaultAioHttpClient, DefaultAsyncHttpxClient
 from ._utils._logs import setup_logging as _setup_logging
 
 from .lib.agents.agent import Agent
@@ -84,6 +84,7 @@ __all__ = [
     "DEFAULT_CONNECTION_LIMITS",
     "DefaultHttpxClient",
     "DefaultAsyncHttpxClient",
+    "DefaultAioHttpClient",
 ]
 
 if not _t.TYPE_CHECKING:

--- a/src/llama_stack_client/_base_client.py
+++ b/src/llama_stack_client/_base_client.py
@@ -1289,6 +1289,24 @@ class _DefaultAsyncHttpxClient(httpx.AsyncClient):
         super().__init__(**kwargs)
 
 
+try:
+    import httpx_aiohttp
+except ImportError:
+
+    class _DefaultAioHttpClient(httpx.AsyncClient):
+        def __init__(self, **_kwargs: Any) -> None:
+            raise RuntimeError("To use the aiohttp client you must have installed the package with the `aiohttp` extra")
+else:
+
+    class _DefaultAioHttpClient(httpx_aiohttp.HttpxAiohttpClient):  # type: ignore
+        def __init__(self, **kwargs: Any) -> None:
+            kwargs.setdefault("timeout", DEFAULT_TIMEOUT)
+            kwargs.setdefault("limits", DEFAULT_CONNECTION_LIMITS)
+            kwargs.setdefault("follow_redirects", True)
+
+            super().__init__(**kwargs)
+
+
 if TYPE_CHECKING:
     DefaultAsyncHttpxClient = httpx.AsyncClient
     """An alias to `httpx.AsyncClient` that provides the same defaults that this SDK
@@ -1297,8 +1315,12 @@ if TYPE_CHECKING:
     This is useful because overriding the `http_client` with your own instance of
     `httpx.AsyncClient` will result in httpx's defaults being used, not ours.
     """
+
+    DefaultAioHttpClient = httpx.AsyncClient
+    """An alias to `httpx.AsyncClient` that changes the default HTTP transport to `aiohttp`."""
 else:
     DefaultAsyncHttpxClient = _DefaultAsyncHttpxClient
+    DefaultAioHttpClient = _DefaultAioHttpClient
 
 
 class AsyncHttpxClientWrapper(DefaultAsyncHttpxClient):

--- a/src/llama_stack_client/_files.py
+++ b/src/llama_stack_client/_files.py
@@ -34,7 +34,7 @@ def assert_is_file_content(obj: object, *, key: str | None = None) -> None:
     if not is_file_content(obj):
         prefix = f"Expected entry at `{key}`" if key is not None else f"Expected file input `{obj!r}`"
         raise RuntimeError(
-            f"{prefix} to be bytes, an io.IOBase instance, PathLike or a tuple but received {type(obj)} instead. See https://github.com/stainless-sdks/llama-stack-python/tree/main#file-uploads"
+            f"{prefix} to be bytes, an io.IOBase instance, PathLike or a tuple but received {type(obj)} instead. See https://github.com/llamastack/llama-stack-client-python/tree/main#file-uploads"
         ) from None
 
 

--- a/src/llama_stack_client/resources/agents/agents.py
+++ b/src/llama_stack_client/resources/agents/agents.py
@@ -65,7 +65,7 @@ class AgentsResource(SyncAPIResource):
         This property can be used as a prefix for any HTTP method call to return
         the raw response object instead of the parsed content.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#accessing-raw-response-data-eg-headers
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#accessing-raw-response-data-eg-headers
         """
         return AgentsResourceWithRawResponse(self)
 
@@ -74,7 +74,7 @@ class AgentsResource(SyncAPIResource):
         """
         An alternative to `.with_raw_response` that doesn't eagerly read the response body.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#with_streaming_response
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#with_streaming_response
         """
         return AgentsResourceWithStreamingResponse(self)
 
@@ -166,7 +166,7 @@ class AsyncAgentsResource(AsyncAPIResource):
         This property can be used as a prefix for any HTTP method call to return
         the raw response object instead of the parsed content.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#accessing-raw-response-data-eg-headers
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#accessing-raw-response-data-eg-headers
         """
         return AsyncAgentsResourceWithRawResponse(self)
 
@@ -175,7 +175,7 @@ class AsyncAgentsResource(AsyncAPIResource):
         """
         An alternative to `.with_raw_response` that doesn't eagerly read the response body.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#with_streaming_response
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#with_streaming_response
         """
         return AsyncAgentsResourceWithStreamingResponse(self)
 

--- a/src/llama_stack_client/resources/agents/session.py
+++ b/src/llama_stack_client/resources/agents/session.py
@@ -31,7 +31,7 @@ class SessionResource(SyncAPIResource):
         This property can be used as a prefix for any HTTP method call to return
         the raw response object instead of the parsed content.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#accessing-raw-response-data-eg-headers
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#accessing-raw-response-data-eg-headers
         """
         return SessionResourceWithRawResponse(self)
 
@@ -40,7 +40,7 @@ class SessionResource(SyncAPIResource):
         """
         An alternative to `.with_raw_response` that doesn't eagerly read the response body.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#with_streaming_response
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#with_streaming_response
         """
         return SessionResourceWithStreamingResponse(self)
 
@@ -169,7 +169,7 @@ class AsyncSessionResource(AsyncAPIResource):
         This property can be used as a prefix for any HTTP method call to return
         the raw response object instead of the parsed content.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#accessing-raw-response-data-eg-headers
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#accessing-raw-response-data-eg-headers
         """
         return AsyncSessionResourceWithRawResponse(self)
 
@@ -178,7 +178,7 @@ class AsyncSessionResource(AsyncAPIResource):
         """
         An alternative to `.with_raw_response` that doesn't eagerly read the response body.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#with_streaming_response
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#with_streaming_response
         """
         return AsyncSessionResourceWithStreamingResponse(self)
 

--- a/src/llama_stack_client/resources/agents/steps.py
+++ b/src/llama_stack_client/resources/agents/steps.py
@@ -26,7 +26,7 @@ class StepsResource(SyncAPIResource):
         This property can be used as a prefix for any HTTP method call to return
         the raw response object instead of the parsed content.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#accessing-raw-response-data-eg-headers
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#accessing-raw-response-data-eg-headers
         """
         return StepsResourceWithRawResponse(self)
 
@@ -35,7 +35,7 @@ class StepsResource(SyncAPIResource):
         """
         An alternative to `.with_raw_response` that doesn't eagerly read the response body.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#with_streaming_response
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#with_streaming_response
         """
         return StepsResourceWithStreamingResponse(self)
 
@@ -89,7 +89,7 @@ class AsyncStepsResource(AsyncAPIResource):
         This property can be used as a prefix for any HTTP method call to return
         the raw response object instead of the parsed content.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#accessing-raw-response-data-eg-headers
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#accessing-raw-response-data-eg-headers
         """
         return AsyncStepsResourceWithRawResponse(self)
 
@@ -98,7 +98,7 @@ class AsyncStepsResource(AsyncAPIResource):
         """
         An alternative to `.with_raw_response` that doesn't eagerly read the response body.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#with_streaming_response
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#with_streaming_response
         """
         return AsyncStepsResourceWithStreamingResponse(self)
 

--- a/src/llama_stack_client/resources/agents/turn.py
+++ b/src/llama_stack_client/resources/agents/turn.py
@@ -34,7 +34,7 @@ class TurnResource(SyncAPIResource):
         This property can be used as a prefix for any HTTP method call to return
         the raw response object instead of the parsed content.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#accessing-raw-response-data-eg-headers
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#accessing-raw-response-data-eg-headers
         """
         return TurnResourceWithRawResponse(self)
 
@@ -43,7 +43,7 @@ class TurnResource(SyncAPIResource):
         """
         An alternative to `.with_raw_response` that doesn't eagerly read the response body.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#with_streaming_response
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#with_streaming_response
         """
         return TurnResourceWithStreamingResponse(self)
 
@@ -428,7 +428,7 @@ class AsyncTurnResource(AsyncAPIResource):
         This property can be used as a prefix for any HTTP method call to return
         the raw response object instead of the parsed content.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#accessing-raw-response-data-eg-headers
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#accessing-raw-response-data-eg-headers
         """
         return AsyncTurnResourceWithRawResponse(self)
 
@@ -437,7 +437,7 @@ class AsyncTurnResource(AsyncAPIResource):
         """
         An alternative to `.with_raw_response` that doesn't eagerly read the response body.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#with_streaming_response
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#with_streaming_response
         """
         return AsyncTurnResourceWithStreamingResponse(self)
 

--- a/src/llama_stack_client/resources/benchmarks.py
+++ b/src/llama_stack_client/resources/benchmarks.py
@@ -32,7 +32,7 @@ class BenchmarksResource(SyncAPIResource):
         This property can be used as a prefix for any HTTP method call to return
         the raw response object instead of the parsed content.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#accessing-raw-response-data-eg-headers
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#accessing-raw-response-data-eg-headers
         """
         return BenchmarksResourceWithRawResponse(self)
 
@@ -41,7 +41,7 @@ class BenchmarksResource(SyncAPIResource):
         """
         An alternative to `.with_raw_response` that doesn't eagerly read the response body.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#with_streaming_response
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#with_streaming_response
         """
         return BenchmarksResourceWithStreamingResponse(self)
 
@@ -169,7 +169,7 @@ class AsyncBenchmarksResource(AsyncAPIResource):
         This property can be used as a prefix for any HTTP method call to return
         the raw response object instead of the parsed content.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#accessing-raw-response-data-eg-headers
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#accessing-raw-response-data-eg-headers
         """
         return AsyncBenchmarksResourceWithRawResponse(self)
 
@@ -178,7 +178,7 @@ class AsyncBenchmarksResource(AsyncAPIResource):
         """
         An alternative to `.with_raw_response` that doesn't eagerly read the response body.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#with_streaming_response
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#with_streaming_response
         """
         return AsyncBenchmarksResourceWithStreamingResponse(self)
 

--- a/src/llama_stack_client/resources/chat/chat.py
+++ b/src/llama_stack_client/resources/chat/chat.py
@@ -27,7 +27,7 @@ class ChatResource(SyncAPIResource):
         This property can be used as a prefix for any HTTP method call to return
         the raw response object instead of the parsed content.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#accessing-raw-response-data-eg-headers
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#accessing-raw-response-data-eg-headers
         """
         return ChatResourceWithRawResponse(self)
 
@@ -36,7 +36,7 @@ class ChatResource(SyncAPIResource):
         """
         An alternative to `.with_raw_response` that doesn't eagerly read the response body.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#with_streaming_response
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#with_streaming_response
         """
         return ChatResourceWithStreamingResponse(self)
 
@@ -52,7 +52,7 @@ class AsyncChatResource(AsyncAPIResource):
         This property can be used as a prefix for any HTTP method call to return
         the raw response object instead of the parsed content.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#accessing-raw-response-data-eg-headers
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#accessing-raw-response-data-eg-headers
         """
         return AsyncChatResourceWithRawResponse(self)
 
@@ -61,7 +61,7 @@ class AsyncChatResource(AsyncAPIResource):
         """
         An alternative to `.with_raw_response` that doesn't eagerly read the response body.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#with_streaming_response
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#with_streaming_response
         """
         return AsyncChatResourceWithStreamingResponse(self)
 

--- a/src/llama_stack_client/resources/chat/completions.py
+++ b/src/llama_stack_client/resources/chat/completions.py
@@ -35,7 +35,7 @@ class CompletionsResource(SyncAPIResource):
         This property can be used as a prefix for any HTTP method call to return
         the raw response object instead of the parsed content.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#accessing-raw-response-data-eg-headers
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#accessing-raw-response-data-eg-headers
         """
         return CompletionsResourceWithRawResponse(self)
 
@@ -44,7 +44,7 @@ class CompletionsResource(SyncAPIResource):
         """
         An alternative to `.with_raw_response` that doesn't eagerly read the response body.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#with_streaming_response
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#with_streaming_response
         """
         return CompletionsResourceWithStreamingResponse(self)
 
@@ -515,7 +515,7 @@ class AsyncCompletionsResource(AsyncAPIResource):
         This property can be used as a prefix for any HTTP method call to return
         the raw response object instead of the parsed content.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#accessing-raw-response-data-eg-headers
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#accessing-raw-response-data-eg-headers
         """
         return AsyncCompletionsResourceWithRawResponse(self)
 
@@ -524,7 +524,7 @@ class AsyncCompletionsResource(AsyncAPIResource):
         """
         An alternative to `.with_raw_response` that doesn't eagerly read the response body.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#with_streaming_response
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#with_streaming_response
         """
         return AsyncCompletionsResourceWithStreamingResponse(self)
 

--- a/src/llama_stack_client/resources/completions.py
+++ b/src/llama_stack_client/resources/completions.py
@@ -32,7 +32,7 @@ class CompletionsResource(SyncAPIResource):
         This property can be used as a prefix for any HTTP method call to return
         the raw response object instead of the parsed content.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#accessing-raw-response-data-eg-headers
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#accessing-raw-response-data-eg-headers
         """
         return CompletionsResourceWithRawResponse(self)
 
@@ -41,7 +41,7 @@ class CompletionsResource(SyncAPIResource):
         """
         An alternative to `.with_raw_response` that doesn't eagerly read the response body.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#with_streaming_response
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#with_streaming_response
         """
         return CompletionsResourceWithStreamingResponse(self)
 
@@ -370,7 +370,7 @@ class AsyncCompletionsResource(AsyncAPIResource):
         This property can be used as a prefix for any HTTP method call to return
         the raw response object instead of the parsed content.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#accessing-raw-response-data-eg-headers
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#accessing-raw-response-data-eg-headers
         """
         return AsyncCompletionsResourceWithRawResponse(self)
 
@@ -379,7 +379,7 @@ class AsyncCompletionsResource(AsyncAPIResource):
         """
         An alternative to `.with_raw_response` that doesn't eagerly read the response body.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#with_streaming_response
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#with_streaming_response
         """
         return AsyncCompletionsResourceWithStreamingResponse(self)
 

--- a/src/llama_stack_client/resources/datasets.py
+++ b/src/llama_stack_client/resources/datasets.py
@@ -35,7 +35,7 @@ class DatasetsResource(SyncAPIResource):
         This property can be used as a prefix for any HTTP method call to return
         the raw response object instead of the parsed content.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#accessing-raw-response-data-eg-headers
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#accessing-raw-response-data-eg-headers
         """
         return DatasetsResourceWithRawResponse(self)
 
@@ -44,7 +44,7 @@ class DatasetsResource(SyncAPIResource):
         """
         An alternative to `.with_raw_response` that doesn't eagerly read the response body.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#with_streaming_response
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#with_streaming_response
         """
         return DatasetsResourceWithStreamingResponse(self)
 
@@ -273,7 +273,7 @@ class AsyncDatasetsResource(AsyncAPIResource):
         This property can be used as a prefix for any HTTP method call to return
         the raw response object instead of the parsed content.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#accessing-raw-response-data-eg-headers
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#accessing-raw-response-data-eg-headers
         """
         return AsyncDatasetsResourceWithRawResponse(self)
 
@@ -282,7 +282,7 @@ class AsyncDatasetsResource(AsyncAPIResource):
         """
         An alternative to `.with_raw_response` that doesn't eagerly read the response body.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#with_streaming_response
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#with_streaming_response
         """
         return AsyncDatasetsResourceWithStreamingResponse(self)
 

--- a/src/llama_stack_client/resources/embeddings.py
+++ b/src/llama_stack_client/resources/embeddings.py
@@ -30,7 +30,7 @@ class EmbeddingsResource(SyncAPIResource):
         This property can be used as a prefix for any HTTP method call to return
         the raw response object instead of the parsed content.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#accessing-raw-response-data-eg-headers
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#accessing-raw-response-data-eg-headers
         """
         return EmbeddingsResourceWithRawResponse(self)
 
@@ -39,7 +39,7 @@ class EmbeddingsResource(SyncAPIResource):
         """
         An alternative to `.with_raw_response` that doesn't eagerly read the response body.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#with_streaming_response
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#with_streaming_response
         """
         return EmbeddingsResourceWithStreamingResponse(self)
 
@@ -112,7 +112,7 @@ class AsyncEmbeddingsResource(AsyncAPIResource):
         This property can be used as a prefix for any HTTP method call to return
         the raw response object instead of the parsed content.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#accessing-raw-response-data-eg-headers
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#accessing-raw-response-data-eg-headers
         """
         return AsyncEmbeddingsResourceWithRawResponse(self)
 
@@ -121,7 +121,7 @@ class AsyncEmbeddingsResource(AsyncAPIResource):
         """
         An alternative to `.with_raw_response` that doesn't eagerly read the response body.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#with_streaming_response
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#with_streaming_response
         """
         return AsyncEmbeddingsResourceWithStreamingResponse(self)
 

--- a/src/llama_stack_client/resources/eval/eval.py
+++ b/src/llama_stack_client/resources/eval/eval.py
@@ -49,7 +49,7 @@ class EvalResource(SyncAPIResource):
         This property can be used as a prefix for any HTTP method call to return
         the raw response object instead of the parsed content.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#accessing-raw-response-data-eg-headers
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#accessing-raw-response-data-eg-headers
         """
         return EvalResourceWithRawResponse(self)
 
@@ -58,7 +58,7 @@ class EvalResource(SyncAPIResource):
         """
         An alternative to `.with_raw_response` that doesn't eagerly read the response body.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#with_streaming_response
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#with_streaming_response
         """
         return EvalResourceWithStreamingResponse(self)
 
@@ -250,7 +250,7 @@ class AsyncEvalResource(AsyncAPIResource):
         This property can be used as a prefix for any HTTP method call to return
         the raw response object instead of the parsed content.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#accessing-raw-response-data-eg-headers
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#accessing-raw-response-data-eg-headers
         """
         return AsyncEvalResourceWithRawResponse(self)
 
@@ -259,7 +259,7 @@ class AsyncEvalResource(AsyncAPIResource):
         """
         An alternative to `.with_raw_response` that doesn't eagerly read the response body.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#with_streaming_response
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#with_streaming_response
         """
         return AsyncEvalResourceWithStreamingResponse(self)
 

--- a/src/llama_stack_client/resources/eval/jobs.py
+++ b/src/llama_stack_client/resources/eval/jobs.py
@@ -27,7 +27,7 @@ class JobsResource(SyncAPIResource):
         This property can be used as a prefix for any HTTP method call to return
         the raw response object instead of the parsed content.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#accessing-raw-response-data-eg-headers
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#accessing-raw-response-data-eg-headers
         """
         return JobsResourceWithRawResponse(self)
 
@@ -36,7 +36,7 @@ class JobsResource(SyncAPIResource):
         """
         An alternative to `.with_raw_response` that doesn't eagerly read the response body.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#with_streaming_response
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#with_streaming_response
         """
         return JobsResourceWithStreamingResponse(self)
 
@@ -157,7 +157,7 @@ class AsyncJobsResource(AsyncAPIResource):
         This property can be used as a prefix for any HTTP method call to return
         the raw response object instead of the parsed content.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#accessing-raw-response-data-eg-headers
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#accessing-raw-response-data-eg-headers
         """
         return AsyncJobsResourceWithRawResponse(self)
 
@@ -166,7 +166,7 @@ class AsyncJobsResource(AsyncAPIResource):
         """
         An alternative to `.with_raw_response` that doesn't eagerly read the response body.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#with_streaming_response
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#with_streaming_response
         """
         return AsyncJobsResourceWithStreamingResponse(self)
 

--- a/src/llama_stack_client/resources/files.py
+++ b/src/llama_stack_client/resources/files.py
@@ -33,7 +33,7 @@ class FilesResource(SyncAPIResource):
         This property can be used as a prefix for any HTTP method call to return
         the raw response object instead of the parsed content.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#accessing-raw-response-data-eg-headers
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#accessing-raw-response-data-eg-headers
         """
         return FilesResourceWithRawResponse(self)
 
@@ -42,7 +42,7 @@ class FilesResource(SyncAPIResource):
         """
         An alternative to `.with_raw_response` that doesn't eagerly read the response body.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#with_streaming_response
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#with_streaming_response
         """
         return FilesResourceWithStreamingResponse(self)
 
@@ -264,7 +264,7 @@ class AsyncFilesResource(AsyncAPIResource):
         This property can be used as a prefix for any HTTP method call to return
         the raw response object instead of the parsed content.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#accessing-raw-response-data-eg-headers
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#accessing-raw-response-data-eg-headers
         """
         return AsyncFilesResourceWithRawResponse(self)
 
@@ -273,7 +273,7 @@ class AsyncFilesResource(AsyncAPIResource):
         """
         An alternative to `.with_raw_response` that doesn't eagerly read the response body.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#with_streaming_response
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#with_streaming_response
         """
         return AsyncFilesResourceWithStreamingResponse(self)
 

--- a/src/llama_stack_client/resources/inference.py
+++ b/src/llama_stack_client/resources/inference.py
@@ -48,7 +48,7 @@ class InferenceResource(SyncAPIResource):
         This property can be used as a prefix for any HTTP method call to return
         the raw response object instead of the parsed content.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#accessing-raw-response-data-eg-headers
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#accessing-raw-response-data-eg-headers
         """
         return InferenceResourceWithRawResponse(self)
 
@@ -57,7 +57,7 @@ class InferenceResource(SyncAPIResource):
         """
         An alternative to `.with_raw_response` that doesn't eagerly read the response body.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#with_streaming_response
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#with_streaming_response
         """
         return InferenceResourceWithStreamingResponse(self)
 
@@ -686,7 +686,7 @@ class AsyncInferenceResource(AsyncAPIResource):
         This property can be used as a prefix for any HTTP method call to return
         the raw response object instead of the parsed content.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#accessing-raw-response-data-eg-headers
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#accessing-raw-response-data-eg-headers
         """
         return AsyncInferenceResourceWithRawResponse(self)
 
@@ -695,7 +695,7 @@ class AsyncInferenceResource(AsyncAPIResource):
         """
         An alternative to `.with_raw_response` that doesn't eagerly read the response body.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#with_streaming_response
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#with_streaming_response
         """
         return AsyncInferenceResourceWithStreamingResponse(self)
 

--- a/src/llama_stack_client/resources/inspect.py
+++ b/src/llama_stack_client/resources/inspect.py
@@ -27,7 +27,7 @@ class InspectResource(SyncAPIResource):
         This property can be used as a prefix for any HTTP method call to return
         the raw response object instead of the parsed content.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#accessing-raw-response-data-eg-headers
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#accessing-raw-response-data-eg-headers
         """
         return InspectResourceWithRawResponse(self)
 
@@ -36,7 +36,7 @@ class InspectResource(SyncAPIResource):
         """
         An alternative to `.with_raw_response` that doesn't eagerly read the response body.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#with_streaming_response
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#with_streaming_response
         """
         return InspectResourceWithStreamingResponse(self)
 
@@ -86,7 +86,7 @@ class AsyncInspectResource(AsyncAPIResource):
         This property can be used as a prefix for any HTTP method call to return
         the raw response object instead of the parsed content.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#accessing-raw-response-data-eg-headers
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#accessing-raw-response-data-eg-headers
         """
         return AsyncInspectResourceWithRawResponse(self)
 
@@ -95,7 +95,7 @@ class AsyncInspectResource(AsyncAPIResource):
         """
         An alternative to `.with_raw_response` that doesn't eagerly read the response body.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#with_streaming_response
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#with_streaming_response
         """
         return AsyncInspectResourceWithStreamingResponse(self)
 

--- a/src/llama_stack_client/resources/models.py
+++ b/src/llama_stack_client/resources/models.py
@@ -33,7 +33,7 @@ class ModelsResource(SyncAPIResource):
         This property can be used as a prefix for any HTTP method call to return
         the raw response object instead of the parsed content.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#accessing-raw-response-data-eg-headers
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#accessing-raw-response-data-eg-headers
         """
         return ModelsResourceWithRawResponse(self)
 
@@ -42,7 +42,7 @@ class ModelsResource(SyncAPIResource):
         """
         An alternative to `.with_raw_response` that doesn't eagerly read the response body.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#with_streaming_response
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#with_streaming_response
         """
         return ModelsResourceWithStreamingResponse(self)
 
@@ -199,7 +199,7 @@ class AsyncModelsResource(AsyncAPIResource):
         This property can be used as a prefix for any HTTP method call to return
         the raw response object instead of the parsed content.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#accessing-raw-response-data-eg-headers
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#accessing-raw-response-data-eg-headers
         """
         return AsyncModelsResourceWithRawResponse(self)
 
@@ -208,7 +208,7 @@ class AsyncModelsResource(AsyncAPIResource):
         """
         An alternative to `.with_raw_response` that doesn't eagerly read the response body.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#with_streaming_response
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#with_streaming_response
         """
         return AsyncModelsResourceWithStreamingResponse(self)
 

--- a/src/llama_stack_client/resources/post_training/job.py
+++ b/src/llama_stack_client/resources/post_training/job.py
@@ -33,7 +33,7 @@ class JobResource(SyncAPIResource):
         This property can be used as a prefix for any HTTP method call to return
         the raw response object instead of the parsed content.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#accessing-raw-response-data-eg-headers
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#accessing-raw-response-data-eg-headers
         """
         return JobResourceWithRawResponse(self)
 
@@ -42,7 +42,7 @@ class JobResource(SyncAPIResource):
         """
         An alternative to `.with_raw_response` that doesn't eagerly read the response body.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#with_streaming_response
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#with_streaming_response
         """
         return JobResourceWithStreamingResponse(self)
 
@@ -186,7 +186,7 @@ class AsyncJobResource(AsyncAPIResource):
         This property can be used as a prefix for any HTTP method call to return
         the raw response object instead of the parsed content.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#accessing-raw-response-data-eg-headers
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#accessing-raw-response-data-eg-headers
         """
         return AsyncJobResourceWithRawResponse(self)
 
@@ -195,7 +195,7 @@ class AsyncJobResource(AsyncAPIResource):
         """
         An alternative to `.with_raw_response` that doesn't eagerly read the response body.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#with_streaming_response
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#with_streaming_response
         """
         return AsyncJobResourceWithStreamingResponse(self)
 

--- a/src/llama_stack_client/resources/post_training/post_training.py
+++ b/src/llama_stack_client/resources/post_training/post_training.py
@@ -46,7 +46,7 @@ class PostTrainingResource(SyncAPIResource):
         This property can be used as a prefix for any HTTP method call to return
         the raw response object instead of the parsed content.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#accessing-raw-response-data-eg-headers
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#accessing-raw-response-data-eg-headers
         """
         return PostTrainingResourceWithRawResponse(self)
 
@@ -55,7 +55,7 @@ class PostTrainingResource(SyncAPIResource):
         """
         An alternative to `.with_raw_response` that doesn't eagerly read the response body.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#with_streaming_response
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#with_streaming_response
         """
         return PostTrainingResourceWithStreamingResponse(self)
 
@@ -193,7 +193,7 @@ class AsyncPostTrainingResource(AsyncAPIResource):
         This property can be used as a prefix for any HTTP method call to return
         the raw response object instead of the parsed content.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#accessing-raw-response-data-eg-headers
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#accessing-raw-response-data-eg-headers
         """
         return AsyncPostTrainingResourceWithRawResponse(self)
 
@@ -202,7 +202,7 @@ class AsyncPostTrainingResource(AsyncAPIResource):
         """
         An alternative to `.with_raw_response` that doesn't eagerly read the response body.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#with_streaming_response
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#with_streaming_response
         """
         return AsyncPostTrainingResourceWithStreamingResponse(self)
 

--- a/src/llama_stack_client/resources/providers.py
+++ b/src/llama_stack_client/resources/providers.py
@@ -30,7 +30,7 @@ class ProvidersResource(SyncAPIResource):
         This property can be used as a prefix for any HTTP method call to return
         the raw response object instead of the parsed content.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#accessing-raw-response-data-eg-headers
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#accessing-raw-response-data-eg-headers
         """
         return ProvidersResourceWithRawResponse(self)
 
@@ -39,7 +39,7 @@ class ProvidersResource(SyncAPIResource):
         """
         An alternative to `.with_raw_response` that doesn't eagerly read the response body.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#with_streaming_response
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#with_streaming_response
         """
         return ProvidersResourceWithStreamingResponse(self)
 
@@ -107,7 +107,7 @@ class AsyncProvidersResource(AsyncAPIResource):
         This property can be used as a prefix for any HTTP method call to return
         the raw response object instead of the parsed content.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#accessing-raw-response-data-eg-headers
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#accessing-raw-response-data-eg-headers
         """
         return AsyncProvidersResourceWithRawResponse(self)
 
@@ -116,7 +116,7 @@ class AsyncProvidersResource(AsyncAPIResource):
         """
         An alternative to `.with_raw_response` that doesn't eagerly read the response body.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#with_streaming_response
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#with_streaming_response
         """
         return AsyncProvidersResourceWithStreamingResponse(self)
 

--- a/src/llama_stack_client/resources/responses/input_items.py
+++ b/src/llama_stack_client/resources/responses/input_items.py
@@ -31,7 +31,7 @@ class InputItemsResource(SyncAPIResource):
         This property can be used as a prefix for any HTTP method call to return
         the raw response object instead of the parsed content.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#accessing-raw-response-data-eg-headers
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#accessing-raw-response-data-eg-headers
         """
         return InputItemsResourceWithRawResponse(self)
 
@@ -40,7 +40,7 @@ class InputItemsResource(SyncAPIResource):
         """
         An alternative to `.with_raw_response` that doesn't eagerly read the response body.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#with_streaming_response
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#with_streaming_response
         """
         return InputItemsResourceWithStreamingResponse(self)
 
@@ -114,7 +114,7 @@ class AsyncInputItemsResource(AsyncAPIResource):
         This property can be used as a prefix for any HTTP method call to return
         the raw response object instead of the parsed content.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#accessing-raw-response-data-eg-headers
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#accessing-raw-response-data-eg-headers
         """
         return AsyncInputItemsResourceWithRawResponse(self)
 
@@ -123,7 +123,7 @@ class AsyncInputItemsResource(AsyncAPIResource):
         """
         An alternative to `.with_raw_response` that doesn't eagerly read the response body.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#with_streaming_response
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#with_streaming_response
         """
         return AsyncInputItemsResourceWithStreamingResponse(self)
 

--- a/src/llama_stack_client/resources/responses/responses.py
+++ b/src/llama_stack_client/resources/responses/responses.py
@@ -46,7 +46,7 @@ class ResponsesResource(SyncAPIResource):
         This property can be used as a prefix for any HTTP method call to return
         the raw response object instead of the parsed content.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#accessing-raw-response-data-eg-headers
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#accessing-raw-response-data-eg-headers
         """
         return ResponsesResourceWithRawResponse(self)
 
@@ -55,7 +55,7 @@ class ResponsesResource(SyncAPIResource):
         """
         An alternative to `.with_raw_response` that doesn't eagerly read the response body.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#with_streaming_response
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#with_streaming_response
         """
         return ResponsesResourceWithStreamingResponse(self)
 
@@ -335,7 +335,7 @@ class AsyncResponsesResource(AsyncAPIResource):
         This property can be used as a prefix for any HTTP method call to return
         the raw response object instead of the parsed content.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#accessing-raw-response-data-eg-headers
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#accessing-raw-response-data-eg-headers
         """
         return AsyncResponsesResourceWithRawResponse(self)
 
@@ -344,7 +344,7 @@ class AsyncResponsesResource(AsyncAPIResource):
         """
         An alternative to `.with_raw_response` that doesn't eagerly read the response body.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#with_streaming_response
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#with_streaming_response
         """
         return AsyncResponsesResourceWithStreamingResponse(self)
 

--- a/src/llama_stack_client/resources/routes.py
+++ b/src/llama_stack_client/resources/routes.py
@@ -29,7 +29,7 @@ class RoutesResource(SyncAPIResource):
         This property can be used as a prefix for any HTTP method call to return
         the raw response object instead of the parsed content.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#accessing-raw-response-data-eg-headers
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#accessing-raw-response-data-eg-headers
         """
         return RoutesResourceWithRawResponse(self)
 
@@ -38,7 +38,7 @@ class RoutesResource(SyncAPIResource):
         """
         An alternative to `.with_raw_response` that doesn't eagerly read the response body.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#with_streaming_response
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#with_streaming_response
         """
         return RoutesResourceWithStreamingResponse(self)
 
@@ -73,7 +73,7 @@ class AsyncRoutesResource(AsyncAPIResource):
         This property can be used as a prefix for any HTTP method call to return
         the raw response object instead of the parsed content.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#accessing-raw-response-data-eg-headers
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#accessing-raw-response-data-eg-headers
         """
         return AsyncRoutesResourceWithRawResponse(self)
 
@@ -82,7 +82,7 @@ class AsyncRoutesResource(AsyncAPIResource):
         """
         An alternative to `.with_raw_response` that doesn't eagerly read the response body.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#with_streaming_response
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#with_streaming_response
         """
         return AsyncRoutesResourceWithStreamingResponse(self)
 

--- a/src/llama_stack_client/resources/safety.py
+++ b/src/llama_stack_client/resources/safety.py
@@ -31,7 +31,7 @@ class SafetyResource(SyncAPIResource):
         This property can be used as a prefix for any HTTP method call to return
         the raw response object instead of the parsed content.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#accessing-raw-response-data-eg-headers
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#accessing-raw-response-data-eg-headers
         """
         return SafetyResourceWithRawResponse(self)
 
@@ -40,7 +40,7 @@ class SafetyResource(SyncAPIResource):
         """
         An alternative to `.with_raw_response` that doesn't eagerly read the response body.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#with_streaming_response
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#with_streaming_response
         """
         return SafetyResourceWithStreamingResponse(self)
 
@@ -99,7 +99,7 @@ class AsyncSafetyResource(AsyncAPIResource):
         This property can be used as a prefix for any HTTP method call to return
         the raw response object instead of the parsed content.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#accessing-raw-response-data-eg-headers
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#accessing-raw-response-data-eg-headers
         """
         return AsyncSafetyResourceWithRawResponse(self)
 
@@ -108,7 +108,7 @@ class AsyncSafetyResource(AsyncAPIResource):
         """
         An alternative to `.with_raw_response` that doesn't eagerly read the response body.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#with_streaming_response
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#with_streaming_response
         """
         return AsyncSafetyResourceWithStreamingResponse(self)
 

--- a/src/llama_stack_client/resources/scoring.py
+++ b/src/llama_stack_client/resources/scoring.py
@@ -32,7 +32,7 @@ class ScoringResource(SyncAPIResource):
         This property can be used as a prefix for any HTTP method call to return
         the raw response object instead of the parsed content.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#accessing-raw-response-data-eg-headers
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#accessing-raw-response-data-eg-headers
         """
         return ScoringResourceWithRawResponse(self)
 
@@ -41,7 +41,7 @@ class ScoringResource(SyncAPIResource):
         """
         An alternative to `.with_raw_response` that doesn't eagerly read the response body.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#with_streaming_response
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#with_streaming_response
         """
         return ScoringResourceWithStreamingResponse(self)
 
@@ -143,7 +143,7 @@ class AsyncScoringResource(AsyncAPIResource):
         This property can be used as a prefix for any HTTP method call to return
         the raw response object instead of the parsed content.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#accessing-raw-response-data-eg-headers
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#accessing-raw-response-data-eg-headers
         """
         return AsyncScoringResourceWithRawResponse(self)
 
@@ -152,7 +152,7 @@ class AsyncScoringResource(AsyncAPIResource):
         """
         An alternative to `.with_raw_response` that doesn't eagerly read the response body.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#with_streaming_response
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#with_streaming_response
         """
         return AsyncScoringResourceWithStreamingResponse(self)
 

--- a/src/llama_stack_client/resources/scoring_functions.py
+++ b/src/llama_stack_client/resources/scoring_functions.py
@@ -34,7 +34,7 @@ class ScoringFunctionsResource(SyncAPIResource):
         This property can be used as a prefix for any HTTP method call to return
         the raw response object instead of the parsed content.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#accessing-raw-response-data-eg-headers
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#accessing-raw-response-data-eg-headers
         """
         return ScoringFunctionsResourceWithRawResponse(self)
 
@@ -43,7 +43,7 @@ class ScoringFunctionsResource(SyncAPIResource):
         """
         An alternative to `.with_raw_response` that doesn't eagerly read the response body.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#with_streaming_response
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#with_streaming_response
         """
         return ScoringFunctionsResourceWithStreamingResponse(self)
 
@@ -170,7 +170,7 @@ class AsyncScoringFunctionsResource(AsyncAPIResource):
         This property can be used as a prefix for any HTTP method call to return
         the raw response object instead of the parsed content.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#accessing-raw-response-data-eg-headers
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#accessing-raw-response-data-eg-headers
         """
         return AsyncScoringFunctionsResourceWithRawResponse(self)
 
@@ -179,7 +179,7 @@ class AsyncScoringFunctionsResource(AsyncAPIResource):
         """
         An alternative to `.with_raw_response` that doesn't eagerly read the response body.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#with_streaming_response
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#with_streaming_response
         """
         return AsyncScoringFunctionsResourceWithStreamingResponse(self)
 

--- a/src/llama_stack_client/resources/shields.py
+++ b/src/llama_stack_client/resources/shields.py
@@ -32,7 +32,7 @@ class ShieldsResource(SyncAPIResource):
         This property can be used as a prefix for any HTTP method call to return
         the raw response object instead of the parsed content.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#accessing-raw-response-data-eg-headers
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#accessing-raw-response-data-eg-headers
         """
         return ShieldsResourceWithRawResponse(self)
 
@@ -41,7 +41,7 @@ class ShieldsResource(SyncAPIResource):
         """
         An alternative to `.with_raw_response` that doesn't eagerly read the response body.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#with_streaming_response
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#with_streaming_response
         """
         return ShieldsResourceWithStreamingResponse(self)
 
@@ -160,7 +160,7 @@ class AsyncShieldsResource(AsyncAPIResource):
         This property can be used as a prefix for any HTTP method call to return
         the raw response object instead of the parsed content.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#accessing-raw-response-data-eg-headers
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#accessing-raw-response-data-eg-headers
         """
         return AsyncShieldsResourceWithRawResponse(self)
 
@@ -169,7 +169,7 @@ class AsyncShieldsResource(AsyncAPIResource):
         """
         An alternative to `.with_raw_response` that doesn't eagerly read the response body.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#with_streaming_response
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#with_streaming_response
         """
         return AsyncShieldsResourceWithStreamingResponse(self)
 

--- a/src/llama_stack_client/resources/synthetic_data_generation.py
+++ b/src/llama_stack_client/resources/synthetic_data_generation.py
@@ -32,7 +32,7 @@ class SyntheticDataGenerationResource(SyncAPIResource):
         This property can be used as a prefix for any HTTP method call to return
         the raw response object instead of the parsed content.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#accessing-raw-response-data-eg-headers
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#accessing-raw-response-data-eg-headers
         """
         return SyntheticDataGenerationResourceWithRawResponse(self)
 
@@ -41,7 +41,7 @@ class SyntheticDataGenerationResource(SyncAPIResource):
         """
         An alternative to `.with_raw_response` that doesn't eagerly read the response body.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#with_streaming_response
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#with_streaming_response
         """
         return SyntheticDataGenerationResourceWithStreamingResponse(self)
 
@@ -94,7 +94,7 @@ class AsyncSyntheticDataGenerationResource(AsyncAPIResource):
         This property can be used as a prefix for any HTTP method call to return
         the raw response object instead of the parsed content.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#accessing-raw-response-data-eg-headers
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#accessing-raw-response-data-eg-headers
         """
         return AsyncSyntheticDataGenerationResourceWithRawResponse(self)
 
@@ -103,7 +103,7 @@ class AsyncSyntheticDataGenerationResource(AsyncAPIResource):
         """
         An alternative to `.with_raw_response` that doesn't eagerly read the response body.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#with_streaming_response
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#with_streaming_response
         """
         return AsyncSyntheticDataGenerationResourceWithStreamingResponse(self)
 

--- a/src/llama_stack_client/resources/telemetry.py
+++ b/src/llama_stack_client/resources/telemetry.py
@@ -43,7 +43,7 @@ class TelemetryResource(SyncAPIResource):
         This property can be used as a prefix for any HTTP method call to return
         the raw response object instead of the parsed content.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#accessing-raw-response-data-eg-headers
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#accessing-raw-response-data-eg-headers
         """
         return TelemetryResourceWithRawResponse(self)
 
@@ -52,7 +52,7 @@ class TelemetryResource(SyncAPIResource):
         """
         An alternative to `.with_raw_response` that doesn't eagerly read the response body.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#with_streaming_response
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#with_streaming_response
         """
         return TelemetryResourceWithStreamingResponse(self)
 
@@ -385,7 +385,7 @@ class AsyncTelemetryResource(AsyncAPIResource):
         This property can be used as a prefix for any HTTP method call to return
         the raw response object instead of the parsed content.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#accessing-raw-response-data-eg-headers
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#accessing-raw-response-data-eg-headers
         """
         return AsyncTelemetryResourceWithRawResponse(self)
 
@@ -394,7 +394,7 @@ class AsyncTelemetryResource(AsyncAPIResource):
         """
         An alternative to `.with_raw_response` that doesn't eagerly read the response body.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#with_streaming_response
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#with_streaming_response
         """
         return AsyncTelemetryResourceWithStreamingResponse(self)
 

--- a/src/llama_stack_client/resources/tool_runtime/rag_tool.py
+++ b/src/llama_stack_client/resources/tool_runtime/rag_tool.py
@@ -33,7 +33,7 @@ class RagToolResource(SyncAPIResource):
         This property can be used as a prefix for any HTTP method call to return
         the raw response object instead of the parsed content.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#accessing-raw-response-data-eg-headers
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#accessing-raw-response-data-eg-headers
         """
         return RagToolResourceWithRawResponse(self)
 
@@ -42,7 +42,7 @@ class RagToolResource(SyncAPIResource):
         """
         An alternative to `.with_raw_response` that doesn't eagerly read the response body.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#with_streaming_response
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#with_streaming_response
         """
         return RagToolResourceWithStreamingResponse(self)
 
@@ -141,7 +141,7 @@ class AsyncRagToolResource(AsyncAPIResource):
         This property can be used as a prefix for any HTTP method call to return
         the raw response object instead of the parsed content.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#accessing-raw-response-data-eg-headers
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#accessing-raw-response-data-eg-headers
         """
         return AsyncRagToolResourceWithRawResponse(self)
 
@@ -150,7 +150,7 @@ class AsyncRagToolResource(AsyncAPIResource):
         """
         An alternative to `.with_raw_response` that doesn't eagerly read the response body.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#with_streaming_response
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#with_streaming_response
         """
         return AsyncRagToolResourceWithStreamingResponse(self)
 

--- a/src/llama_stack_client/resources/tool_runtime/tool_runtime.py
+++ b/src/llama_stack_client/resources/tool_runtime/tool_runtime.py
@@ -44,7 +44,7 @@ class ToolRuntimeResource(SyncAPIResource):
         This property can be used as a prefix for any HTTP method call to return
         the raw response object instead of the parsed content.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#accessing-raw-response-data-eg-headers
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#accessing-raw-response-data-eg-headers
         """
         return ToolRuntimeResourceWithRawResponse(self)
 
@@ -53,7 +53,7 @@ class ToolRuntimeResource(SyncAPIResource):
         """
         An alternative to `.with_raw_response` that doesn't eagerly read the response body.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#with_streaming_response
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#with_streaming_response
         """
         return ToolRuntimeResourceWithStreamingResponse(self)
 
@@ -159,7 +159,7 @@ class AsyncToolRuntimeResource(AsyncAPIResource):
         This property can be used as a prefix for any HTTP method call to return
         the raw response object instead of the parsed content.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#accessing-raw-response-data-eg-headers
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#accessing-raw-response-data-eg-headers
         """
         return AsyncToolRuntimeResourceWithRawResponse(self)
 
@@ -168,7 +168,7 @@ class AsyncToolRuntimeResource(AsyncAPIResource):
         """
         An alternative to `.with_raw_response` that doesn't eagerly read the response body.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#with_streaming_response
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#with_streaming_response
         """
         return AsyncToolRuntimeResourceWithStreamingResponse(self)
 

--- a/src/llama_stack_client/resources/toolgroups.py
+++ b/src/llama_stack_client/resources/toolgroups.py
@@ -32,7 +32,7 @@ class ToolgroupsResource(SyncAPIResource):
         This property can be used as a prefix for any HTTP method call to return
         the raw response object instead of the parsed content.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#accessing-raw-response-data-eg-headers
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#accessing-raw-response-data-eg-headers
         """
         return ToolgroupsResourceWithRawResponse(self)
 
@@ -41,7 +41,7 @@ class ToolgroupsResource(SyncAPIResource):
         """
         An alternative to `.with_raw_response` that doesn't eagerly read the response body.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#with_streaming_response
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#with_streaming_response
         """
         return ToolgroupsResourceWithStreamingResponse(self)
 
@@ -195,7 +195,7 @@ class AsyncToolgroupsResource(AsyncAPIResource):
         This property can be used as a prefix for any HTTP method call to return
         the raw response object instead of the parsed content.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#accessing-raw-response-data-eg-headers
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#accessing-raw-response-data-eg-headers
         """
         return AsyncToolgroupsResourceWithRawResponse(self)
 
@@ -204,7 +204,7 @@ class AsyncToolgroupsResource(AsyncAPIResource):
         """
         An alternative to `.with_raw_response` that doesn't eagerly read the response body.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#with_streaming_response
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#with_streaming_response
         """
         return AsyncToolgroupsResourceWithStreamingResponse(self)
 

--- a/src/llama_stack_client/resources/tools.py
+++ b/src/llama_stack_client/resources/tools.py
@@ -32,7 +32,7 @@ class ToolsResource(SyncAPIResource):
         This property can be used as a prefix for any HTTP method call to return
         the raw response object instead of the parsed content.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#accessing-raw-response-data-eg-headers
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#accessing-raw-response-data-eg-headers
         """
         return ToolsResourceWithRawResponse(self)
 
@@ -41,7 +41,7 @@ class ToolsResource(SyncAPIResource):
         """
         An alternative to `.with_raw_response` that doesn't eagerly read the response body.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#with_streaming_response
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#with_streaming_response
         """
         return ToolsResourceWithStreamingResponse(self)
 
@@ -124,7 +124,7 @@ class AsyncToolsResource(AsyncAPIResource):
         This property can be used as a prefix for any HTTP method call to return
         the raw response object instead of the parsed content.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#accessing-raw-response-data-eg-headers
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#accessing-raw-response-data-eg-headers
         """
         return AsyncToolsResourceWithRawResponse(self)
 
@@ -133,7 +133,7 @@ class AsyncToolsResource(AsyncAPIResource):
         """
         An alternative to `.with_raw_response` that doesn't eagerly read the response body.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#with_streaming_response
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#with_streaming_response
         """
         return AsyncToolsResourceWithStreamingResponse(self)
 

--- a/src/llama_stack_client/resources/vector_dbs.py
+++ b/src/llama_stack_client/resources/vector_dbs.py
@@ -33,7 +33,7 @@ class VectorDBsResource(SyncAPIResource):
         This property can be used as a prefix for any HTTP method call to return
         the raw response object instead of the parsed content.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#accessing-raw-response-data-eg-headers
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#accessing-raw-response-data-eg-headers
         """
         return VectorDBsResourceWithRawResponse(self)
 
@@ -42,7 +42,7 @@ class VectorDBsResource(SyncAPIResource):
         """
         An alternative to `.with_raw_response` that doesn't eagerly read the response body.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#with_streaming_response
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#with_streaming_response
         """
         return VectorDBsResourceWithStreamingResponse(self)
 
@@ -199,7 +199,7 @@ class AsyncVectorDBsResource(AsyncAPIResource):
         This property can be used as a prefix for any HTTP method call to return
         the raw response object instead of the parsed content.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#accessing-raw-response-data-eg-headers
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#accessing-raw-response-data-eg-headers
         """
         return AsyncVectorDBsResourceWithRawResponse(self)
 
@@ -208,7 +208,7 @@ class AsyncVectorDBsResource(AsyncAPIResource):
         """
         An alternative to `.with_raw_response` that doesn't eagerly read the response body.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#with_streaming_response
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#with_streaming_response
         """
         return AsyncVectorDBsResourceWithStreamingResponse(self)
 

--- a/src/llama_stack_client/resources/vector_io.py
+++ b/src/llama_stack_client/resources/vector_io.py
@@ -31,7 +31,7 @@ class VectorIoResource(SyncAPIResource):
         This property can be used as a prefix for any HTTP method call to return
         the raw response object instead of the parsed content.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#accessing-raw-response-data-eg-headers
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#accessing-raw-response-data-eg-headers
         """
         return VectorIoResourceWithRawResponse(self)
 
@@ -40,7 +40,7 @@ class VectorIoResource(SyncAPIResource):
         """
         An alternative to `.with_raw_response` that doesn't eagerly read the response body.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#with_streaming_response
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#with_streaming_response
         """
         return VectorIoResourceWithStreamingResponse(self)
 
@@ -152,7 +152,7 @@ class AsyncVectorIoResource(AsyncAPIResource):
         This property can be used as a prefix for any HTTP method call to return
         the raw response object instead of the parsed content.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#accessing-raw-response-data-eg-headers
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#accessing-raw-response-data-eg-headers
         """
         return AsyncVectorIoResourceWithRawResponse(self)
 
@@ -161,7 +161,7 @@ class AsyncVectorIoResource(AsyncAPIResource):
         """
         An alternative to `.with_raw_response` that doesn't eagerly read the response body.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#with_streaming_response
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#with_streaming_response
         """
         return AsyncVectorIoResourceWithStreamingResponse(self)
 

--- a/src/llama_stack_client/resources/vector_stores/files.py
+++ b/src/llama_stack_client/resources/vector_stores/files.py
@@ -30,7 +30,7 @@ class FilesResource(SyncAPIResource):
         This property can be used as a prefix for any HTTP method call to return
         the raw response object instead of the parsed content.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#accessing-raw-response-data-eg-headers
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#accessing-raw-response-data-eg-headers
         """
         return FilesResourceWithRawResponse(self)
 
@@ -39,7 +39,7 @@ class FilesResource(SyncAPIResource):
         """
         An alternative to `.with_raw_response` that doesn't eagerly read the response body.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#with_streaming_response
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#with_streaming_response
         """
         return FilesResourceWithStreamingResponse(self)
 
@@ -101,7 +101,7 @@ class AsyncFilesResource(AsyncAPIResource):
         This property can be used as a prefix for any HTTP method call to return
         the raw response object instead of the parsed content.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#accessing-raw-response-data-eg-headers
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#accessing-raw-response-data-eg-headers
         """
         return AsyncFilesResourceWithRawResponse(self)
 
@@ -110,7 +110,7 @@ class AsyncFilesResource(AsyncAPIResource):
         """
         An alternative to `.with_raw_response` that doesn't eagerly read the response body.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#with_streaming_response
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#with_streaming_response
         """
         return AsyncFilesResourceWithStreamingResponse(self)
 

--- a/src/llama_stack_client/resources/vector_stores/vector_stores.py
+++ b/src/llama_stack_client/resources/vector_stores/vector_stores.py
@@ -50,7 +50,7 @@ class VectorStoresResource(SyncAPIResource):
         This property can be used as a prefix for any HTTP method call to return
         the raw response object instead of the parsed content.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#accessing-raw-response-data-eg-headers
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#accessing-raw-response-data-eg-headers
         """
         return VectorStoresResourceWithRawResponse(self)
 
@@ -59,7 +59,7 @@ class VectorStoresResource(SyncAPIResource):
         """
         An alternative to `.with_raw_response` that doesn't eagerly read the response body.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#with_streaming_response
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#with_streaming_response
         """
         return VectorStoresResourceWithStreamingResponse(self)
 
@@ -320,6 +320,7 @@ class VectorStoresResource(SyncAPIResource):
         max_num_results: int | NotGiven = NOT_GIVEN,
         ranking_options: vector_store_search_params.RankingOptions | NotGiven = NOT_GIVEN,
         rewrite_query: bool | NotGiven = NOT_GIVEN,
+        search_mode: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -343,6 +344,8 @@ class VectorStoresResource(SyncAPIResource):
 
           rewrite_query: Whether to rewrite the natural language query for vector search (default false)
 
+          search_mode: The search mode to use - "keyword", "vector", or "hybrid" (default "vector")
+
           extra_headers: Send extra headers
 
           extra_query: Add additional query parameters to the request
@@ -362,6 +365,7 @@ class VectorStoresResource(SyncAPIResource):
                     "max_num_results": max_num_results,
                     "ranking_options": ranking_options,
                     "rewrite_query": rewrite_query,
+                    "search_mode": search_mode,
                 },
                 vector_store_search_params.VectorStoreSearchParams,
             ),
@@ -383,7 +387,7 @@ class AsyncVectorStoresResource(AsyncAPIResource):
         This property can be used as a prefix for any HTTP method call to return
         the raw response object instead of the parsed content.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#accessing-raw-response-data-eg-headers
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#accessing-raw-response-data-eg-headers
         """
         return AsyncVectorStoresResourceWithRawResponse(self)
 
@@ -392,7 +396,7 @@ class AsyncVectorStoresResource(AsyncAPIResource):
         """
         An alternative to `.with_raw_response` that doesn't eagerly read the response body.
 
-        For more information, see https://www.github.com/stainless-sdks/llama-stack-python#with_streaming_response
+        For more information, see https://www.github.com/llamastack/llama-stack-client-python#with_streaming_response
         """
         return AsyncVectorStoresResourceWithStreamingResponse(self)
 
@@ -653,6 +657,7 @@ class AsyncVectorStoresResource(AsyncAPIResource):
         max_num_results: int | NotGiven = NOT_GIVEN,
         ranking_options: vector_store_search_params.RankingOptions | NotGiven = NOT_GIVEN,
         rewrite_query: bool | NotGiven = NOT_GIVEN,
+        search_mode: str | NotGiven = NOT_GIVEN,
         # Use the following arguments if you need to pass additional parameters to the API that aren't available via kwargs.
         # The extra values given here take precedence over values defined on the client or passed to this method.
         extra_headers: Headers | None = None,
@@ -676,6 +681,8 @@ class AsyncVectorStoresResource(AsyncAPIResource):
 
           rewrite_query: Whether to rewrite the natural language query for vector search (default false)
 
+          search_mode: The search mode to use - "keyword", "vector", or "hybrid" (default "vector")
+
           extra_headers: Send extra headers
 
           extra_query: Add additional query parameters to the request
@@ -695,6 +702,7 @@ class AsyncVectorStoresResource(AsyncAPIResource):
                     "max_num_results": max_num_results,
                     "ranking_options": ranking_options,
                     "rewrite_query": rewrite_query,
+                    "search_mode": search_mode,
                 },
                 vector_store_search_params.VectorStoreSearchParams,
             ),

--- a/src/llama_stack_client/types/query_chunks_response.py
+++ b/src/llama_stack_client/types/query_chunks_response.py
@@ -5,7 +5,45 @@ from typing import Dict, List, Union, Optional
 from .._models import BaseModel
 from .shared.interleaved_content import InterleavedContent
 
-__all__ = ["QueryChunksResponse", "Chunk"]
+__all__ = ["QueryChunksResponse", "Chunk", "ChunkChunkMetadata"]
+
+
+class ChunkChunkMetadata(BaseModel):
+    chunk_embedding_dimension: Optional[int] = None
+    """The dimension of the embedding vector for the chunk."""
+
+    chunk_embedding_model: Optional[str] = None
+    """The embedding model used to create the chunk's embedding."""
+
+    chunk_id: Optional[str] = None
+    """The ID of the chunk.
+
+    If not set, it will be generated based on the document ID and content.
+    """
+
+    chunk_tokenizer: Optional[str] = None
+    """The tokenizer used to create the chunk. Default is Tiktoken."""
+
+    chunk_window: Optional[str] = None
+    """The window of the chunk, which can be used to group related chunks together."""
+
+    content_token_count: Optional[int] = None
+    """The number of tokens in the content of the chunk."""
+
+    created_timestamp: Optional[int] = None
+    """An optional timestamp indicating when the chunk was created."""
+
+    document_id: Optional[str] = None
+    """The ID of the document this chunk belongs to."""
+
+    metadata_token_count: Optional[int] = None
+    """The number of tokens in the metadata of the chunk."""
+
+    source: Optional[str] = None
+    """The source of the content, such as a URL, file path, or other identifier."""
+
+    updated_timestamp: Optional[int] = None
+    """An optional timestamp indicating when the chunk was last updated."""
 
 
 class Chunk(BaseModel):
@@ -16,12 +54,24 @@ class Chunk(BaseModel):
 
     metadata: Dict[str, Union[bool, float, str, List[object], object, None]]
     """
-    Metadata associated with the chunk, such as document ID, source, or other
-    relevant information.
+    Metadata associated with the chunk that will be used in the model context during
+    inference.
+    """
+
+    chunk_metadata: Optional[ChunkChunkMetadata] = None
+    """Metadata for the chunk that will NOT be used in the context during inference.
+
+    The `chunk_metadata` is required backend functionality.
     """
 
     embedding: Optional[List[float]] = None
     """Optional embedding for the chunk. If not provided, it will be computed later."""
+
+    stored_chunk_id: Optional[str] = None
+    """The chunk ID that is stored in the vector database.
+
+    Used for backend functionality.
+    """
 
 
 class QueryChunksResponse(BaseModel):

--- a/src/llama_stack_client/types/response_create_params.py
+++ b/src/llama_stack_client/types/response_create_params.py
@@ -17,6 +17,11 @@ __all__ = [
     "InputUnionMember1OpenAIResponseMessageContentUnionMember1OpenAIResponseInputMessageContentText",
     "InputUnionMember1OpenAIResponseMessageContentUnionMember1OpenAIResponseInputMessageContentImage",
     "InputUnionMember1OpenAIResponseMessageContentUnionMember2",
+    "InputUnionMember1OpenAIResponseMessageContentUnionMember2Annotation",
+    "InputUnionMember1OpenAIResponseMessageContentUnionMember2AnnotationOpenAIResponseAnnotationFileCitation",
+    "InputUnionMember1OpenAIResponseMessageContentUnionMember2AnnotationOpenAIResponseAnnotationCitation",
+    "InputUnionMember1OpenAIResponseMessageContentUnionMember2AnnotationOpenAIResponseAnnotationContainerFileCitation",
+    "InputUnionMember1OpenAIResponseMessageContentUnionMember2AnnotationOpenAIResponseAnnotationFilePath",
     "Text",
     "TextFormat",
     "Tool",
@@ -131,7 +136,69 @@ InputUnionMember1OpenAIResponseMessageContentUnionMember1: TypeAlias = Union[
 ]
 
 
+class InputUnionMember1OpenAIResponseMessageContentUnionMember2AnnotationOpenAIResponseAnnotationFileCitation(
+    TypedDict, total=False
+):
+    file_id: Required[str]
+
+    filename: Required[str]
+
+    index: Required[int]
+
+    type: Required[Literal["file_citation"]]
+
+
+class InputUnionMember1OpenAIResponseMessageContentUnionMember2AnnotationOpenAIResponseAnnotationCitation(
+    TypedDict, total=False
+):
+    end_index: Required[int]
+
+    start_index: Required[int]
+
+    title: Required[str]
+
+    type: Required[Literal["url_citation"]]
+
+    url: Required[str]
+
+
+class InputUnionMember1OpenAIResponseMessageContentUnionMember2AnnotationOpenAIResponseAnnotationContainerFileCitation(
+    TypedDict, total=False
+):
+    container_id: Required[str]
+
+    end_index: Required[int]
+
+    file_id: Required[str]
+
+    filename: Required[str]
+
+    start_index: Required[int]
+
+    type: Required[Literal["container_file_citation"]]
+
+
+class InputUnionMember1OpenAIResponseMessageContentUnionMember2AnnotationOpenAIResponseAnnotationFilePath(
+    TypedDict, total=False
+):
+    file_id: Required[str]
+
+    index: Required[int]
+
+    type: Required[Literal["file_path"]]
+
+
+InputUnionMember1OpenAIResponseMessageContentUnionMember2Annotation: TypeAlias = Union[
+    InputUnionMember1OpenAIResponseMessageContentUnionMember2AnnotationOpenAIResponseAnnotationFileCitation,
+    InputUnionMember1OpenAIResponseMessageContentUnionMember2AnnotationOpenAIResponseAnnotationCitation,
+    InputUnionMember1OpenAIResponseMessageContentUnionMember2AnnotationOpenAIResponseAnnotationContainerFileCitation,
+    InputUnionMember1OpenAIResponseMessageContentUnionMember2AnnotationOpenAIResponseAnnotationFilePath,
+]
+
+
 class InputUnionMember1OpenAIResponseMessageContentUnionMember2(TypedDict, total=False):
+    annotations: Required[Iterable[InputUnionMember1OpenAIResponseMessageContentUnionMember2Annotation]]
+
     text: Required[str]
 
     type: Required[Literal["output_text"]]
@@ -193,7 +260,7 @@ class Text(TypedDict, total=False):
 
 
 class ToolOpenAIResponseInputToolWebSearch(TypedDict, total=False):
-    type: Required[Literal["web_search", "web_search_preview_2025_03_11"]]
+    type: Required[Literal["web_search", "web_search_preview", "web_search_preview_2025_03_11"]]
 
     search_context_size: str
 

--- a/src/llama_stack_client/types/response_list_response.py
+++ b/src/llama_stack_client/types/response_list_response.py
@@ -21,12 +21,22 @@ __all__ = [
     "DataInputOpenAIResponseMessageContentUnionMember1OpenAIResponseInputMessageContentText",
     "DataInputOpenAIResponseMessageContentUnionMember1OpenAIResponseInputMessageContentImage",
     "DataInputOpenAIResponseMessageContentUnionMember2",
+    "DataInputOpenAIResponseMessageContentUnionMember2Annotation",
+    "DataInputOpenAIResponseMessageContentUnionMember2AnnotationOpenAIResponseAnnotationFileCitation",
+    "DataInputOpenAIResponseMessageContentUnionMember2AnnotationOpenAIResponseAnnotationCitation",
+    "DataInputOpenAIResponseMessageContentUnionMember2AnnotationOpenAIResponseAnnotationContainerFileCitation",
+    "DataInputOpenAIResponseMessageContentUnionMember2AnnotationOpenAIResponseAnnotationFilePath",
     "DataOutput",
     "DataOutputOpenAIResponseMessage",
     "DataOutputOpenAIResponseMessageContentUnionMember1",
     "DataOutputOpenAIResponseMessageContentUnionMember1OpenAIResponseInputMessageContentText",
     "DataOutputOpenAIResponseMessageContentUnionMember1OpenAIResponseInputMessageContentImage",
     "DataOutputOpenAIResponseMessageContentUnionMember2",
+    "DataOutputOpenAIResponseMessageContentUnionMember2Annotation",
+    "DataOutputOpenAIResponseMessageContentUnionMember2AnnotationOpenAIResponseAnnotationFileCitation",
+    "DataOutputOpenAIResponseMessageContentUnionMember2AnnotationOpenAIResponseAnnotationCitation",
+    "DataOutputOpenAIResponseMessageContentUnionMember2AnnotationOpenAIResponseAnnotationContainerFileCitation",
+    "DataOutputOpenAIResponseMessageContentUnionMember2AnnotationOpenAIResponseAnnotationFilePath",
     "DataOutputOpenAIResponseOutputMessageWebSearchToolCall",
     "DataOutputOpenAIResponseOutputMessageFileSearchToolCall",
     "DataOutputOpenAIResponseOutputMessageFunctionToolCall",
@@ -108,7 +118,66 @@ DataInputOpenAIResponseMessageContentUnionMember1: TypeAlias = Annotated[
 ]
 
 
+class DataInputOpenAIResponseMessageContentUnionMember2AnnotationOpenAIResponseAnnotationFileCitation(BaseModel):
+    file_id: str
+
+    filename: str
+
+    index: int
+
+    type: Literal["file_citation"]
+
+
+class DataInputOpenAIResponseMessageContentUnionMember2AnnotationOpenAIResponseAnnotationCitation(BaseModel):
+    end_index: int
+
+    start_index: int
+
+    title: str
+
+    type: Literal["url_citation"]
+
+    url: str
+
+
+class DataInputOpenAIResponseMessageContentUnionMember2AnnotationOpenAIResponseAnnotationContainerFileCitation(
+    BaseModel
+):
+    container_id: str
+
+    end_index: int
+
+    file_id: str
+
+    filename: str
+
+    start_index: int
+
+    type: Literal["container_file_citation"]
+
+
+class DataInputOpenAIResponseMessageContentUnionMember2AnnotationOpenAIResponseAnnotationFilePath(BaseModel):
+    file_id: str
+
+    index: int
+
+    type: Literal["file_path"]
+
+
+DataInputOpenAIResponseMessageContentUnionMember2Annotation: TypeAlias = Annotated[
+    Union[
+        DataInputOpenAIResponseMessageContentUnionMember2AnnotationOpenAIResponseAnnotationFileCitation,
+        DataInputOpenAIResponseMessageContentUnionMember2AnnotationOpenAIResponseAnnotationCitation,
+        DataInputOpenAIResponseMessageContentUnionMember2AnnotationOpenAIResponseAnnotationContainerFileCitation,
+        DataInputOpenAIResponseMessageContentUnionMember2AnnotationOpenAIResponseAnnotationFilePath,
+    ],
+    PropertyInfo(discriminator="type"),
+]
+
+
 class DataInputOpenAIResponseMessageContentUnionMember2(BaseModel):
+    annotations: List[DataInputOpenAIResponseMessageContentUnionMember2Annotation]
+
     text: str
 
     type: Literal["output_text"]
@@ -162,7 +231,66 @@ DataOutputOpenAIResponseMessageContentUnionMember1: TypeAlias = Annotated[
 ]
 
 
+class DataOutputOpenAIResponseMessageContentUnionMember2AnnotationOpenAIResponseAnnotationFileCitation(BaseModel):
+    file_id: str
+
+    filename: str
+
+    index: int
+
+    type: Literal["file_citation"]
+
+
+class DataOutputOpenAIResponseMessageContentUnionMember2AnnotationOpenAIResponseAnnotationCitation(BaseModel):
+    end_index: int
+
+    start_index: int
+
+    title: str
+
+    type: Literal["url_citation"]
+
+    url: str
+
+
+class DataOutputOpenAIResponseMessageContentUnionMember2AnnotationOpenAIResponseAnnotationContainerFileCitation(
+    BaseModel
+):
+    container_id: str
+
+    end_index: int
+
+    file_id: str
+
+    filename: str
+
+    start_index: int
+
+    type: Literal["container_file_citation"]
+
+
+class DataOutputOpenAIResponseMessageContentUnionMember2AnnotationOpenAIResponseAnnotationFilePath(BaseModel):
+    file_id: str
+
+    index: int
+
+    type: Literal["file_path"]
+
+
+DataOutputOpenAIResponseMessageContentUnionMember2Annotation: TypeAlias = Annotated[
+    Union[
+        DataOutputOpenAIResponseMessageContentUnionMember2AnnotationOpenAIResponseAnnotationFileCitation,
+        DataOutputOpenAIResponseMessageContentUnionMember2AnnotationOpenAIResponseAnnotationCitation,
+        DataOutputOpenAIResponseMessageContentUnionMember2AnnotationOpenAIResponseAnnotationContainerFileCitation,
+        DataOutputOpenAIResponseMessageContentUnionMember2AnnotationOpenAIResponseAnnotationFilePath,
+    ],
+    PropertyInfo(discriminator="type"),
+]
+
+
 class DataOutputOpenAIResponseMessageContentUnionMember2(BaseModel):
+    annotations: List[DataOutputOpenAIResponseMessageContentUnionMember2Annotation]
+
     text: str
 
     type: Literal["output_text"]

--- a/src/llama_stack_client/types/response_object.py
+++ b/src/llama_stack_client/types/response_object.py
@@ -16,6 +16,11 @@ __all__ = [
     "OutputOpenAIResponseMessageContentUnionMember1OpenAIResponseInputMessageContentText",
     "OutputOpenAIResponseMessageContentUnionMember1OpenAIResponseInputMessageContentImage",
     "OutputOpenAIResponseMessageContentUnionMember2",
+    "OutputOpenAIResponseMessageContentUnionMember2Annotation",
+    "OutputOpenAIResponseMessageContentUnionMember2AnnotationOpenAIResponseAnnotationFileCitation",
+    "OutputOpenAIResponseMessageContentUnionMember2AnnotationOpenAIResponseAnnotationCitation",
+    "OutputOpenAIResponseMessageContentUnionMember2AnnotationOpenAIResponseAnnotationContainerFileCitation",
+    "OutputOpenAIResponseMessageContentUnionMember2AnnotationOpenAIResponseAnnotationFilePath",
     "OutputOpenAIResponseOutputMessageWebSearchToolCall",
     "OutputOpenAIResponseOutputMessageFileSearchToolCall",
     "OutputOpenAIResponseOutputMessageFunctionToolCall",
@@ -51,7 +56,64 @@ OutputOpenAIResponseMessageContentUnionMember1: TypeAlias = Annotated[
 ]
 
 
+class OutputOpenAIResponseMessageContentUnionMember2AnnotationOpenAIResponseAnnotationFileCitation(BaseModel):
+    file_id: str
+
+    filename: str
+
+    index: int
+
+    type: Literal["file_citation"]
+
+
+class OutputOpenAIResponseMessageContentUnionMember2AnnotationOpenAIResponseAnnotationCitation(BaseModel):
+    end_index: int
+
+    start_index: int
+
+    title: str
+
+    type: Literal["url_citation"]
+
+    url: str
+
+
+class OutputOpenAIResponseMessageContentUnionMember2AnnotationOpenAIResponseAnnotationContainerFileCitation(BaseModel):
+    container_id: str
+
+    end_index: int
+
+    file_id: str
+
+    filename: str
+
+    start_index: int
+
+    type: Literal["container_file_citation"]
+
+
+class OutputOpenAIResponseMessageContentUnionMember2AnnotationOpenAIResponseAnnotationFilePath(BaseModel):
+    file_id: str
+
+    index: int
+
+    type: Literal["file_path"]
+
+
+OutputOpenAIResponseMessageContentUnionMember2Annotation: TypeAlias = Annotated[
+    Union[
+        OutputOpenAIResponseMessageContentUnionMember2AnnotationOpenAIResponseAnnotationFileCitation,
+        OutputOpenAIResponseMessageContentUnionMember2AnnotationOpenAIResponseAnnotationCitation,
+        OutputOpenAIResponseMessageContentUnionMember2AnnotationOpenAIResponseAnnotationContainerFileCitation,
+        OutputOpenAIResponseMessageContentUnionMember2AnnotationOpenAIResponseAnnotationFilePath,
+    ],
+    PropertyInfo(discriminator="type"),
+]
+
+
 class OutputOpenAIResponseMessageContentUnionMember2(BaseModel):
+    annotations: List[OutputOpenAIResponseMessageContentUnionMember2Annotation]
+
     text: str
 
     type: Literal["output_text"]
@@ -189,6 +251,16 @@ class Error(BaseModel):
 
 
 class ResponseObject(BaseModel):
+    @property
+    def output_text(self) -> str:
+        texts: List[str] = []
+        for output in self.output:
+            if output.type == "message":
+                for content in output.content:
+                    if content.type == "output_text":
+                        texts.append(content.text)
+        return "".join(texts)
+
     id: str
 
     created_at: int

--- a/src/llama_stack_client/types/response_object_stream.py
+++ b/src/llama_stack_client/types/response_object_stream.py
@@ -17,6 +17,11 @@ __all__ = [
     "OpenAIResponseObjectStreamResponseOutputItemAddedItemOpenAIResponseMessageContentUnionMember1OpenAIResponseInputMessageContentText",
     "OpenAIResponseObjectStreamResponseOutputItemAddedItemOpenAIResponseMessageContentUnionMember1OpenAIResponseInputMessageContentImage",
     "OpenAIResponseObjectStreamResponseOutputItemAddedItemOpenAIResponseMessageContentUnionMember2",
+    "OpenAIResponseObjectStreamResponseOutputItemAddedItemOpenAIResponseMessageContentUnionMember2Annotation",
+    "OpenAIResponseObjectStreamResponseOutputItemAddedItemOpenAIResponseMessageContentUnionMember2AnnotationOpenAIResponseAnnotationFileCitation",
+    "OpenAIResponseObjectStreamResponseOutputItemAddedItemOpenAIResponseMessageContentUnionMember2AnnotationOpenAIResponseAnnotationCitation",
+    "OpenAIResponseObjectStreamResponseOutputItemAddedItemOpenAIResponseMessageContentUnionMember2AnnotationOpenAIResponseAnnotationContainerFileCitation",
+    "OpenAIResponseObjectStreamResponseOutputItemAddedItemOpenAIResponseMessageContentUnionMember2AnnotationOpenAIResponseAnnotationFilePath",
     "OpenAIResponseObjectStreamResponseOutputItemAddedItemOpenAIResponseOutputMessageWebSearchToolCall",
     "OpenAIResponseObjectStreamResponseOutputItemAddedItemOpenAIResponseOutputMessageFileSearchToolCall",
     "OpenAIResponseObjectStreamResponseOutputItemAddedItemOpenAIResponseOutputMessageFunctionToolCall",
@@ -30,6 +35,11 @@ __all__ = [
     "OpenAIResponseObjectStreamResponseOutputItemDoneItemOpenAIResponseMessageContentUnionMember1OpenAIResponseInputMessageContentText",
     "OpenAIResponseObjectStreamResponseOutputItemDoneItemOpenAIResponseMessageContentUnionMember1OpenAIResponseInputMessageContentImage",
     "OpenAIResponseObjectStreamResponseOutputItemDoneItemOpenAIResponseMessageContentUnionMember2",
+    "OpenAIResponseObjectStreamResponseOutputItemDoneItemOpenAIResponseMessageContentUnionMember2Annotation",
+    "OpenAIResponseObjectStreamResponseOutputItemDoneItemOpenAIResponseMessageContentUnionMember2AnnotationOpenAIResponseAnnotationFileCitation",
+    "OpenAIResponseObjectStreamResponseOutputItemDoneItemOpenAIResponseMessageContentUnionMember2AnnotationOpenAIResponseAnnotationCitation",
+    "OpenAIResponseObjectStreamResponseOutputItemDoneItemOpenAIResponseMessageContentUnionMember2AnnotationOpenAIResponseAnnotationContainerFileCitation",
+    "OpenAIResponseObjectStreamResponseOutputItemDoneItemOpenAIResponseMessageContentUnionMember2AnnotationOpenAIResponseAnnotationFilePath",
     "OpenAIResponseObjectStreamResponseOutputItemDoneItemOpenAIResponseOutputMessageWebSearchToolCall",
     "OpenAIResponseObjectStreamResponseOutputItemDoneItemOpenAIResponseOutputMessageFileSearchToolCall",
     "OpenAIResponseObjectStreamResponseOutputItemDoneItemOpenAIResponseOutputMessageFunctionToolCall",
@@ -88,7 +98,74 @@ OpenAIResponseObjectStreamResponseOutputItemAddedItemOpenAIResponseMessageConten
 ]
 
 
+class OpenAIResponseObjectStreamResponseOutputItemAddedItemOpenAIResponseMessageContentUnionMember2AnnotationOpenAIResponseAnnotationFileCitation(
+    BaseModel
+):
+    file_id: str
+
+    filename: str
+
+    index: int
+
+    type: Literal["file_citation"]
+
+
+class OpenAIResponseObjectStreamResponseOutputItemAddedItemOpenAIResponseMessageContentUnionMember2AnnotationOpenAIResponseAnnotationCitation(
+    BaseModel
+):
+    end_index: int
+
+    start_index: int
+
+    title: str
+
+    type: Literal["url_citation"]
+
+    url: str
+
+
+class OpenAIResponseObjectStreamResponseOutputItemAddedItemOpenAIResponseMessageContentUnionMember2AnnotationOpenAIResponseAnnotationContainerFileCitation(
+    BaseModel
+):
+    container_id: str
+
+    end_index: int
+
+    file_id: str
+
+    filename: str
+
+    start_index: int
+
+    type: Literal["container_file_citation"]
+
+
+class OpenAIResponseObjectStreamResponseOutputItemAddedItemOpenAIResponseMessageContentUnionMember2AnnotationOpenAIResponseAnnotationFilePath(
+    BaseModel
+):
+    file_id: str
+
+    index: int
+
+    type: Literal["file_path"]
+
+
+OpenAIResponseObjectStreamResponseOutputItemAddedItemOpenAIResponseMessageContentUnionMember2Annotation: TypeAlias = Annotated[
+    Union[
+        OpenAIResponseObjectStreamResponseOutputItemAddedItemOpenAIResponseMessageContentUnionMember2AnnotationOpenAIResponseAnnotationFileCitation,
+        OpenAIResponseObjectStreamResponseOutputItemAddedItemOpenAIResponseMessageContentUnionMember2AnnotationOpenAIResponseAnnotationCitation,
+        OpenAIResponseObjectStreamResponseOutputItemAddedItemOpenAIResponseMessageContentUnionMember2AnnotationOpenAIResponseAnnotationContainerFileCitation,
+        OpenAIResponseObjectStreamResponseOutputItemAddedItemOpenAIResponseMessageContentUnionMember2AnnotationOpenAIResponseAnnotationFilePath,
+    ],
+    PropertyInfo(discriminator="type"),
+]
+
+
 class OpenAIResponseObjectStreamResponseOutputItemAddedItemOpenAIResponseMessageContentUnionMember2(BaseModel):
+    annotations: List[
+        OpenAIResponseObjectStreamResponseOutputItemAddedItemOpenAIResponseMessageContentUnionMember2Annotation
+    ]
+
     text: str
 
     type: Literal["output_text"]
@@ -235,7 +312,74 @@ OpenAIResponseObjectStreamResponseOutputItemDoneItemOpenAIResponseMessageContent
 ]
 
 
+class OpenAIResponseObjectStreamResponseOutputItemDoneItemOpenAIResponseMessageContentUnionMember2AnnotationOpenAIResponseAnnotationFileCitation(
+    BaseModel
+):
+    file_id: str
+
+    filename: str
+
+    index: int
+
+    type: Literal["file_citation"]
+
+
+class OpenAIResponseObjectStreamResponseOutputItemDoneItemOpenAIResponseMessageContentUnionMember2AnnotationOpenAIResponseAnnotationCitation(
+    BaseModel
+):
+    end_index: int
+
+    start_index: int
+
+    title: str
+
+    type: Literal["url_citation"]
+
+    url: str
+
+
+class OpenAIResponseObjectStreamResponseOutputItemDoneItemOpenAIResponseMessageContentUnionMember2AnnotationOpenAIResponseAnnotationContainerFileCitation(
+    BaseModel
+):
+    container_id: str
+
+    end_index: int
+
+    file_id: str
+
+    filename: str
+
+    start_index: int
+
+    type: Literal["container_file_citation"]
+
+
+class OpenAIResponseObjectStreamResponseOutputItemDoneItemOpenAIResponseMessageContentUnionMember2AnnotationOpenAIResponseAnnotationFilePath(
+    BaseModel
+):
+    file_id: str
+
+    index: int
+
+    type: Literal["file_path"]
+
+
+OpenAIResponseObjectStreamResponseOutputItemDoneItemOpenAIResponseMessageContentUnionMember2Annotation: TypeAlias = Annotated[
+    Union[
+        OpenAIResponseObjectStreamResponseOutputItemDoneItemOpenAIResponseMessageContentUnionMember2AnnotationOpenAIResponseAnnotationFileCitation,
+        OpenAIResponseObjectStreamResponseOutputItemDoneItemOpenAIResponseMessageContentUnionMember2AnnotationOpenAIResponseAnnotationCitation,
+        OpenAIResponseObjectStreamResponseOutputItemDoneItemOpenAIResponseMessageContentUnionMember2AnnotationOpenAIResponseAnnotationContainerFileCitation,
+        OpenAIResponseObjectStreamResponseOutputItemDoneItemOpenAIResponseMessageContentUnionMember2AnnotationOpenAIResponseAnnotationFilePath,
+    ],
+    PropertyInfo(discriminator="type"),
+]
+
+
 class OpenAIResponseObjectStreamResponseOutputItemDoneItemOpenAIResponseMessageContentUnionMember2(BaseModel):
+    annotations: List[
+        OpenAIResponseObjectStreamResponseOutputItemDoneItemOpenAIResponseMessageContentUnionMember2Annotation
+    ]
+
     text: str
 
     type: Literal["output_text"]

--- a/src/llama_stack_client/types/responses/input_item_list_response.py
+++ b/src/llama_stack_client/types/responses/input_item_list_response.py
@@ -18,6 +18,11 @@ __all__ = [
     "DataOpenAIResponseMessageContentUnionMember1OpenAIResponseInputMessageContentText",
     "DataOpenAIResponseMessageContentUnionMember1OpenAIResponseInputMessageContentImage",
     "DataOpenAIResponseMessageContentUnionMember2",
+    "DataOpenAIResponseMessageContentUnionMember2Annotation",
+    "DataOpenAIResponseMessageContentUnionMember2AnnotationOpenAIResponseAnnotationFileCitation",
+    "DataOpenAIResponseMessageContentUnionMember2AnnotationOpenAIResponseAnnotationCitation",
+    "DataOpenAIResponseMessageContentUnionMember2AnnotationOpenAIResponseAnnotationContainerFileCitation",
+    "DataOpenAIResponseMessageContentUnionMember2AnnotationOpenAIResponseAnnotationFilePath",
 ]
 
 
@@ -90,7 +95,64 @@ DataOpenAIResponseMessageContentUnionMember1: TypeAlias = Annotated[
 ]
 
 
+class DataOpenAIResponseMessageContentUnionMember2AnnotationOpenAIResponseAnnotationFileCitation(BaseModel):
+    file_id: str
+
+    filename: str
+
+    index: int
+
+    type: Literal["file_citation"]
+
+
+class DataOpenAIResponseMessageContentUnionMember2AnnotationOpenAIResponseAnnotationCitation(BaseModel):
+    end_index: int
+
+    start_index: int
+
+    title: str
+
+    type: Literal["url_citation"]
+
+    url: str
+
+
+class DataOpenAIResponseMessageContentUnionMember2AnnotationOpenAIResponseAnnotationContainerFileCitation(BaseModel):
+    container_id: str
+
+    end_index: int
+
+    file_id: str
+
+    filename: str
+
+    start_index: int
+
+    type: Literal["container_file_citation"]
+
+
+class DataOpenAIResponseMessageContentUnionMember2AnnotationOpenAIResponseAnnotationFilePath(BaseModel):
+    file_id: str
+
+    index: int
+
+    type: Literal["file_path"]
+
+
+DataOpenAIResponseMessageContentUnionMember2Annotation: TypeAlias = Annotated[
+    Union[
+        DataOpenAIResponseMessageContentUnionMember2AnnotationOpenAIResponseAnnotationFileCitation,
+        DataOpenAIResponseMessageContentUnionMember2AnnotationOpenAIResponseAnnotationCitation,
+        DataOpenAIResponseMessageContentUnionMember2AnnotationOpenAIResponseAnnotationContainerFileCitation,
+        DataOpenAIResponseMessageContentUnionMember2AnnotationOpenAIResponseAnnotationFilePath,
+    ],
+    PropertyInfo(discriminator="type"),
+]
+
+
 class DataOpenAIResponseMessageContentUnionMember2(BaseModel):
+    annotations: List[DataOpenAIResponseMessageContentUnionMember2Annotation]
+
     text: str
 
     type: Literal["output_text"]

--- a/src/llama_stack_client/types/vector_io_insert_params.py
+++ b/src/llama_stack_client/types/vector_io_insert_params.py
@@ -7,7 +7,7 @@ from typing_extensions import Required, TypedDict
 
 from .shared_params.interleaved_content import InterleavedContent
 
-__all__ = ["VectorIoInsertParams", "Chunk"]
+__all__ = ["VectorIoInsertParams", "Chunk", "ChunkChunkMetadata"]
 
 
 class VectorIoInsertParams(TypedDict, total=False):
@@ -28,6 +28,44 @@ class VectorIoInsertParams(TypedDict, total=False):
     """The time to live of the chunks."""
 
 
+class ChunkChunkMetadata(TypedDict, total=False):
+    chunk_embedding_dimension: int
+    """The dimension of the embedding vector for the chunk."""
+
+    chunk_embedding_model: str
+    """The embedding model used to create the chunk's embedding."""
+
+    chunk_id: str
+    """The ID of the chunk.
+
+    If not set, it will be generated based on the document ID and content.
+    """
+
+    chunk_tokenizer: str
+    """The tokenizer used to create the chunk. Default is Tiktoken."""
+
+    chunk_window: str
+    """The window of the chunk, which can be used to group related chunks together."""
+
+    content_token_count: int
+    """The number of tokens in the content of the chunk."""
+
+    created_timestamp: int
+    """An optional timestamp indicating when the chunk was created."""
+
+    document_id: str
+    """The ID of the document this chunk belongs to."""
+
+    metadata_token_count: int
+    """The number of tokens in the metadata of the chunk."""
+
+    source: str
+    """The source of the content, such as a URL, file path, or other identifier."""
+
+    updated_timestamp: int
+    """An optional timestamp indicating when the chunk was last updated."""
+
+
 class Chunk(TypedDict, total=False):
     content: Required[InterleavedContent]
     """
@@ -36,9 +74,21 @@ class Chunk(TypedDict, total=False):
 
     metadata: Required[Dict[str, Union[bool, float, str, Iterable[object], object, None]]]
     """
-    Metadata associated with the chunk, such as document ID, source, or other
-    relevant information.
+    Metadata associated with the chunk that will be used in the model context during
+    inference.
+    """
+
+    chunk_metadata: ChunkChunkMetadata
+    """Metadata for the chunk that will NOT be used in the context during inference.
+
+    The `chunk_metadata` is required backend functionality.
     """
 
     embedding: Iterable[float]
     """Optional embedding for the chunk. If not provided, it will be computed later."""
+
+    stored_chunk_id: str
+    """The chunk ID that is stored in the vector database.
+
+    Used for backend functionality.
+    """

--- a/src/llama_stack_client/types/vector_store_search_params.py
+++ b/src/llama_stack_client/types/vector_store_search_params.py
@@ -24,6 +24,9 @@ class VectorStoreSearchParams(TypedDict, total=False):
     rewrite_query: bool
     """Whether to rewrite the natural language query for vector search (default false)"""
 
+    search_mode: str
+    """The search mode to use - "keyword", "vector", or "hybrid" (default "vector")"""
+
 
 class RankingOptions(TypedDict, total=False):
     ranker: str

--- a/tests/api_resources/agents/test_session.py
+++ b/tests/api_resources/agents/test_session.py
@@ -169,7 +169,9 @@ class TestSession:
 
 
 class TestAsyncSession:
-    parametrize = pytest.mark.parametrize("async_client", [False, True], indirect=True, ids=["loose", "strict"])
+    parametrize = pytest.mark.parametrize(
+        "async_client", [False, True, {"http_client": "aiohttp"}], indirect=True, ids=["loose", "strict", "aiohttp"]
+    )
 
     @parametrize
     async def test_method_create(self, async_client: AsyncLlamaStackClient) -> None:

--- a/tests/api_resources/agents/test_steps.py
+++ b/tests/api_resources/agents/test_steps.py
@@ -93,7 +93,9 @@ class TestSteps:
 
 
 class TestAsyncSteps:
-    parametrize = pytest.mark.parametrize("async_client", [False, True], indirect=True, ids=["loose", "strict"])
+    parametrize = pytest.mark.parametrize(
+        "async_client", [False, True, {"http_client": "aiohttp"}], indirect=True, ids=["loose", "strict", "aiohttp"]
+    )
 
     @parametrize
     async def test_method_retrieve(self, async_client: AsyncLlamaStackClient) -> None:

--- a/tests/api_resources/agents/test_turn.py
+++ b/tests/api_resources/agents/test_turn.py
@@ -522,7 +522,9 @@ class TestTurn:
 
 
 class TestAsyncTurn:
-    parametrize = pytest.mark.parametrize("async_client", [False, True], indirect=True, ids=["loose", "strict"])
+    parametrize = pytest.mark.parametrize(
+        "async_client", [False, True, {"http_client": "aiohttp"}], indirect=True, ids=["loose", "strict", "aiohttp"]
+    )
 
     @parametrize
     async def test_method_create_overload_1(self, async_client: AsyncLlamaStackClient) -> None:

--- a/tests/api_resources/chat/test_completions.py
+++ b/tests/api_resources/chat/test_completions.py
@@ -266,7 +266,9 @@ class TestCompletions:
 
 
 class TestAsyncCompletions:
-    parametrize = pytest.mark.parametrize("async_client", [False, True], indirect=True, ids=["loose", "strict"])
+    parametrize = pytest.mark.parametrize(
+        "async_client", [False, True, {"http_client": "aiohttp"}], indirect=True, ids=["loose", "strict", "aiohttp"]
+    )
 
     @parametrize
     async def test_method_create_overload_1(self, async_client: AsyncLlamaStackClient) -> None:

--- a/tests/api_resources/eval/test_jobs.py
+++ b/tests/api_resources/eval/test_jobs.py
@@ -163,7 +163,9 @@ class TestJobs:
 
 
 class TestAsyncJobs:
-    parametrize = pytest.mark.parametrize("async_client", [False, True], indirect=True, ids=["loose", "strict"])
+    parametrize = pytest.mark.parametrize(
+        "async_client", [False, True, {"http_client": "aiohttp"}], indirect=True, ids=["loose", "strict", "aiohttp"]
+    )
 
     @parametrize
     async def test_method_retrieve(self, async_client: AsyncLlamaStackClient) -> None:

--- a/tests/api_resources/post_training/test_job.py
+++ b/tests/api_resources/post_training/test_job.py
@@ -141,7 +141,9 @@ class TestJob:
 
 
 class TestAsyncJob:
-    parametrize = pytest.mark.parametrize("async_client", [False, True], indirect=True, ids=["loose", "strict"])
+    parametrize = pytest.mark.parametrize(
+        "async_client", [False, True, {"http_client": "aiohttp"}], indirect=True, ids=["loose", "strict", "aiohttp"]
+    )
 
     @parametrize
     async def test_method_list(self, async_client: AsyncLlamaStackClient) -> None:

--- a/tests/api_resources/responses/test_input_items.py
+++ b/tests/api_resources/responses/test_input_items.py
@@ -69,7 +69,9 @@ class TestInputItems:
 
 
 class TestAsyncInputItems:
-    parametrize = pytest.mark.parametrize("async_client", [False, True], indirect=True, ids=["loose", "strict"])
+    parametrize = pytest.mark.parametrize(
+        "async_client", [False, True, {"http_client": "aiohttp"}], indirect=True, ids=["loose", "strict", "aiohttp"]
+    )
 
     @parametrize
     async def test_method_list(self, async_client: AsyncLlamaStackClient) -> None:

--- a/tests/api_resources/test_agents.py
+++ b/tests/api_resources/test_agents.py
@@ -146,7 +146,9 @@ class TestAgents:
 
 
 class TestAsyncAgents:
-    parametrize = pytest.mark.parametrize("async_client", [False, True], indirect=True, ids=["loose", "strict"])
+    parametrize = pytest.mark.parametrize(
+        "async_client", [False, True, {"http_client": "aiohttp"}], indirect=True, ids=["loose", "strict", "aiohttp"]
+    )
 
     @parametrize
     async def test_method_create(self, async_client: AsyncLlamaStackClient) -> None:

--- a/tests/api_resources/test_benchmarks.py
+++ b/tests/api_resources/test_benchmarks.py
@@ -131,7 +131,9 @@ class TestBenchmarks:
 
 
 class TestAsyncBenchmarks:
-    parametrize = pytest.mark.parametrize("async_client", [False, True], indirect=True, ids=["loose", "strict"])
+    parametrize = pytest.mark.parametrize(
+        "async_client", [False, True, {"http_client": "aiohttp"}], indirect=True, ids=["loose", "strict", "aiohttp"]
+    )
 
     @parametrize
     async def test_method_retrieve(self, async_client: AsyncLlamaStackClient) -> None:

--- a/tests/api_resources/test_completions.py
+++ b/tests/api_resources/test_completions.py
@@ -141,7 +141,9 @@ class TestCompletions:
 
 
 class TestAsyncCompletions:
-    parametrize = pytest.mark.parametrize("async_client", [False, True], indirect=True, ids=["loose", "strict"])
+    parametrize = pytest.mark.parametrize(
+        "async_client", [False, True, {"http_client": "aiohttp"}], indirect=True, ids=["loose", "strict", "aiohttp"]
+    )
 
     @parametrize
     async def test_method_create_overload_1(self, async_client: AsyncLlamaStackClient) -> None:

--- a/tests/api_resources/test_datasets.py
+++ b/tests/api_resources/test_datasets.py
@@ -228,7 +228,9 @@ class TestDatasets:
 
 
 class TestAsyncDatasets:
-    parametrize = pytest.mark.parametrize("async_client", [False, True], indirect=True, ids=["loose", "strict"])
+    parametrize = pytest.mark.parametrize(
+        "async_client", [False, True, {"http_client": "aiohttp"}], indirect=True, ids=["loose", "strict", "aiohttp"]
+    )
 
     @parametrize
     async def test_method_retrieve(self, async_client: AsyncLlamaStackClient) -> None:

--- a/tests/api_resources/test_embeddings.py
+++ b/tests/api_resources/test_embeddings.py
@@ -64,7 +64,9 @@ class TestEmbeddings:
 
 
 class TestAsyncEmbeddings:
-    parametrize = pytest.mark.parametrize("async_client", [False, True], indirect=True, ids=["loose", "strict"])
+    parametrize = pytest.mark.parametrize(
+        "async_client", [False, True, {"http_client": "aiohttp"}], indirect=True, ids=["loose", "strict", "aiohttp"]
+    )
 
     @parametrize
     async def test_method_create(self, async_client: AsyncLlamaStackClient) -> None:

--- a/tests/api_resources/test_eval.py
+++ b/tests/api_resources/test_eval.py
@@ -566,7 +566,9 @@ class TestEval:
 
 
 class TestAsyncEval:
-    parametrize = pytest.mark.parametrize("async_client", [False, True], indirect=True, ids=["loose", "strict"])
+    parametrize = pytest.mark.parametrize(
+        "async_client", [False, True, {"http_client": "aiohttp"}], indirect=True, ids=["loose", "strict", "aiohttp"]
+    )
 
     @parametrize
     async def test_method_evaluate_rows(self, async_client: AsyncLlamaStackClient) -> None:

--- a/tests/api_resources/test_files.py
+++ b/tests/api_resources/test_files.py
@@ -202,7 +202,9 @@ class TestFiles:
 
 
 class TestAsyncFiles:
-    parametrize = pytest.mark.parametrize("async_client", [False, True], indirect=True, ids=["loose", "strict"])
+    parametrize = pytest.mark.parametrize(
+        "async_client", [False, True, {"http_client": "aiohttp"}], indirect=True, ids=["loose", "strict", "aiohttp"]
+    )
 
     @parametrize
     async def test_method_create(self, async_client: AsyncLlamaStackClient) -> None:

--- a/tests/api_resources/test_inference.py
+++ b/tests/api_resources/test_inference.py
@@ -527,7 +527,9 @@ class TestInference:
 
 
 class TestAsyncInference:
-    parametrize = pytest.mark.parametrize("async_client", [False, True], indirect=True, ids=["loose", "strict"])
+    parametrize = pytest.mark.parametrize(
+        "async_client", [False, True, {"http_client": "aiohttp"}], indirect=True, ids=["loose", "strict", "aiohttp"]
+    )
 
     @parametrize
     async def test_method_batch_chat_completion(self, async_client: AsyncLlamaStackClient) -> None:

--- a/tests/api_resources/test_inspect.py
+++ b/tests/api_resources/test_inspect.py
@@ -69,7 +69,9 @@ class TestInspect:
 
 
 class TestAsyncInspect:
-    parametrize = pytest.mark.parametrize("async_client", [False, True], indirect=True, ids=["loose", "strict"])
+    parametrize = pytest.mark.parametrize(
+        "async_client", [False, True, {"http_client": "aiohttp"}], indirect=True, ids=["loose", "strict", "aiohttp"]
+    )
 
     @parametrize
     async def test_method_health(self, async_client: AsyncLlamaStackClient) -> None:

--- a/tests/api_resources/test_models.py
+++ b/tests/api_resources/test_models.py
@@ -162,7 +162,9 @@ class TestModels:
 
 
 class TestAsyncModels:
-    parametrize = pytest.mark.parametrize("async_client", [False, True], indirect=True, ids=["loose", "strict"])
+    parametrize = pytest.mark.parametrize(
+        "async_client", [False, True, {"http_client": "aiohttp"}], indirect=True, ids=["loose", "strict", "aiohttp"]
+    )
 
     @parametrize
     async def test_method_retrieve(self, async_client: AsyncLlamaStackClient) -> None:

--- a/tests/api_resources/test_post_training.py
+++ b/tests/api_resources/test_post_training.py
@@ -239,7 +239,9 @@ class TestPostTraining:
 
 
 class TestAsyncPostTraining:
-    parametrize = pytest.mark.parametrize("async_client", [False, True], indirect=True, ids=["loose", "strict"])
+    parametrize = pytest.mark.parametrize(
+        "async_client", [False, True, {"http_client": "aiohttp"}], indirect=True, ids=["loose", "strict", "aiohttp"]
+    )
 
     @parametrize
     async def test_method_preference_optimize(self, async_client: AsyncLlamaStackClient) -> None:

--- a/tests/api_resources/test_providers.py
+++ b/tests/api_resources/test_providers.py
@@ -82,7 +82,9 @@ class TestProviders:
 
 
 class TestAsyncProviders:
-    parametrize = pytest.mark.parametrize("async_client", [False, True], indirect=True, ids=["loose", "strict"])
+    parametrize = pytest.mark.parametrize(
+        "async_client", [False, True, {"http_client": "aiohttp"}], indirect=True, ids=["loose", "strict", "aiohttp"]
+    )
 
     @parametrize
     async def test_method_retrieve(self, async_client: AsyncLlamaStackClient) -> None:

--- a/tests/api_resources/test_responses.py
+++ b/tests/api_resources/test_responses.py
@@ -220,7 +220,9 @@ class TestResponses:
 
 
 class TestAsyncResponses:
-    parametrize = pytest.mark.parametrize("async_client", [False, True], indirect=True, ids=["loose", "strict"])
+    parametrize = pytest.mark.parametrize(
+        "async_client", [False, True, {"http_client": "aiohttp"}], indirect=True, ids=["loose", "strict", "aiohttp"]
+    )
 
     @parametrize
     async def test_method_create_overload_1(self, async_client: AsyncLlamaStackClient) -> None:

--- a/tests/api_resources/test_routes.py
+++ b/tests/api_resources/test_routes.py
@@ -44,7 +44,9 @@ class TestRoutes:
 
 
 class TestAsyncRoutes:
-    parametrize = pytest.mark.parametrize("async_client", [False, True], indirect=True, ids=["loose", "strict"])
+    parametrize = pytest.mark.parametrize(
+        "async_client", [False, True, {"http_client": "aiohttp"}], indirect=True, ids=["loose", "strict", "aiohttp"]
+    )
 
     @parametrize
     async def test_method_list(self, async_client: AsyncLlamaStackClient) -> None:

--- a/tests/api_resources/test_safety.py
+++ b/tests/api_resources/test_safety.py
@@ -71,7 +71,9 @@ class TestSafety:
 
 
 class TestAsyncSafety:
-    parametrize = pytest.mark.parametrize("async_client", [False, True], indirect=True, ids=["loose", "strict"])
+    parametrize = pytest.mark.parametrize(
+        "async_client", [False, True, {"http_client": "aiohttp"}], indirect=True, ids=["loose", "strict", "aiohttp"]
+    )
 
     @parametrize
     async def test_method_run_shield(self, async_client: AsyncLlamaStackClient) -> None:

--- a/tests/api_resources/test_scoring.py
+++ b/tests/api_resources/test_scoring.py
@@ -135,7 +135,9 @@ class TestScoring:
 
 
 class TestAsyncScoring:
-    parametrize = pytest.mark.parametrize("async_client", [False, True], indirect=True, ids=["loose", "strict"])
+    parametrize = pytest.mark.parametrize(
+        "async_client", [False, True, {"http_client": "aiohttp"}], indirect=True, ids=["loose", "strict", "aiohttp"]
+    )
 
     @parametrize
     async def test_method_score(self, async_client: AsyncLlamaStackClient) -> None:

--- a/tests/api_resources/test_scoring_functions.py
+++ b/tests/api_resources/test_scoring_functions.py
@@ -140,7 +140,9 @@ class TestScoringFunctions:
 
 
 class TestAsyncScoringFunctions:
-    parametrize = pytest.mark.parametrize("async_client", [False, True], indirect=True, ids=["loose", "strict"])
+    parametrize = pytest.mark.parametrize(
+        "async_client", [False, True, {"http_client": "aiohttp"}], indirect=True, ids=["loose", "strict", "aiohttp"]
+    )
 
     @parametrize
     async def test_method_retrieve(self, async_client: AsyncLlamaStackClient) -> None:

--- a/tests/api_resources/test_shields.py
+++ b/tests/api_resources/test_shields.py
@@ -123,7 +123,9 @@ class TestShields:
 
 
 class TestAsyncShields:
-    parametrize = pytest.mark.parametrize("async_client", [False, True], indirect=True, ids=["loose", "strict"])
+    parametrize = pytest.mark.parametrize(
+        "async_client", [False, True, {"http_client": "aiohttp"}], indirect=True, ids=["loose", "strict", "aiohttp"]
+    )
 
     @parametrize
     async def test_method_retrieve(self, async_client: AsyncLlamaStackClient) -> None:

--- a/tests/api_resources/test_synthetic_data_generation.py
+++ b/tests/api_resources/test_synthetic_data_generation.py
@@ -83,7 +83,9 @@ class TestSyntheticDataGeneration:
 
 
 class TestAsyncSyntheticDataGeneration:
-    parametrize = pytest.mark.parametrize("async_client", [False, True], indirect=True, ids=["loose", "strict"])
+    parametrize = pytest.mark.parametrize(
+        "async_client", [False, True, {"http_client": "aiohttp"}], indirect=True, ids=["loose", "strict", "aiohttp"]
+    )
 
     @parametrize
     async def test_method_generate(self, async_client: AsyncLlamaStackClient) -> None:

--- a/tests/api_resources/test_telemetry.py
+++ b/tests/api_resources/test_telemetry.py
@@ -417,7 +417,9 @@ class TestTelemetry:
 
 
 class TestAsyncTelemetry:
-    parametrize = pytest.mark.parametrize("async_client", [False, True], indirect=True, ids=["loose", "strict"])
+    parametrize = pytest.mark.parametrize(
+        "async_client", [False, True, {"http_client": "aiohttp"}], indirect=True, ids=["loose", "strict", "aiohttp"]
+    )
 
     @parametrize
     async def test_method_get_span(self, async_client: AsyncLlamaStackClient) -> None:

--- a/tests/api_resources/test_tool_runtime.py
+++ b/tests/api_resources/test_tool_runtime.py
@@ -89,7 +89,9 @@ class TestToolRuntime:
 
 
 class TestAsyncToolRuntime:
-    parametrize = pytest.mark.parametrize("async_client", [False, True], indirect=True, ids=["loose", "strict"])
+    parametrize = pytest.mark.parametrize(
+        "async_client", [False, True, {"http_client": "aiohttp"}], indirect=True, ids=["loose", "strict", "aiohttp"]
+    )
 
     @parametrize
     async def test_method_invoke_tool(self, async_client: AsyncLlamaStackClient) -> None:

--- a/tests/api_resources/test_toolgroups.py
+++ b/tests/api_resources/test_toolgroups.py
@@ -164,7 +164,9 @@ class TestToolgroups:
 
 
 class TestAsyncToolgroups:
-    parametrize = pytest.mark.parametrize("async_client", [False, True], indirect=True, ids=["loose", "strict"])
+    parametrize = pytest.mark.parametrize(
+        "async_client", [False, True, {"http_client": "aiohttp"}], indirect=True, ids=["loose", "strict", "aiohttp"]
+    )
 
     @parametrize
     async def test_method_list(self, async_client: AsyncLlamaStackClient) -> None:

--- a/tests/api_resources/test_tools.py
+++ b/tests/api_resources/test_tools.py
@@ -89,7 +89,9 @@ class TestTools:
 
 
 class TestAsyncTools:
-    parametrize = pytest.mark.parametrize("async_client", [False, True], indirect=True, ids=["loose", "strict"])
+    parametrize = pytest.mark.parametrize(
+        "async_client", [False, True, {"http_client": "aiohttp"}], indirect=True, ids=["loose", "strict", "aiohttp"]
+    )
 
     @parametrize
     async def test_method_list(self, async_client: AsyncLlamaStackClient) -> None:

--- a/tests/api_resources/test_vector_dbs.py
+++ b/tests/api_resources/test_vector_dbs.py
@@ -169,7 +169,9 @@ class TestVectorDBs:
 
 
 class TestAsyncVectorDBs:
-    parametrize = pytest.mark.parametrize("async_client", [False, True], indirect=True, ids=["loose", "strict"])
+    parametrize = pytest.mark.parametrize(
+        "async_client", [False, True, {"http_client": "aiohttp"}], indirect=True, ids=["loose", "strict", "aiohttp"]
+    )
 
     @parametrize
     async def test_method_retrieve(self, async_client: AsyncLlamaStackClient) -> None:

--- a/tests/api_resources/test_vector_io.py
+++ b/tests/api_resources/test_vector_io.py
@@ -37,7 +37,21 @@ class TestVectorIo:
                 {
                     "content": "string",
                     "metadata": {"foo": True},
+                    "chunk_metadata": {
+                        "chunk_embedding_dimension": 0,
+                        "chunk_embedding_model": "chunk_embedding_model",
+                        "chunk_id": "chunk_id",
+                        "chunk_tokenizer": "chunk_tokenizer",
+                        "chunk_window": "chunk_window",
+                        "content_token_count": 0,
+                        "created_timestamp": 0,
+                        "document_id": "document_id",
+                        "metadata_token_count": 0,
+                        "source": "source",
+                        "updated_timestamp": 0,
+                    },
                     "embedding": [0],
+                    "stored_chunk_id": "stored_chunk_id",
                 }
             ],
             vector_db_id="vector_db_id",
@@ -126,7 +140,9 @@ class TestVectorIo:
 
 
 class TestAsyncVectorIo:
-    parametrize = pytest.mark.parametrize("async_client", [False, True], indirect=True, ids=["loose", "strict"])
+    parametrize = pytest.mark.parametrize(
+        "async_client", [False, True, {"http_client": "aiohttp"}], indirect=True, ids=["loose", "strict", "aiohttp"]
+    )
 
     @parametrize
     async def test_method_insert(self, async_client: AsyncLlamaStackClient) -> None:
@@ -148,7 +164,21 @@ class TestAsyncVectorIo:
                 {
                     "content": "string",
                     "metadata": {"foo": True},
+                    "chunk_metadata": {
+                        "chunk_embedding_dimension": 0,
+                        "chunk_embedding_model": "chunk_embedding_model",
+                        "chunk_id": "chunk_id",
+                        "chunk_tokenizer": "chunk_tokenizer",
+                        "chunk_window": "chunk_window",
+                        "content_token_count": 0,
+                        "created_timestamp": 0,
+                        "document_id": "document_id",
+                        "metadata_token_count": 0,
+                        "source": "source",
+                        "updated_timestamp": 0,
+                    },
                     "embedding": [0],
+                    "stored_chunk_id": "stored_chunk_id",
                 }
             ],
             vector_db_id="vector_db_id",

--- a/tests/api_resources/test_vector_stores.py
+++ b/tests/api_resources/test_vector_stores.py
@@ -247,6 +247,7 @@ class TestVectorStores:
                 "score_threshold": 0,
             },
             rewrite_query=True,
+            search_mode="search_mode",
         )
         assert_matches_type(VectorStoreSearchResponse, vector_store, path=["response"])
 
@@ -286,7 +287,9 @@ class TestVectorStores:
 
 
 class TestAsyncVectorStores:
-    parametrize = pytest.mark.parametrize("async_client", [False, True], indirect=True, ids=["loose", "strict"])
+    parametrize = pytest.mark.parametrize(
+        "async_client", [False, True, {"http_client": "aiohttp"}], indirect=True, ids=["loose", "strict", "aiohttp"]
+    )
 
     @parametrize
     async def test_method_create(self, async_client: AsyncLlamaStackClient) -> None:
@@ -513,6 +516,7 @@ class TestAsyncVectorStores:
                 "score_threshold": 0,
             },
             rewrite_query=True,
+            search_mode="search_mode",
         )
         assert_matches_type(VectorStoreSearchResponse, vector_store, path=["response"])
 

--- a/tests/api_resources/tool_runtime/test_rag_tool.py
+++ b/tests/api_resources/tool_runtime/test_rag_tool.py
@@ -130,7 +130,9 @@ class TestRagTool:
 
 
 class TestAsyncRagTool:
-    parametrize = pytest.mark.parametrize("async_client", [False, True], indirect=True, ids=["loose", "strict"])
+    parametrize = pytest.mark.parametrize(
+        "async_client", [False, True, {"http_client": "aiohttp"}], indirect=True, ids=["loose", "strict", "aiohttp"]
+    )
 
     @parametrize
     async def test_method_insert(self, async_client: AsyncLlamaStackClient) -> None:

--- a/tests/api_resources/vector_stores/test_files.py
+++ b/tests/api_resources/vector_stores/test_files.py
@@ -71,7 +71,9 @@ class TestFiles:
 
 
 class TestAsyncFiles:
-    parametrize = pytest.mark.parametrize("async_client", [False, True], indirect=True, ids=["loose", "strict"])
+    parametrize = pytest.mark.parametrize(
+        "async_client", [False, True, {"http_client": "aiohttp"}], indirect=True, ids=["loose", "strict", "aiohttp"]
+    )
 
     @parametrize
     async def test_method_create(self, async_client: AsyncLlamaStackClient) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,10 +6,12 @@ import os
 import logging
 from typing import TYPE_CHECKING, Iterator, AsyncIterator
 
+import httpx
 import pytest
 from pytest_asyncio import is_async_test
 
-from llama_stack_client import LlamaStackClient, AsyncLlamaStackClient
+from llama_stack_client import LlamaStackClient, DefaultAioHttpClient, AsyncLlamaStackClient
+from llama_stack_client._utils import is_dict
 
 if TYPE_CHECKING:
     from _pytest.fixtures import FixtureRequest  # pyright: ignore[reportPrivateImportUsage]
@@ -27,6 +29,19 @@ def pytest_collection_modifyitems(items: list[pytest.Function]) -> None:
     for async_test in pytest_asyncio_tests:
         async_test.add_marker(session_scope_marker, append=False)
 
+    # We skip tests that use both the aiohttp client and respx_mock as respx_mock
+    # doesn't support custom transports.
+    for item in items:
+        if "async_client" not in item.fixturenames or "respx_mock" not in item.fixturenames:
+            continue
+
+        if not hasattr(item, "callspec"):
+            continue
+
+        async_client_param = item.callspec.params.get("async_client")
+        if is_dict(async_client_param) and async_client_param.get("http_client") == "aiohttp":
+            item.add_marker(pytest.mark.skip(reason="aiohttp client is not compatible with respx_mock"))
+
 
 base_url = os.environ.get("TEST_API_BASE_URL", "http://127.0.0.1:4010")
 
@@ -43,9 +58,25 @@ def client(request: FixtureRequest) -> Iterator[LlamaStackClient]:
 
 @pytest.fixture(scope="session")
 async def async_client(request: FixtureRequest) -> AsyncIterator[AsyncLlamaStackClient]:
-    strict = getattr(request, "param", True)
-    if not isinstance(strict, bool):
-        raise TypeError(f"Unexpected fixture parameter type {type(strict)}, expected {bool}")
+    param = getattr(request, "param", True)
 
-    async with AsyncLlamaStackClient(base_url=base_url, _strict_response_validation=strict) as client:
+    # defaults
+    strict = True
+    http_client: None | httpx.AsyncClient = None
+
+    if isinstance(param, bool):
+        strict = param
+    elif is_dict(param):
+        strict = param.get("strict", True)
+        assert isinstance(strict, bool)
+
+        http_client_type = param.get("http_client", "httpx")
+        if http_client_type == "aiohttp":
+            http_client = DefaultAioHttpClient()
+    else:
+        raise TypeError(f"Unexpected fixture parameter type {type(param)}, expected bool or dict")
+
+    async with AsyncLlamaStackClient(
+        base_url=base_url, _strict_response_validation=strict, http_client=http_client
+    ) as client:
         yield client

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -182,6 +182,7 @@ class TestLlamaStackClient:
             copy_param = copy_signature.parameters.get(name)
             assert copy_param is not None, f"copy() signature is missing the {name} param"
 
+    @pytest.mark.skipif(sys.version_info >= (3, 10), reason="fails because of a memory leak that started from 3.12")
     def test_copy_build_request(self) -> None:
         options = FinalRequestOptions(method="get", url="/foo")
 
@@ -993,6 +994,7 @@ class TestAsyncLlamaStackClient:
             copy_param = copy_signature.parameters.get(name)
             assert copy_param is not None, f"copy() signature is missing the {name} param"
 
+    @pytest.mark.skipif(sys.version_info >= (3, 10), reason="fails because of a memory leak that started from 3.12")
     def test_copy_build_request(self) -> None:
         options = FinalRequestOptions(method="get", url="/foo")
 


### PR DESCRIPTION
Syncing stainless changes as the title says. The repository is at: https://github.com/llamastack/llama-stack-client-python/

Please see https://github.com/llamastack/llama-stack-client-python/pull/2 for the source of the changes. The commit hash in the PR title is the commit hash after the PR above landed in the source repository.

> [!NOTE]
> This repository will soon be deprecated. We will be moving source of truth to https://github.com/llamastack/llama-stack-client-python/