### PR TITLE
fix: model register missing model-type and not accepting metadata

### DIFF
--- a/src/llama_stack_client/lib/cli/models/models.py
+++ b/src/llama_stack_client/lib/cli/models/models.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
+import json
 from typing import Optional
 
 import click
@@ -99,6 +100,7 @@ def get_model(ctx, model_id: str):
 @click.option("--provider-id", help="Provider ID for the model", default=None)
 @click.option("--provider-model-id", help="Provider's model ID", default=None)
 @click.option("--metadata", help="JSON metadata for the model", default=None)
+@click.option("--model-type", help="Model type", default="llm")
 @click.pass_context
 @handle_client_errors("register model")
 def register_model(
@@ -107,16 +109,29 @@ def register_model(
     provider_id: Optional[str],
     provider_model_id: Optional[str],
     metadata: Optional[str],
+    model_type: Optional[str],
 ):
     """Register a new model at distribution endpoint"""
     client = ctx.obj["client"]
     console = Console()
 
+    # Parse metadata JSON string to dictionary if provided
+    parsed_metadata = None
+    if metadata:
+        try:
+            parsed_metadata = json.loads(metadata)
+        except json.JSONDecodeError as e:
+            console.print(
+                f"[red]Error parsing metadata JSON: {e}[/red]"
+            )
+            return
+
     response = client.models.register(
         model_id=model_id,
         provider_id=provider_id,
         provider_model_id=provider_model_id,
-        metadata=metadata,
+        metadata=parsed_metadata,
+        model_type=model_type,
     )
     if response:
         console.print(f"[green]Successfully registered model {model_id}[/green]")


### PR DESCRIPTION
# What does this PR do?
[Provide a short summary of what this PR does and why. Link to relevant issues if applicable.]
Added the ability to specify the model type when registering models. 
Also fixed a bug with passing metadata which would result in the following error:
```
Error Type: BadRequestError                                                                                                                                     │
│ Details: Error code: 400 - {'error': {'detail': {'errors': [{'loc': ['body', 'metadata'], 'msg': 'Input should be a valid dictionary', 'type': 'dict_type'}]}}}
```

Closes: #215
## Test Plan
Run the following commands
```
# Note a Llama Stack Server must be running
# Create a venv
uv sync --python 3.12
# Install the LSC with the new code changes
uv pip install -e .
# List the available models
llama-stack-client models list
# Register the granite-embedding-30m embedding model NOTE must have sentence-transformers as an inference provider
llama-stack-client models register granite-embedding-30m --provider-id "sentence-transformers" --provider-model-id ibm-granite/granite-embedding-30m-english --metadata '{"embedding_dimension": 384}' --model-type embedding
# Verify the embedding model added are present
llama-stack-client models list
```

