### PR TITLE
fix(agent): fix wrong module import in ReAct agent

### DIFF
--- a/src/llama_stack_client/lib/agents/react/agent.py
+++ b/src/llama_stack_client/lib/agents/react/agent.py
@@ -13,7 +13,7 @@ from llama_stack_client.types.shared_params.agent_config import ToolConfig
 from llama_stack_client.types.shared_params.response_format import ResponseFormat
 from llama_stack_client.types.shared_params.sampling_params import SamplingParams
 
-from ..._types import Headers
+from ...._types import Headers
 from ..agent import Agent, AgentUtils
 from ..client_tool import ClientTool
 from ..tool_parser import ToolParser


### PR DESCRIPTION
In module `llama_stack_client/lib/agents/react/agent.py`, the `Headers` class is imported with the wrong path.

Fixes: #261 