### PR TITLE
fix(cli): update post_training import to use alpha namespace

### DIFF
--- a/src/llama_stack_client/lib/cli/post_training/post_training.py
+++ b/src/llama_stack_client/lib/cli/post_training/post_training.py
@@ -9,7 +9,7 @@ from typing import Optional
 import click
 from rich.console import Console
 
-from llama_stack_client.types.post_training_supervised_fine_tune_params import AlgorithmConfigParam, TrainingConfig
+from llama_stack_client.types.alpha.post_training_supervised_fine_tune_params import AlgorithmConfigParam, TrainingConfig
 
 from ..common.utils import handle_client_errors
 


### PR DESCRIPTION
The post_training_supervised_fine_tune_params module was moved to the alpha namespace but the CLI import wasn't updated, causing ModuleNotFoundError when running post_training commands.

Closes: #288