### PR TITLE
fix: update post_training CLI import path to use alpha subdirectory

### DIFF
--- a/src/llama_stack_client/lib/cli/post_training/post_training.py
+++ b/src/llama_stack_client/lib/cli/post_training/post_training.py
@@ -9,7 +9,10 @@ from typing import Optional
 import click
 from rich.console import Console
 
-from llama_stack_client.types.post_training_supervised_fine_tune_params import AlgorithmConfigParam, TrainingConfig
+from llama_stack_client.types.alpha.post_training_supervised_fine_tune_params import (
+    AlgorithmConfigParam,
+    TrainingConfig,
+)
 
 from ..common.utils import handle_client_errors
 

--- a/uv.lock
+++ b/uv.lock
@@ -440,7 +440,7 @@ wheels = [
 
 [[package]]
 name = "llama-stack-client"
-version = "0.3.0"
+version = "0.4.0a2"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
Closes https://github.com/llamastack/llama-stack/issues/3958