### PR TITLE
fix: remove agent types

### DIFF
--- a/src/llama_stack_client/__init__.py
+++ b/src/llama_stack_client/__init__.py
@@ -48,14 +48,12 @@ from .lib.agents.agent import Agent
 from .lib.agents.event_logger import EventLogger as AgentEventLogger
 from .lib.inference.event_logger import EventLogger as InferenceEventLogger
 from .types.shared_params.document import Document as RAGDocument
-from .types.alpha.agents.turn_create_params import Document
 
 __all__ = [
     "types",
     "Agent",
     "AgentEventLogger",
     "InferenceEventLogger",
-    "Document",
     "RAGDocument",
     "__version__",
     "__title__",


### PR DESCRIPTION
`__init__.py` imports agent types. Remove these and remove the entry in __all__