### PR TITLE
fix: post training algorithm param

### DIFF
--- a/src/llama_stack_client/lib/cli/post_training/post_training.py
+++ b/src/llama_stack_client/lib/cli/post_training/post_training.py
@@ -10,7 +10,7 @@ import click
 from rich.console import Console
 
 from llama_stack_client.types.alpha.post_training_supervised_fine_tune_params import (
-    AlgorithmConfigParam,
+    AlgorithmConfig,
     TrainingConfig,
 )
 
@@ -36,7 +36,7 @@ def supervised_fine_tune(
     ctx,
     job_uuid: str,
     model: str,
-    algorithm_config: AlgorithmConfigParam,
+    algorithm_config: AlgorithmConfig,
     training_config: TrainingConfig,
     checkpoint_dir: Optional[str],
 ):


### PR DESCRIPTION
was getting:

```
╰─ llama-stack-client --version
Traceback (most recent call last):
  File "/Users/charliedoern/projects/Documents/llama-stack/venv/bin/llama-stack-client", line 4, in <module>
    from llama_stack_client.lib.cli.llama_stack_client import main
  File "/Users/charliedoern/projects/Documents/llama-stack-client-python/src/llama_stack_client/lib/cli/llama_stack_client.py", line 23, in <module>
    from .post_training import post_training
  File "/Users/charliedoern/projects/Documents/llama-stack-client-python/src/llama_stack_client/lib/cli/post_training/__init__.py", line 7, in <module>
    from .post_training import post_training
  File "/Users/charliedoern/projects/Documents/llama-stack-client-python/src/llama_stack_client/lib/cli/post_training/post_training.py", line 12, in <module>
    from llama_stack_client.types.alpha.post_training_supervised_fine_tune_params import (
ImportError: cannot import name 'AlgorithmConfigParam' from 'llama_stack_client.types.alpha.post_training_supervised_fine_tune_params' (/Users/charliedoern/projects/Documents/llama-stack-client-python/src/llama_stack_client/types/alpha/post_training_supervised_fine_tune_params.py). Did you mean: 'AlgorithmConfig'?

```

fixes that.