### PR TITLE
fix: export path_template from _utils

### DIFF
--- a/src/llama_stack_client/_utils/__init__.py
+++ b/src/llama_stack_client/_utils/__init__.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the terms described in the LICENSE file in
 # the root directory of this source tree.
 
+from ._path import path_template as path_template
 from ._sync import asyncify as asyncify
 from ._proxy import LazyProxy as LazyProxy
 from ._utils import (


### PR DESCRIPTION
## Summary
- `_utils/_path.py` defines `path_template` which is imported by multiple resource modules (admin, benchmarks, eval, models, etc.)
- `_utils/__init__.py` was missing the re-export, causing `ImportError: cannot import name 'path_template' from 'llama_stack_client._utils'` at import time
- This breaks llama-stack CI (`client=latest` variant) and anyone installing from git main

## Test plan
- [x] Verify `from llama_stack_client._utils import path_template` works
- [ ] Verify llama-stack integration tests pass with `client=latest`